### PR TITLE
feat: per-output collapse_dims in shape config

### DIFF
--- a/docs/examples/nemo_asr/README.md
+++ b/docs/examples/nemo_asr/README.md
@@ -88,7 +88,8 @@ t2n_export_nemo \
 
 The generated `shapes.yaml` uses a nested layout per subnet:
 
-- `inputs`: mapping of input-name → settings
+- `inputs`: mapping of input-name -> settings
+- `outputs` (optional): mapping of output-name -> settings
 - `renamed_symbols` (optional): `{ TARGET: [SOURCES...] }` aliasing of dynamic symbols
 - `outputs_keep` (always present in the template): ordered list of output names to keep (default if omitted: keep all)
 
@@ -97,6 +98,10 @@ Per-input settings under `inputs`:
 - `original_shape`: list of dims (ints or strings)
 - `collapse_dims` (optional): list of symbols to collapse at the boundary
 - `bind_scalar_to_dim_size` (optional): dynamic source as `subnet.input.SYMBOL`
+
+Per-output settings under `outputs`:
+
+- `collapse_dims` (optional): list of axis indices to squeeze from the output tensor (e.g., `[0]` to remove the batch axis)
 
 Example (abbreviated):
 
@@ -110,6 +115,9 @@ encoder:
       original_shape: [LENGTH__BATCH]
       collapse_dims: [LENGTH__BATCH]
       bind_scalar_to_dim_size: encoder.audio_signal.AUDIO_SIGNAL__TIME
+  outputs:
+    outputs:
+      collapse_dims: [0]
 
 decoder_joint:
   inputs:
@@ -168,9 +176,11 @@ Notes:
 - To expose a common tract-facing name (e.g., `BATCH`) across inputs, declare it via `renamed_symbols`.
 - Aliases listed in `renamed_symbols` are accepted anywhere a symbol is referenced (collapse/bind).
 - `renamed_symbols` targets cannot include themselves in sources.
-- `collapse_dims` requires the symbol to be dynamic on that input at the selected stage.
+- `collapse_dims` (inputs) requires the symbol to be dynamic on that input at the selected stage.
+- `collapse_dims` (outputs) takes axis indices (integers), not symbols. Only axes of size 1 are squeezed.
 - `bind_scalar_to_dim_size` binds a dynamic size as an `int64` scalar.
 - `outputs_keep` filters exported outputs; order follows the subnet’s original `output_names`. The template always includes it so you can easily trim.
+- When batch collapse is detected on inputs, the NeMo registry auto-populates `outputs.collapse_dims: [0]` for all outputs of that subnet. Explicit config takes precedence.
 
 Boundary semantics
 

--- a/docs/tutos/11_remodeler.md
+++ b/docs/tutos/11_remodeler.md
@@ -21,6 +21,8 @@ Core concepts
     - `original_shape`: list of dims (ints or symbols)
     - `collapse_dims` (optional): symbols to drop at boundary
     - `bind_scalar_to_dim_size` (optional): `subnet.input.SYMBOL`
+  - `outputs` (optional): per-output settings
+    - `collapse_dims`: list of axis indices to squeeze from the output
   - `renamed_symbols` (optional): `{ TARGET: [SOURCES...] }` for backend-facing
     symbol unification
   - `outputs_keep` (optional): list of outputs to keep (template pre-fills)
