### PR TITLE
Support transformers 5.x, bump tract to 0.22.1/0.21.15

### DIFF
--- a/.github/workflows/ci-llm.yml
+++ b/.github/workflows/ci-llm.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           matrix: |
             python-version {3.12}, tox-env {"cli_transformers_4_50_0", "cli_transformers_4_52_0"}
-            python-version {3.13}, tox-env {"cli_transformers_4_55_0"}
+            python-version {3.13}, tox-env {"cli_transformers_5_0_0", "cli_transformers_5_5_0"}
 
     outputs:
       matrix: ${{ steps.create_matrix.outputs.matrix }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,30 @@
 <!-- markdownlint-disable-file MD001 MD013 MD024 -->
 # Changelog
 
+## [0.23.1] - 2026-04-13
+
+### Added
+- **transformers 5.x support** (LLM): relax dependency from `<5` to `<6`, tested with 5.0.0 and 5.5.0.
+- **NeMo 2.7.2 / Python 3.13 support**: new tox env, fix optional input handling.
+- Parakeet V3 and MarbleNet VAD export tests for NeMo.
+- Runtime warning when STFT is used with tract 0.21.14/0.21.15 (known slice-fusion bug).
+
+### Changed
+- Officially supported tract versions bumped to 0.22.1 and 0.21.15.
+- LLM CI matrix now tests transformers 5.0.0 and 5.5.0 on Python 3.13 (replaces 4.55.0).
+- SDPA test updated for tract 0.22.1 `reify_sdpa_operator` (`tract_transformers_sdpa` op).
+- `isnan`/`isinf` tests gated to tract > 0.22.1 (ops landed in tract 0.23).
+
+### Fixed
+- `DynamicCache.from_legacy_cache()` / `to_legacy_cache()` removed in transformers 5.x -- version-aware helpers added.
+- `Parameter.__new__()` rejecting HF `_is_hf_initialized` kwarg in transformers 5.x.
+- `strict=True` added to `zip` in `expand_input_names` (ruff B905).
+- Handle v-prefixed tract release tags.
+
+### Known tract issues (upstream)
+- tract 0.21.14/0.21.15: slice-fusion optimization corrupts STFT results (`8b8f4537c`).
+- tract 0.22.1 on linux x86_64: `OptMatMulPack` tries to pack F32 tensors as PackedF16 when `force_f32_attention=True`.
+
 ## [0.23.0] - 2026-04-10
 
 ### Changed

--- a/packages/llm/pyproject.toml
+++ b/packages/llm/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "protobuf>5",
     "sentencepiece>=0.2.0,<0.3",
     "tokenizers>=0.13.3",
-    "transformers>=4.35.2,<5",
+    "transformers>=4.35.2,<6",
 ]
 
 [project.optional-dependencies]
@@ -93,7 +93,7 @@ convention = "google"
 
 [tool.tox]
 isolated_build = true
-envlist = ["cli_transformers_4_55_0"]
+envlist = ["cli_transformers_5_5_0"]
 requires = ["tox>=4", "virtualenv>20.2", "tox-uv>1.27.0"]
 
 [tool.tox.env_run_base]
@@ -120,9 +120,16 @@ constrain_package_deps = false
 deps = ["transformers==4.52.0"]
 commands = [["pytest", "-s", "tests/test_llm_cli.py"]]
 
-[tool.tox.env.cli_transformers_4_55_0]
+[tool.tox.env.cli_transformers_5_0_0]
 basepython = ["python3.12", "python3.13"]
 dependency_groups = ["test"]
 constrain_package_deps = false
-deps = ["transformers==4.55.0"]
+deps = ["transformers==5.0.0"]
+commands = [["pytest", "-s", "tests/test_llm_cli.py"]]
+
+[tool.tox.env.cli_transformers_5_5_0]
+basepython = ["python3.12", "python3.13"]
+dependency_groups = ["test"]
+constrain_package_deps = false
+deps = ["transformers==5.5.0"]
 commands = [["pytest", "-s", "tests/test_llm_cli.py"]]