@@ -153,10 +155,35 @@ export_model_to_nnef(
 )
 ```
 
+Output collapse
+- When `collapse_dims` removes a batch axis from inputs, the internal module
+  still runs with that axis (size 1). The `outputs.collapse_dims` setting
+  squeezes configured axes from each output tensor so the exported model
+  produces batch-free tensors.
+- Each output can declare its own `collapse_dims` as a list of axis indices.
+- For NeMo models, the registry auto-populates `collapse_dims: [0]` for all
+  outputs when batch collapse is detected on inputs. Explicit config takes
+  precedence over auto-population.
+
+Example:
+
+```yaml
+encoder:
+  inputs:
+    audio_signal:
+      original_shape: [AUDIO_SIGNAL__BATCH, 128, AUDIO_SIGNAL__TIME]
+      collapse_dims: [AUDIO_SIGNAL__BATCH]
+  outputs_keep: [outputs]
+  outputs:
+    outputs:
+      collapse_dims: [0]
+```
+
 Validation
 - The remodeler validates configs early against discovered signatures:
   - Rejects unknown subnets/inputs
   - Ensures `outputs_keep` is a subset of outputs
+  - Ensures `outputs.collapse_dims` references known output names with valid axis indices
   - Verifies `bind_scalar_to_dim_size` sources and symbols exist among dynamic axes
   - Verifies `collapse_dims` symbols exist among dynamic axes per input
   - Verifies `renamed_symbols` sources exist among the subnet’s dynamic axes

--- a/tests/assets/shapes.marblenet.collapsed.yaml
+++ b/tests/assets/shapes.marblenet.collapsed.yaml
@@ -6,9 +6,10 @@
 #     --dry-run --dump-shape-config shapes.marblenet.yaml
 #
 # Then apply:
-#   - collapse_dims: all __BATCH symbols
+#   - collapse_dims: all __BATCH symbols (inputs and outputs)
 #   - bind_scalar_to_dim_size: length inputs → sibling TIME dim
 #   - outputs_keep: drop length outputs
+#   - outputs.collapse_dims: squeeze batch axis from kept outputs
 
 preprocessor:
   inputs:
@@ -20,6 +21,9 @@ preprocessor:
       collapse_dims: [LENGTH__BATCH]
       bind_scalar_to_dim_size: input_signal.INPUT_SIGNAL__TIME
   outputs_keep: [processed_signal]
+  outputs:
+    processed_signal:
+      collapse_dims: [0]
 encoder:
   inputs:
     audio_signal:
@@ -30,8 +34,14 @@ encoder:
       collapse_dims: [LENGTH__BATCH]
       bind_scalar_to_dim_size: audio_signal.AUDIO_SIGNAL__TIME
   outputs_keep: [outputs]
+  outputs:
+    outputs:
+      collapse_dims: [0]
 decoder:
   inputs:
     encoder_output:
       original_shape: [ENCODER_OUTPUT__BATCH, ENCODER_OUTPUT__CHANNEL, ENCODER_OUTPUT__TIME]
       collapse_dims: [ENCODER_OUTPUT__BATCH]
+  outputs:
+    logits:
+      collapse_dims: [0]

--- a/tests/test_remodeler_adapter.py
+++ b/tests/test_remodeler_adapter.py
@@ -33,3 +33,110 @@ def test_dynamic_axes_symbol_renames_applied():
     out_dyn = ba.dynamic_shapes_for_export()
     assert out_dyn["a"][0] == "BATCH"
     assert out_dyn["a"][1] == "U"
+
+
+# ---------------------------------------------------------------------------
+# Output collapse_dims tests
+# ---------------------------------------------------------------------------
+
+
+class _BatchedOutput(torch.nn.Module):
+    """Returns a [1, C, T] tensor (batch=1 at axis 0)."""
+
+    def __init__(self):
+        super().__init__()
+        self.input_names = ["x"]
+        self.output_names = ["out"]
+
+    def forward(self, x):
+        return x.unsqueeze(0)  # add batch dim
+
+
+def test_output_collapse_dims_squeezes_batch():
+    m = _BatchedOutput().eval()
+    ex = [torch.zeros(2, 4, dtype=torch.float32)]
+    ba = BoundaryAdapter(
+        m,
+        "s",
+        ex,
+        {},
+        collapse_by_input={},
+        outputs_keep=[],
+        output_collapse_dims={"out": [0]},
+    )
+    result = ba(torch.zeros(2, 4))
+    assert result.shape == (2, 4), f"Expected (2, 4), got {result.shape}"
+
+
+def test_output_collapse_dims_no_squeeze_when_not_one():
+    """If the axis is not size 1, squeeze must not remove it."""
+
+    class _NoCollapse(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.input_names = ["x"]
+            self.output_names = ["out"]
+
+        def forward(self, x):
+            return x  # shape stays [3, 4], axis 0 is not 1
+
+    m = _NoCollapse().eval()
+    ex = [torch.zeros(3, 4)]
+    ba = BoundaryAdapter(
+        m,
+        "s",
+        ex,
+        {},
+        collapse_by_input={},
+        outputs_keep=[],
+        output_collapse_dims={"out": [0]},
+    )
+    result = ba(torch.zeros(3, 4))
+    assert result.shape == (3, 4), f"Expected (3, 4), got {result.shape}"
+
+
+class _TwoOutputs(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.input_names = ["x"]
+        self.output_names = ["feat", "length"]
+
+    def forward(self, x):
+        return x.unsqueeze(0), torch.tensor([x.shape[1]]).unsqueeze(0)
+
+
+def test_output_collapse_dims_multiple_outputs():
+    m = _TwoOutputs().eval()
+    ex = [torch.zeros(2, 4)]
+    ba = BoundaryAdapter(
+        m,
+        "s",
+        ex,
+        {},
+        collapse_by_input={},
+        outputs_keep=[],
+        output_collapse_dims={"feat": [0], "length": [0]},
+    )
+    feat, length = ba(torch.zeros(2, 4))
+    assert feat.shape == (2, 4), f"feat: expected (2, 4), got {feat.shape}"
+    assert length.shape == (1,), f"length: expected (1,), got {length.shape}"
+
+
+def test_output_collapse_dims_selective():
+    """Only squeeze outputs that are configured, leave others untouched."""
+    m = _TwoOutputs().eval()
+    ex = [torch.zeros(2, 4)]
+    ba = BoundaryAdapter(
+        m,
+        "s",
+        ex,
+        {},
+        collapse_by_input={},
+        outputs_keep=[],
+        output_collapse_dims={"feat": [0]},  # only feat, not length
+    )
+    feat, length = ba(torch.zeros(2, 4))
+    assert feat.shape == (2, 4)
+    assert length.shape == (1, 1), (
+        f"length should keep batch: got {length.shape}"
+    )

--- a/torch_to_nnef/nemo_tract/axis_registry.py
+++ b/torch_to_nnef/nemo_tract/axis_registry.py
@@ -13,7 +13,9 @@ from torch_to_nnef.remodeler.schema import (
     INPUT_FIELD_BIND_SCALAR_TO_DIM_SIZE,
     INPUT_FIELD_COLLAPSE_DIMS,
     INPUT_FIELD_ORIGINAL_SHAPE,
+    OUTPUT_FIELD_COLLAPSE_DIMS,
     SHAPE_KEY_INPUTS,
+    SHAPE_KEY_OUTPUTS,
     SHAPE_KEY_OUTPUTS_KEEP,
     SHAPE_KEY_RENAMED,
 )
@@ -41,6 +43,9 @@ class AxisSymbolRegistry:
     renamed_symbols_per_subnet: T.Dict[str, T.Dict[str, T.List[str]]]
     # Optional per-subnet output selection: keep only these outputs
     outputs_keep_per_subnet: T.Dict[str, T.List[str]]
+    # Per-output collapse dims: qualified output name -> list of axis indices
+    # to squeeze (e.g., {"preprocessor.processed_signal": [0]})
+    output_collapse_dims: T.Dict[str, T.List[int]] = field(default_factory=dict)
     # Optional: discovered shapes with mixed ints/symbols per qualified input
     # (used for template serialization; not required when loading config)
     original_shape_per_input: T.Dict[str, T.List[T.Union[int, str]]] = field(
@@ -56,6 +61,7 @@ class AxisSymbolRegistry:
             input_collapse_dims={},
             renamed_symbols_per_subnet={},
             outputs_keep_per_subnet={},
+            output_collapse_dims={},
             original_shape_per_input={},
         )
 
@@ -251,6 +257,7 @@ def _parse_top_level(
     T.Dict[str, str],
     T.Dict[str, T.List[str]],
     T.Dict[str, T.List[str]],
+    T.Dict[str, T.List[int]],
     T.Dict[str, T.List[T.Union[int, str]]],
 ]:
     """Parse top-level entries into symbols/ranks/binds/input_dims."""
@@ -259,13 +266,21 @@ def _parse_top_level(
     binds: T.Dict[str, str] = {}
     input_dims: T.Dict[str, T.List[str]] = {}
     outputs_keep: T.Dict[str, T.List[str]] = {}
+    output_collapse: T.Dict[str, T.List[int]] = {}
     orig_shapes: T.Dict[str, T.List[T.Union[int, str]]] = {}
     for top_key, val in dict(raw or {}).items():
         _validate_key(top_key)
         if isinstance(val, dict):
             _ = _parse_renamed_symbols(top_key, val.get(SHAPE_KEY_RENAMED))
             _parse_nested_subnet(
-                top_key, val, symbols, ranks, binds, input_dims, orig_shapes
+                top_key,
+                val,
+                symbols,
+                ranks,
+                binds,
+                input_dims,
+                output_collapse,
+                orig_shapes,
             )
             if SHAPE_KEY_OUTPUTS_KEEP in val:
                 oks = val.get(SHAPE_KEY_OUTPUTS_KEEP)
@@ -286,7 +301,15 @@ def _parse_top_level(
                 "mapping"
             )
             raise T2NErrorInvalidArgument(msg)
-    return symbols, ranks, binds, input_dims, outputs_keep, orig_shapes
+    return (
+        symbols,
+        ranks,
+        binds,
+        input_dims,
+        outputs_keep,
+        output_collapse,
+        orig_shapes,
+    )
 
 
 def _build_renamed_map(raw: dict) -> dict[str, dict[str, list[str]]]:
@@ -302,6 +325,39 @@ def _build_renamed_map(raw: dict) -> dict[str, dict[str, list[str]]]:
     return out
 
 
+def _parse_output_collapse_section(
+    top_key: str,
+    outputs_section: dict,
+    output_collapse: T.Dict[str, T.List[int]],
+) -> None:
+    """Parse the ``outputs`` section of a subnet config.
+
+    Each entry maps an output name to ``{collapse_dims: [axis_indices]}``.
+    """
+    for out_name, out_cfg in outputs_section.items():
+        qname = f"{top_key}.{out_name}"
+        if not isinstance(out_cfg, dict):
+            raise T2NErrorInvalidArgument(
+                f"Invalid output config for '{qname}': expected mapping"
+            )
+        if OUTPUT_FIELD_COLLAPSE_DIMS in out_cfg:
+            cdv = out_cfg[OUTPUT_FIELD_COLLAPSE_DIMS]
+            if not isinstance(cdv, (list, tuple)) or not all(
+                isinstance(x, int) for x in cdv
+            ):
+                raise T2NErrorInvalidArgument(
+                    f"output collapse_dims for '{qname}' must be a list "
+                    "of int axis indices"
+                )
+            output_collapse[qname] = list(cdv)
+        unknown_keys = set(out_cfg.keys()) - {OUTPUT_FIELD_COLLAPSE_DIMS}
+        if unknown_keys:
+            raise T2NErrorInvalidArgument(
+                f"Unknown keys in output config for '{qname}': "
+                + ", ".join(sorted(unknown_keys))
+            )
+
+
 def _parse_nested_subnet(
     top_key: str,
     val: dict,
@@ -309,6 +365,7 @@ def _parse_nested_subnet(
     ranks: T.Dict[str, int],
     binds: T.Dict[str, str],
     input_dims: T.Dict[str, T.List[str]],
+    output_collapse: T.Dict[str, T.List[int]],
     orig_shapes: T.Dict[str, T.List[T.Union[int, str]]],
 ) -> None:
     """Parse a nested subnet mapping into outputs.
@@ -320,6 +377,7 @@ def _parse_nested_subnet(
         ranks: Output ranks map.
         binds: Output binds mapping.
         input_dims: Output collapse-dims mapping.
+        output_collapse: Output per-output collapse axes.
         orig_shapes: Output map to original dims (ints/strings).
     """
     if INPUT_FIELD_COLLAPSE_DIMS in val:
@@ -336,12 +394,31 @@ def _parse_nested_subnet(
             "keys at the subnet level are no longer supported."
         )
     # Reject unknown top-level keys besides the allowed ones
-    allowed = {SHAPE_KEY_INPUTS, SHAPE_KEY_RENAMED, SHAPE_KEY_OUTPUTS_KEEP}
+    allowed = {
+        SHAPE_KEY_INPUTS,
+        SHAPE_KEY_OUTPUTS,
+        SHAPE_KEY_RENAMED,
+        SHAPE_KEY_OUTPUTS_KEEP,
+    }
     unknown = {k for k in val if k not in allowed}
     if unknown:
         raise T2NErrorInvalidArgument(
             "Unknown keys in subnet config: " + ", ".join(sorted(unknown))
         )
+
+    # Parse outputs section (per-output collapse_dims)
+    outputs_section = val.get(SHAPE_KEY_OUTPUTS)
+    if outputs_section is not None:
+        if not isinstance(outputs_section, dict):
+            raise T2NErrorInvalidArgument(
+                f"'outputs' for subnet '{top_key}' must be a mapping"
+            )
+        _parse_output_collapse_section(
+            top_key,
+            outputs_section,
+            output_collapse,
+        )
+
     items = input_section.items()
 
     for inp_name, shape in items:
@@ -408,9 +485,15 @@ def load_axis_symbol_registry(config_path: Path) -> AxisSymbolRegistry:
             "input-name -> list of dims"
         )
     # Delegate detailed parsing to helpers to keep complexity low
-    symbols, ranks, binds, input_dims, outputs_keep, orig_shapes = (
-        _parse_top_level(raw)
-    )
+    (
+        symbols,
+        ranks,
+        binds,
+        input_dims,
+        outputs_keep,
+        output_collapse,
+        orig_shapes,
+    ) = _parse_top_level(raw)
     if not symbols:
         raise T2NErrorInvalidArgument(
             "shape-config did not define any input shapes"
@@ -424,5 +507,6 @@ def load_axis_symbol_registry(config_path: Path) -> AxisSymbolRegistry:
         input_collapse_dims=input_dims,
         renamed_symbols_per_subnet=renamed_per_subnet,
         outputs_keep_per_subnet=outputs_keep,
+        output_collapse_dims=output_collapse,
         original_shape_per_input=orig_shapes,
     )

--- a/torch_to_nnef/nemo_tract/cli.py
+++ b/torch_to_nnef/nemo_tract/cli.py
@@ -57,6 +57,7 @@ from torch_to_nnef.nemo_tract.model_loader import (
 )
 from torch_to_nnef.nemo_tract.provider import NemoProvider
 from torch_to_nnef.nemo_tract.registry_utils import (
+    auto_populate_output_collapse_dims,
     dump_registry_from_signatures,
     tie_batch_symbols_in_registry,
     validate_registry_against_signatures,
@@ -156,9 +157,13 @@ def _build_axis_registry(
     raw_sigs = provider.discover_signatures(asr_model, Stage.RAW)
     if cfg.inspect.shape_config is None:
         default_axis_reg = dump_registry_from_signatures(raw_sigs)
-        return tie_batch_symbols_in_registry(default_axis_reg)
+        default_axis_reg = tie_batch_symbols_in_registry(default_axis_reg)
+        return auto_populate_output_collapse_dims(default_axis_reg)
     axis_reg = load_axis_symbol_registry(cfg.inspect.shape_config)
     validate_registry_against_signatures(raw_sigs, axis_reg)
+    # Auto-populate output collapse for subnets with batch collapse when
+    # the user config doesn't explicitly declare outputs.collapse_dims
+    auto_populate_output_collapse_dims(axis_reg)
     return axis_reg
 
 

--- a/torch_to_nnef/nemo_tract/export.py
+++ b/torch_to_nnef/nemo_tract/export.py
@@ -650,8 +650,21 @@ def build_preprocessor_export_params(
                 outputs_keep
             ) != set(output_names)
 
+            # Per-output collapse dims for this subnet
+            out_collapse = {
+                qout.split(".", 1)[1]: axes
+                for qout, axes in axis_registry.output_collapse_dims.items()
+                if qout.startswith(f"{subnet_name}.")
+            }
+            has_out_collapse = bool(out_collapse)
+
             # Only wrap with BoundaryAdapter for structural transforms
-            if has_collapse or has_bind or has_outputs_filter:
+            if (
+                has_collapse
+                or has_bind
+                or has_outputs_filter
+                or has_out_collapse
+            ):
                 model = BoundaryAdapter(
                     model,
                     subnet_name,
@@ -664,6 +677,7 @@ def build_preprocessor_export_params(
                     axis_registry.bind_to_dim,
                     rename_map,
                     outputs_keep=outputs_keep,
+                    output_collapse_dims=out_collapse,
                 )
                 input_names = model.input_names
                 test_input = list(model.input_example())
@@ -784,8 +798,21 @@ def iter_export_params_for_generic_nemo_asr_model(
                 outputs_keep
             ) != set(output_names)
 
+            # Per-output collapse dims for this subnet
+            out_collapse = {
+                qout.split(".", 1)[1]: axes
+                for qout, axes in axis_registry.output_collapse_dims.items()
+                if qout.startswith(f"{subnet_name}.")
+            }
+            has_out_collapse = bool(out_collapse)
+
             # Only wrap with BoundaryAdapter for structural transforms
-            if has_collapse or has_bind or has_outputs_filter:
+            if (
+                has_collapse
+                or has_bind
+                or has_outputs_filter
+                or has_out_collapse
+            ):
                 model = BoundaryAdapter(
                     model,
                     subnet_name,
@@ -798,6 +825,7 @@ def iter_export_params_for_generic_nemo_asr_model(
                     axis_registry.bind_to_dim,
                     rename_map,
                     outputs_keep=outputs_keep,
+                    output_collapse_dims=out_collapse,
                 )
                 input_names = model.input_names
                 test_input = list(model.input_example())

--- a/torch_to_nnef/nemo_tract/registry_utils.py
+++ b/torch_to_nnef/nemo_tract/registry_utils.py
@@ -127,6 +127,33 @@ def _check_bind_refs(
                 )
 
 
+def _check_output_collapse_dims(
+    problems: list[str],
+    *,
+    registry: AxisSymbolRegistry,
+    disc_outputs: dict[str, set[str]],
+) -> None:
+    for qout, axes in registry.output_collapse_dims.items():
+        if "." not in qout:
+            problems.append(
+                f"output_collapse_dims key '{qout}' must be qualified "
+                "(subnet.output_name)"
+            )
+            continue
+        subnet, oname = qout.split(".", 1)
+        disc = disc_outputs.get(subnet, set())
+        if oname not in disc:
+            problems.append(
+                f"output_collapse_dims references unknown output '{oname}' "
+                f"for subnet '{subnet}'"
+            )
+        for ax in axes:
+            if not isinstance(ax, int) or ax < 0:
+                problems.append(
+                    f"output_collapse_dims for '{qout}' has invalid axis: {ax}"
+                )
+
+
 def _check_collapse_and_renames(
     problems: list[str],
     *,
@@ -188,6 +215,46 @@ def dump_registry_from_signatures(
         outputs_keep_per_subnet=outputs_keep_per_subnet,
         original_shape_per_input=original_shapes,
     )
+
+
+def auto_populate_output_collapse_dims(
+    registry: AxisSymbolRegistry,
+) -> AxisSymbolRegistry:
+    """Auto-add ``collapse_dims: [0]`` for batch collapse.
+
+    For outputs of subnets with batch collapse on inputs.
+
+    For each subnet where at least one input has a ``collapse_dims`` containing
+    a ``*__BATCH`` symbol, add ``collapse_dims: [0]`` for every output of that
+    subnet (taken from ``outputs_keep_per_subnet``).  User-provided entries
+    take precedence and are not overwritten.
+
+    Args:
+        registry: Axis symbol registry (possibly loaded from config).
+
+    Returns:
+        The same registry instance with ``output_collapse_dims`` updated.
+    """
+    subnets_with_batch_collapse: set[str] = set()
+    for qname, syms in registry.input_collapse_dims.items():
+        if "." not in qname:
+            continue
+        subnet = qname.split(".", 1)[0]
+        if any(str(s).upper().endswith(f"{_SEP}BATCH") for s in syms):
+            subnets_with_batch_collapse.add(subnet)
+
+    if not subnets_with_batch_collapse:
+        return registry
+
+    out_collapse = dict(registry.output_collapse_dims)
+    for subnet in subnets_with_batch_collapse:
+        output_names = registry.outputs_keep_per_subnet.get(subnet, [])
+        for oname in output_names:
+            qout = f"{subnet}.{oname}"
+            if qout not in out_collapse:
+                out_collapse[qout] = [0]
+    registry.output_collapse_dims = out_collapse
+    return registry
 
 
 def tie_batch_symbols_in_registry(
@@ -262,6 +329,9 @@ def validate_registry_against_signatures(
         disc_inputs=disc_inputs,
     )
     _check_outputs_keep(problems, registry=registry, disc_outputs=disc_outputs)
+    _check_output_collapse_dims(
+        problems, registry=registry, disc_outputs=disc_outputs
+    )
     _check_bind_refs(
         problems,
         registry=registry,

--- a/torch_to_nnef/remodeler/adapter.py
+++ b/torch_to_nnef/remodeler/adapter.py
@@ -24,6 +24,7 @@ class BoundaryAdapter(torch.nn.Module):
         binds_by_input: T.Optional[dict[str, str]] = None,
         renamed_map: T.Optional[dict[str, list[str]]] = None,
         outputs_keep: T.Optional[list[str]] = None,
+        output_collapse_dims: T.Optional[dict[str, list[int]]] = None,
         *,
         apply_symbol_renames: bool = True,
     ) -> None:
@@ -37,6 +38,7 @@ class BoundaryAdapter(torch.nn.Module):
         self._orig_input_example = list(input_example or [])
         self._dyn_axes = dict(dynamic_axes or {})
         self._outputs_keep = list(outputs_keep or [])
+        self._output_collapse_dims = dict(output_collapse_dims or {})
         self._apply_syms = bool(apply_symbol_renames)
         (
             initial_ext_names,
@@ -308,10 +310,32 @@ class BoundaryAdapter(torch.nn.Module):
                 lst[idx] = tval
                 by_base[base] = lst
 
+    def _squeeze_outputs(self, outs):
+        """Squeeze configured axes from outputs."""
+        if not self._output_collapse_dims:
+            return outs
+        was_tuple = isinstance(outs, tuple)
+        items = outs if was_tuple else (outs,)
+        squeezed = list(items)
+        for i, name in enumerate(self._orig_output_names):
+            if i >= len(squeezed):
+                break
+            axes = self._output_collapse_dims.get(name)
+            if not axes:
+                continue
+            t = squeezed[i]
+            if torch.is_tensor(t):
+                for ax in sorted(axes, reverse=True):
+                    if 0 <= ax < t.dim() and t.size(ax) == 1:
+                        t = t.squeeze(ax)
+                squeezed[i] = t
+        return tuple(squeezed) if was_tuple else squeezed[0]
+
     def forward(self, *args, **kwargs):
         assert not kwargs, "BoundaryAdapter expects positional args only"
         rebuilt = self._rebuild_internal_args(list(args))
         outs = self.module(*rebuilt)
+        outs = self._squeeze_outputs(outs)
         if not self._outputs_keep:
             return outs
         if not isinstance(outs, tuple):

--- a/torch_to_nnef/remodeler/schema.py
+++ b/torch_to_nnef/remodeler/schema.py
@@ -6,6 +6,7 @@ support the remodeler boundary plan (collapse, bind, renamed_symbols, etc.).
 
 # Top-level subnet mapping keys
 SHAPE_KEY_INPUTS = "inputs"
+SHAPE_KEY_OUTPUTS = "outputs"
 SHAPE_KEY_RENAMED = "renamed_symbols"
 SHAPE_KEY_OUTPUTS_KEEP = "outputs_keep"
 
@@ -15,11 +16,16 @@ INPUT_FIELD_COLLAPSE_DIMS = "collapse_dims"
 # Canonical bind key in user config (descriptive)
 INPUT_FIELD_BIND_SCALAR_TO_DIM_SIZE = "bind_scalar_to_dim_size"
 
+# Per-output fields
+OUTPUT_FIELD_COLLAPSE_DIMS = "collapse_dims"
+
 __all__ = [
     "SHAPE_KEY_INPUTS",
+    "SHAPE_KEY_OUTPUTS",
     "SHAPE_KEY_RENAMED",
     "SHAPE_KEY_OUTPUTS_KEEP",
     "INPUT_FIELD_ORIGINAL_SHAPE",
     "INPUT_FIELD_COLLAPSE_DIMS",
     "INPUT_FIELD_BIND_SCALAR_TO_DIM_SIZE",
+    "OUTPUT_FIELD_COLLAPSE_DIMS",
 ]


### PR DESCRIPTION
## Summary

- Adds per-output `collapse_dims` to the shape YAML config, allowing explicit declaration of which axes to squeeze from each output tensor
- `BoundaryAdapter.forward()` now squeezes configured output axes after calling the inner module, fixing the extra `[1, ...]` batch dimension in exported NNEF models
- NeMo registry auto-populates `collapse_dims: [0]` for outputs when batch collapse is detected on inputs (mirrors existing batch-rename auto-population)
- Updated `shapes.marblenet.collapsed.yaml` with output collapse config for preprocessor, encoder, and decoder

### YAML schema

```yaml
preprocessor:
  inputs:
    input_signal:
      collapse_dims: [INPUT_SIGNAL__BATCH]
  outputs_keep: [processed_signal]
  outputs:
    processed_signal:
      collapse_dims: [0]
```
## Test plan

- [x] `pytest tests/test_remodeler_adapter.py` — 5/5 pass