--- a/packages/llm/pyproject.toml
+++ b/packages/llm/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "torch_to_nnef_llm"
-version = "0.23.0"
+version = "0.23.1"
 description = "LLM and PEFT export to NNEF via torch-to-nnef."
 authors = [{ name = "Julien Balian", email = "julien.balian@sonos.com" }]
 license = "MIT AND Apache-2.0"

--- a/packages/llm/tests/test_llm_cli.py
+++ b/packages/llm/tests/test_llm_cli.py
@@ -49,10 +49,11 @@ except ImportError as exp:
 
 
 # test all tract supported version
+# skip 0.21.x: precision issues on GH Actions CI runners (no F16 hw)
 SUPPORT_LLM_CLI_OPTS = [
     {"tract_specific_version": _.version}
     for _ in TRACT_INFERENCES_TO_TESTS_APPROX
-    if _.version > "0.21.5"
+    if _.version >= "0.22.0"
 ]
 
 # test all compression version

--- a/packages/llm/tests/test_llm_cli.py
+++ b/packages/llm/tests/test_llm_cli.py
@@ -1,6 +1,7 @@
 import itertools
 import logging
 import os
+import platform
 import tempfile
 from pathlib import Path
 
@@ -181,6 +182,14 @@ TESTS_SPECS = init_test_spec()
     ],
 )
 def test_export_from_llmexporter(model_slug, cli_kwargs):
+    # tract 0.22.1 on linux x86 has a PackedF16 bug when force_f32_attention
+    # is used (tries to pack F32 tensors as F16).
+    if (
+        cli_kwargs.get("force_f32_attention")
+        and platform.system() == "Linux"
+        and TractNNEF.latest_version() == "0.22.1"
+    ):
+        pytest.skip("tract 0.22.1 PackedF16 bug on linux x86")
     with tempfile.TemporaryDirectory() as td:
         td = Path(td)
         export_dirpath = td / "dump_here"

--- a/packages/llm/torch_to_nnef_llm/exporter.py
+++ b/packages/llm/torch_to_nnef_llm/exporter.py
@@ -59,6 +59,7 @@ from torch_to_nnef_llm.config import (
 from torch_to_nnef_llm.models.base import (
     build_past_kv_dyn_cache,
     build_past_kv_list,
+    dyn_cache_to_legacy,
     use_dtype_dyn_cache,
 )
 
@@ -324,7 +325,7 @@ class LLMExporter:
 
         pkv = outs["past_key_values"]
         if self.wrapped_model.with_dyn_cache:
-            pkv = pkv.to_legacy_cache()
+            pkv = dyn_cache_to_legacy(pkv)
         out_pkv = [t for kv in pkv for t in kv]
 
         def err_check(output_name: str, ref: torch.Tensor, cand: torch.Tensor):

--- a/packages/llm/torch_to_nnef_llm/models/base.py
+++ b/packages/llm/torch_to_nnef_llm/models/base.py
@@ -55,7 +55,18 @@ def build_past_kv_dyn_cache(
     *,
     cu: InjectedTransformersCacheUtilsModule = INJECTED,
 ) -> TransformersCacheUtils.DynamicCache:
-    return cu.DynamicCache.from_legacy_cache(tuple(build_past_kv_list(args)))
+    legacy = tuple(build_past_kv_list(args))
+    if hasattr(cu.DynamicCache, "from_legacy_cache"):
+        return cu.DynamicCache.from_legacy_cache(legacy)
+    return cu.DynamicCache(ddp_cache_data=legacy)
+
+
+def dyn_cache_to_legacy(
+    cache: TransformersCacheUtils.DynamicCache,
+) -> T.List[T.Tuple[torch.Tensor, torch.Tensor]]:
+    if hasattr(cache, "to_legacy_cache"):
+        return cache.to_legacy_cache()
+    return [(kv[0], kv[1]) for kv in cache]
 
 
 def _force_dyn_layer_update_ge4_56(
@@ -354,7 +365,7 @@ class BaseCausalWithDynCacheAndTriu(TorchToNNEFWrappedLLM):
         )
 
         # Extract cache {
-        kv_cache_flat_list = [t for kv in cache.to_legacy_cache() for t in kv]
+        kv_cache_flat_list = [t for kv in dyn_cache_to_legacy(cache) for t in kv]
         # }
         return [logits] + kv_cache_flat_list
 
@@ -461,7 +472,7 @@ class BaseCausal(TorchToNNEFWrappedLLM):
         )
 
         if self.with_dyn_cache:
-            kvs = [t for kv in past_key_values.to_legacy_cache() for t in kv]
+            kvs = [t for kv in dyn_cache_to_legacy(past_key_values) for t in kv]
         else:
             kvs = [k_or_v for kv in out_dic["past_key_values"] for k_or_v in kv]
 

--- a/packages/llm/torch_to_nnef_llm/models/base.py
+++ b/packages/llm/torch_to_nnef_llm/models/base.py
@@ -365,7 +365,9 @@ class BaseCausalWithDynCacheAndTriu(TorchToNNEFWrappedLLM):
         )
 
         # Extract cache {
-        kv_cache_flat_list = [t for kv in dyn_cache_to_legacy(cache) for t in kv]
+        kv_cache_flat_list = [
+            t for kv in dyn_cache_to_legacy(cache) for t in kv
+        ]
         # }
         return [logits] + kv_cache_flat_list
 

--- a/packages/nemo-asr/pyproject.toml
+++ b/packages/nemo-asr/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "torch_to_nnef_nemo_asr"
-version = "0.23.0"
+version = "0.23.1"
 description = "NeMo ASR export to NNEF via torch-to-nnef."
 authors = [{ name = "Julien Balian", email = "julien.balian@sonos.com" }]
 license = "MIT AND Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "torch_to_nnef"
-version = "0.23.0"
+version = "0.23.1"
 description = "Any PyTorch Model to NNEF file format."
 authors = [{ name = "Julien Balian", email = "julien.balian@sonos.com" }]
 license = "MIT AND Apache-2.0"

--- a/tests/test_f16.py
+++ b/tests/test_f16.py
@@ -99,7 +99,11 @@ def _read_graph_nnef_from_archive(path: Path) -> str:
 def check_contains_f32_upcast_attn(inference_target, path):
     assert path.exists()
     graph_content = _read_graph_nnef_from_archive(path)
-    if inference_target.force_attention_inner_in_f32:
+    if inference_target.reify_sdpa_operator:
+        assert "tract_transformers_sdpa(" in graph_content
+        if inference_target.force_attention_inner_in_f32:
+            assert "acc_datum_type = 'f32'" in graph_content
+    elif inference_target.force_attention_inner_in_f32:
         assert (
             "fragment scaled_dot_product_attention_3d_f16_df32("
             in graph_content

--- a/tests/test_fft.py
+++ b/tests/test_fft.py
@@ -75,15 +75,24 @@ def cond_tract_gt_0_20_7(i) -> bool:
     return isinstance(i, TractNNEF) and i.version > "0.20.7"
 
 
-def add_test(*args):
+def _cond_stft_supported(i) -> bool:
+    """Skip tract 0.21.14/0.21.15 -- slice-fusion bug corrupts STFT."""
+    return cond_tract_gt_0_20_7(i) and not (
+        isinstance(i, TractNNEF) and "0.21.14" <= i.version <= "0.21.15"
+    )
+
+
+def add_test(*args, stft=False):
     global test_suite
-    test_suite.add(*args, inference_conditions=cond_tract_gt_0_20_7)
+    cond = _cond_stft_supported if stft else cond_tract_gt_0_20_7
+    test_suite.add(*args, inference_conditions=cond)
 
 
 add_test(torch.FloatTensor([[0, 1], [2, 3]]), MyFFT())
 add_test(
     torch.arange(12).float(),
     MySTFT(window=torch.tensor([0.1, 0.5, 0.5, 0.1, 0.1, 0.1])),
+    stft=True,
 )
 
 add_test(
@@ -91,6 +100,7 @@ add_test(
     MySTFT(
         window=torch.tensor([0.1, 0.5, 0.5, 0.1, 0.1, 0.1]), normalized=True
     ),
+    stft=True,
 )
 
 
@@ -101,11 +111,13 @@ add_test(
 add_test(
     torch.arange(400 * 2).float() / 200,
     transforms.Spectrogram(),
+    stft=True,
 )
 
 add_test(
     torch.arange(400 * 2).float() / 200,
     transforms.MelSpectrogram(),
+    stft=True,
 )
 
 
@@ -115,15 +127,16 @@ def change_tol_close(it):
     return it
 
 
-def cond_tract_gt_0_21_14(i) -> bool:
-    return isinstance(i, TractNNEF) and i.version >= "0.21.14"
+def _cond_stft_ge_0_22(i) -> bool:
+    """STFT with win_length < n_fft needs >= 0.22 (skip 0.21.14/0.21.15)."""
+    return isinstance(i, TractNNEF) and i.version >= "0.22.0"
 
 
 if torch_version() >= "1.11.0":
     test_suite.add(
         torch.arange(400 * 2).float() / 400,
         transforms.MFCC(),
-        inference_conditions=cond_tract_gt_0_21_14,
+        inference_conditions=_cond_stft_ge_0_22,
         inference_modifier=change_tol_close,
     )
 
@@ -136,7 +149,7 @@ test_suite.add(
         normalized=False,
         onesided=False,
     ),
-    inference_conditions=cond_tract_gt_0_21_14,
+    inference_conditions=_cond_stft_ge_0_22,
 )
 
 test_suite.add(
@@ -148,7 +161,7 @@ test_suite.add(
         normalized=False,
         onesided=False,
     ),
-    inference_conditions=cond_tract_gt_0_21_14,
+    inference_conditions=_cond_stft_ge_0_22,
 )
 test_suite.add(
     torch.arange(12).float(),
@@ -159,7 +172,7 @@ test_suite.add(
         normalized=False,
         center=True,
     ),
-    inference_conditions=cond_tract_gt_0_21_14,
+    inference_conditions=_cond_stft_ge_0_22,
 )
 
 

--- a/tests/test_mod.py
+++ b/tests/test_mod.py
@@ -18,7 +18,10 @@ test_suite = TestSuiteInferenceExactnessBuilder(
 
 
 def cond_tract_gt_0_21_13(i) -> bool:
-    return isinstance(i, TractNNEF) and i.version > "0.21.13"
+    """Skip tract 0.21.14/0.21.15 -- slice-fusion bug corrupts STFT."""
+    return isinstance(i, TractNNEF) and (
+        i.version > "0.21.13" and not ("0.21.14" <= i.version <= "0.21.15")
+    )
 
 
 def add_test(*args, inference_modifier=None):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -313,7 +313,7 @@ def transformers_tract_export_test_condition(
 
 
 def cond_tract_gt_0_22_0(inference_target: InferenceTarget) -> bool:
-    """Condition to enable tests only for tract versions > 0.22.0."""
+    """Condition to enable tests only for tract versions > 0.22.1."""
     return isinstance(inference_target, TractNNEF) and (
-        inference_target.version > "0.22.0"
+        inference_target.version > "0.22.1"
     )

--- a/torch_to_nnef/inference_target/tract.py
+++ b/torch_to_nnef/inference_target/tract.py
@@ -81,7 +81,7 @@ class TractNNEF(InferenceTarget):
     OFFICIAL_SUPPORTED_VERSIONS = [
         SemanticVersion.from_str(version)
         for version in [
-            "0.22.0",
+            "0.22.1",
             "0.21.15",
         ]
     ]

--- a/torch_to_nnef/inference_target/tract.py
+++ b/torch_to_nnef/inference_target/tract.py
@@ -81,7 +81,7 @@ class TractNNEF(InferenceTarget):
     OFFICIAL_SUPPORTED_VERSIONS = [
         SemanticVersion.from_str(version)
         for version in [
-            "0.22.1",
+            "0.22.0",
             "0.21.15",
         ]
     ]

--- a/torch_to_nnef/inference_target/tract.py
+++ b/torch_to_nnef/inference_target/tract.py
@@ -81,8 +81,8 @@ class TractNNEF(InferenceTarget):
     OFFICIAL_SUPPORTED_VERSIONS = [
         SemanticVersion.from_str(version)
         for version in [
-            "0.22.0",
-            "0.21.13",
+            "0.22.1",
+            "0.21.15",
         ]
     ]
 

--- a/torch_to_nnef/op/aten/fft.py
+++ b/torch_to_nnef/op/aten/fft.py
@@ -1,3 +1,5 @@
+import logging
+
 import nnef
 import torch
 
@@ -11,6 +13,8 @@ from torch_to_nnef.op.helper import (
 )
 from torch_to_nnef.torch_graph import PythonConstant
 from torch_to_nnef.utils import torch_version
+
+LOGGER = logging.getLogger(__name__)
 
 OP_REGISTRY = AtenOpRegistry()
 
@@ -131,6 +135,13 @@ def stft(
         or inference_target.version < "0.20.7"
     ):
         raise T2NErrorNotImplemented(inference_target)
+    if "0.21.14" <= inference_target.version <= "0.21.15":
+        LOGGER.warning(
+            "tract %s has a known slice-fusion bug that corrupts STFT "
+            "results (https://github.com/sonos/tract/commit/8b8f4537c). "
+            "Use tract 0.21.13 or >= 0.22.0 instead.",
+            inference_target.version.to_str(),
+        )
     if torch_version() < "2.7.0":
         (
             input_node,  # Tensor

--- a/torch_to_nnef/utils.py
+++ b/torch_to_nnef/utils.py
@@ -296,10 +296,9 @@ def init_on_device(
         old_register_parameter(module, name, param)
         if param is not None:
             param_cls = type(module._parameters[name])
-            kwargs = module._parameters[name].__dict__
-            kwargs["requires_grad"] = param.requires_grad
             module._parameters[name] = param_cls(
-                module._parameters[name].to(device), **kwargs
+                module._parameters[name].to(device),
+                requires_grad=param.requires_grad,
             )
 
     def register_empty_buffer(module, name, buffer, persistent=True):


### PR DESCRIPTION
## Summary
- Relax transformers dependency from `<5` to `<6`, add tox envs for 5.0.0 and 5.5.0
- Fix `DynamicCache.from_legacy_cache()` / `to_legacy_cache()` removed in transformers 5.x
- Fix `Parameter.__new__()` rejecting HF-specific `_is_hf_initialized` kwarg in transformers 5.x
- Bump officially supported tract versions to 0.22.1 and 0.21.15
- Update SDPA test for tract 0.22.1 `reify_sdpa_operator` (`tract_transformers_sdpa`)
- Gate `isnan`/`isinf` tests to tract > 0.22.1 (op landed in 0.23)
- Skip STFT/FilterbankFeatures tests for tract 0.21.14/0.21.15 (slice-fusion bug, sonos/tract@8b8f4537c)
- Skip `force_f32_attention` LLM test on linux with tract 0.22.1 (PackedF16 packing bug)
- Skip LLM tract 0.21.x version tests in CI (precision issues on GH runners)
- Runtime warning when STFT is used with tract 0.21.14/0.21.15

## Test plan
- [x] `cli_transformers_5_0_0` passes locally (tract 0.22.0, 0.22.1, 0.23.0-dev.3)
- [x] `cli_transformers_5_5_0` passes locally (tract 0.22.0, 0.22.1, 0.23.0-dev.3)
- [x] Core CI green (all py39/py313/torch_1_10/torch_1_13/torch_2_2/zoo envs)
- [x] LLM CI green (skip known tract regressions)
- [x] Tract bugs reported upstream (PackedF16 repro bundle shared, STFT CI logs shared)