### PR TITLE
feat(nemo-asr): auto-resolve slug from fingerprint and derive tract extensions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -123,4 +123,5 @@ site/
 graph.nnef
 *.dat
 *.json
+!packages/nemo-asr/torch_to_nnef_nemo/slug_fingerprints.json
 *.out

--- a/packages/nemo-asr/tests/test_extensions.py
+++ b/packages/nemo-asr/tests/test_extensions.py
@@ -289,3 +289,24 @@ def test_derived_empty_for_unknown_attention():
     cfg.encoder.self_attention_model = "rotary"
     m = _patched_model(cfg)
     assert derive_extensions(m) == {}
+
+
+def test_derived_empty_for_model_without_encoder():
+    """Models that aren't encoder/decoder ASR should bail gracefully."""
+
+    class _NoEncoderModel:
+        pass
+
+    m = _NoEncoderModel()
+    m.cfg = OmegaConf.create({"foo": "bar"})
+    assert derive_extensions(m) == {}
+
+
+def test_fingerprint_none_for_model_without_encoder():
+    class _NoEncoderModel:
+        pass
+
+    m = _NoEncoderModel()
+    m.cfg = OmegaConf.create({"foo": "bar"})
+    assert fingerprint_from_asr_model(m) is None
+    assert resolve_slug_from_asr_model(m) is None

--- a/packages/nemo-asr/tests/test_extensions.py
+++ b/packages/nemo-asr/tests/test_extensions.py
@@ -2,6 +2,7 @@ import tempfile
 from pathlib import Path
 
 import yaml
+from omegaconf import OmegaConf
 
 from torch_to_nnef.exceptions import T2NErrorInvalidArgument
 from torch_to_nnef.remodeler import save_config
@@ -9,9 +10,21 @@ from torch_to_nnef_nemo.axis_registry import (
     AxisSymbolRegistry,
     load_axis_symbol_registry,
 )
+from torch_to_nnef_nemo.derived_constraints import (
+    derive_encoder_time_bound,
+    derive_extensions,
+)
+from torch_to_nnef_nemo.model_loader import (
+    NEMOTRON_0_6B,
+    PARAKEET_V3_SLUG,
+)
 from torch_to_nnef_nemo.slug_extensions import (
     SLUG_EXTENSIONS,
+    EncoderFingerprint,
+    fingerprint_from_asr_model,
     get_extensions_for_slug,
+    load_slug_fingerprints,
+    resolve_slug_from_asr_model,
 )
 
 
@@ -113,3 +126,166 @@ def test_slug_extensions_unknown():
 
 def test_slug_registry_is_not_empty():
     assert len(SLUG_EXTENSIONS) > 0
+
+
+# -- fingerprint resolver ----------------------------------------------------
+
+
+def _patched_model(
+    cfg,
+    model_class="EncDecRNNTBPEModel",
+    encoder_class="ConformerEncoder",
+):
+    """Build a minimal stand-in for an ``ASRModel`` instance.
+
+    The resolver reads ``type(asr_model).__name__`` and
+    ``type(asr_model.encoder).__name__``, so we dynamically create
+    classes with the target names rather than importing NeMo.
+    """
+    enc_cls = type(encoder_class, (), {})
+    model_cls = type(model_class, (), {})
+    m = model_cls()
+    m.cfg = cfg
+    m.encoder = enc_cls()
+    return m
+
+
+def _parakeet_v3_cfg():
+    return OmegaConf.create(
+        {
+            "model_defaults": {"num_tdt_durations": 5},
+            "encoder": {
+                "feat_in": 128,
+                "d_model": 1024,
+                "n_layers": 24,
+                "subsampling": "dw_striding",
+                "subsampling_factor": 8,
+                "conv_kernel_size": 9,
+                "self_attention_model": "rel_pos",
+                "att_context_size": [-1, -1],
+                "pos_emb_max_len": 5000,
+            },
+        }
+    )
+
+
+def _nemotron_0_6b_cfg():
+    return OmegaConf.create(
+        {
+            "model_defaults": {},
+            "encoder": {
+                "feat_in": 128,
+                "d_model": 1024,
+                "n_layers": 24,
+                "subsampling": "dw_striding",
+                "subsampling_factor": 8,
+                "conv_kernel_size": 9,
+                "self_attention_model": "rel_pos",
+                "pos_emb_max_len": 5000,
+                "att_context_size": [[70, 13], [70, 6], [70, 1], [70, 0]],
+            },
+        }
+    )
+
+
+def test_fingerprints_cover_all_slugs():
+    """Maintainer guardrail: every SLUG_EXTENSIONS entry has a fingerprint.
+
+    If this fails, run
+    ``python -m torch_to_nnef_nemo.tools.refresh_slug_fingerprints``.
+    """
+    missing = set(SLUG_EXTENSIONS) - set(load_slug_fingerprints())
+    assert not missing, f"missing fingerprints for slugs: {missing}"
+
+
+def test_fingerprint_from_dict_roundtrip():
+    for fp in load_slug_fingerprints().values():
+        assert EncoderFingerprint.from_dict(fp.to_dict()) == fp
+
+
+def test_resolve_parakeet_v3_from_fake_cfg():
+    m = _patched_model(_parakeet_v3_cfg())
+    assert resolve_slug_from_asr_model(m) == "nvidia/parakeet-tdt-0.6b-v3"
+
+
+def test_resolve_nemotron_from_fake_cfg():
+    m = _patched_model(_nemotron_0_6b_cfg())
+    assert (
+        resolve_slug_from_asr_model(m)
+        == "nvidia/nemotron-speech-streaming-en-0.6b"
+    )
+
+
+def test_fingerprint_distinguishes_streaming_from_offline():
+    """Flipping att_context_size alone should break the v3 match."""
+    cfg = _parakeet_v3_cfg()
+    cfg.encoder.att_context_size = [[70, 13], [70, 6], [70, 1], [70, 0]]
+    m = _patched_model(cfg)
+    # streaming context + num_tdt_durations=5 is not a registered combo
+    assert resolve_slug_from_asr_model(m) is None
+
+
+def test_fingerprint_miss_on_unknown_arch():
+    cfg = _parakeet_v3_cfg()
+    cfg.encoder.d_model = 768  # arbitrary change
+    m = _patched_model(cfg)
+    assert resolve_slug_from_asr_model(m) is None
+
+
+def test_fingerprint_from_asr_model_shape():
+    """Smoke: builder returns a fingerprint with the expected shape.
+
+    Independent of the committed JSON.
+    """
+    m = _patched_model(_parakeet_v3_cfg())
+    fp = fingerprint_from_asr_model(m)
+    assert fp.model_class == "EncDecRNNTBPEModel"
+    assert fp.encoder_class == "ConformerEncoder"
+    assert fp.att_context_size == ((-1, -1),)
+    assert fp.num_tdt_durations == 5
+
+
+# -- architecture-derived constraints ---------------------------------------
+
+
+def test_derived_parakeet_v3_matches_hardcoded_registry():
+    """Parity: deriver output equals the committed SLUG_EXTENSIONS entry."""
+    m = _patched_model(_parakeet_v3_cfg())
+    assert derive_extensions(m) == get_extensions_for_slug(PARAKEET_V3_SLUG)
+
+
+def test_derived_nemotron_matches_hardcoded_registry():
+    """Parity: deriver output equals the committed SLUG_EXTENSIONS entry."""
+    m = _patched_model(_nemotron_0_6b_cfg())
+    assert derive_extensions(m) == get_extensions_for_slug(NEMOTRON_0_6B)
+
+
+def test_derived_bound_value_is_39993():
+    """Pin the exact numeric bound for the pos_emb_max_len=5000 + factor=8 case.
+
+    Guards against regressions if the preimage formula is touched.
+    """
+    cfg = _parakeet_v3_cfg()
+    assert derive_encoder_time_bound(cfg.encoder) == 39993
+
+
+def test_derived_scales_with_pos_emb_and_factor():
+    cfg = _parakeet_v3_cfg()
+    cfg.encoder.pos_emb_max_len = 8000
+    cfg.encoder.subsampling_factor = 4
+    # (8000 - 1) * 4 + 1 = 31997
+    assert derive_encoder_time_bound(cfg.encoder) == 31997
+
+
+def test_derived_empty_for_unknown_subsampling():
+    cfg = _parakeet_v3_cfg()
+    cfg.encoder.subsampling = "stacking"
+    m = _patched_model(cfg)
+    assert derive_extensions(m) == {}
+
+
+def test_derived_empty_for_unknown_attention():
+    cfg = _parakeet_v3_cfg()
+    cfg.encoder.self_attention_model = "rotary"
+    m = _patched_model(cfg)
+    assert derive_extensions(m) == {}

--- a/packages/nemo-asr/torch_to_nnef_nemo/cli.py
+++ b/packages/nemo-asr/torch_to_nnef_nemo/cli.py
@@ -52,6 +52,7 @@ from torch_to_nnef_nemo.config import (
 from torch_to_nnef_nemo.constants import (
     NEMO_INPUT_SYMBOL_SEPARATOR as _SEP,
 )
+from torch_to_nnef_nemo.derived_constraints import derive_extensions
 from torch_to_nnef_nemo.export import export_nemo_from_model
 from torch_to_nnef_nemo.inspect import run_inspection
 from torch_to_nnef_nemo.model_loader import (
@@ -65,7 +66,10 @@ from torch_to_nnef_nemo.registry_utils import (
     tie_batch_symbols_in_registry,
     validate_registry_against_signatures,
 )
-from torch_to_nnef_nemo.slug_extensions import get_extensions_for_slug
+from torch_to_nnef_nemo.slug_extensions import (
+    get_extensions_for_slug,
+    resolve_slug_from_asr_model,
+)
 from torch_to_nnef_nemo.wrappers import use_pytorch_sdpa
 
 LOGGER = logging.getLogger(__name__)
@@ -140,25 +144,60 @@ def _normalize_tolerance(cfg: NemoTractConfig) -> None:
         )
 
 
-def _merge_slug_extensions(axis_reg: AxisSymbolRegistry, slug: str) -> None:
-    """Merge known slug extensions into the registry as defaults.
+def _merge_extension_map(
+    axis_reg: AxisSymbolRegistry,
+    ext_map: T.Mapping[str, T.Sequence[str]],
+) -> None:
+    """Merge a per-subnet extension map into the registry as defaults.
 
     Extensions already declared in the user config take precedence:
-    if a subnet already has extensions, slug defaults are not added
-    for that subnet.
+    duplicates are skipped so the same assertion string is not added
+    twice when the slug registry and the architecture deriver produce
+    the same bound.
     """
-    slug_exts = get_extensions_for_slug(slug)
-    if not slug_exts:
+    if not ext_map:
         return
-    for subnet, exts in slug_exts.items():
+    for subnet, exts in ext_map.items():
         if subnet not in axis_reg.extensions_per_subnet:
             axis_reg.extensions_per_subnet[subnet] = list(exts)
         else:
-            # Append slug entries that the user didn't already declare
             existing = set(axis_reg.extensions_per_subnet[subnet])
             axis_reg.extensions_per_subnet[subnet].extend(
                 e for e in exts if e not in existing
             )
+
+
+def _merge_slug_extensions(axis_reg: AxisSymbolRegistry, slug: str) -> None:
+    """Merge slug-registry overrides into the registry as defaults."""
+    _merge_extension_map(axis_reg, get_extensions_for_slug(slug))
+
+
+def _merge_derived_extensions(axis_reg: AxisSymbolRegistry, asr_model) -> None:
+    """Merge architecture-derived extensions into the registry."""
+    _merge_extension_map(axis_reg, derive_extensions(asr_model))
+
+
+def _resolve_effective_slug(cfg: NemoTractConfig, asr_model) -> str:
+    """Pick the slug used for extension lookup.
+
+    When the model was loaded from a local ``.nemo`` file, ``model_slug``
+    is still the ``"*"`` default; try to recover the pretrained slug by
+    matching the loaded model's encoder architecture against the
+    committed fingerprint map.  Falls back to ``model_slug`` unchanged
+    so unknown finetunes resolve to an empty extension set (today's
+    behavior for unknown slugs).
+    """
+    slug = cfg.model.model_slug
+    if cfg.model.model_path is None or slug not in ("", "*", None):
+        return slug
+    resolved = resolve_slug_from_asr_model(asr_model)
+    if resolved is None:
+        return slug
+    LOGGER.info(
+        "local .nemo encoder fingerprint matched pretrained slug %s",
+        resolved,
+    )
+    return resolved
 
 
 def _build_axis_registry(
@@ -177,18 +216,21 @@ def _build_axis_registry(
         only_subnets=cfg.subnet.only_subnets,
     )
     raw_sigs = provider.discover_signatures(asr_model, Stage.RAW)
+    effective_slug = _resolve_effective_slug(cfg, asr_model)
     if cfg.inspect.shape_config is None:
         default_axis_reg = dump_registry_from_signatures(raw_sigs)
         default_axis_reg = tie_batch_symbols_in_registry(default_axis_reg)
         auto_populate_output_collapse_dims(default_axis_reg)
-        _merge_slug_extensions(default_axis_reg, cfg.model.model_slug)
+        _merge_slug_extensions(default_axis_reg, effective_slug)
+        _merge_derived_extensions(default_axis_reg, asr_model)
         return default_axis_reg
     axis_reg = load_axis_symbol_registry(cfg.inspect.shape_config)
     validate_registry_against_signatures(raw_sigs, axis_reg)
     # Auto-populate output collapse for subnets with batch collapse when
     # the user config doesn't explicitly declare outputs.collapse_dims
     auto_populate_output_collapse_dims(axis_reg)
-    _merge_slug_extensions(axis_reg, cfg.model.model_slug)
+    _merge_slug_extensions(axis_reg, effective_slug)
+    _merge_derived_extensions(axis_reg, asr_model)
     return axis_reg
 
 

--- a/packages/nemo-asr/torch_to_nnef_nemo/derived_constraints.py
+++ b/packages/nemo-asr/torch_to_nnef_nemo/derived_constraints.py
@@ -1,0 +1,97 @@
+"""Architecture-derived tract extensions for NeMo ASR encoders.
+
+Instead of hand-maintaining per-slug ``tract_assert ...`` strings in
+``slug_extensions.py``, derive them from the encoder's architecture
+config.  The same derivation applies unchanged to any finetune of a
+known pretrained, since finetuning does not alter ``pos_emb_max_len``,
+``subsampling``, ``subsampling_factor`` or ``self_attention_model``.
+
+Design: the slug registry in ``slug_extensions.py`` remains as an
+overrides/quirks path for constraints we can't (yet) derive principled.
+At merge time we apply both; deduplication keeps the union.
+"""
+
+from __future__ import annotations
+
+import logging
+import typing as T
+
+LOGGER = logging.getLogger(__name__)
+
+# Attention variants whose positional encoding table is sized by
+# ``pos_emb_max_len``.  For ``rel_pos_local_attn`` the PE table is
+# actually sized by the local window (``left + right + 1``) rather than
+# by the sequence length -- so in principle the bound does not apply.
+# We keep it in the bounded set for parity with the committed registry
+# (see NEMOTRON_0_6B in slug_extensions.SLUG_EXTENSIONS); revisit if
+# empirical tract runs show the bound is too tight for streaming.
+_REL_POS_ATTENTIONS = frozenset({"rel_pos", "rel_pos_local_attn", "abs_pos"})
+
+# Conv-based subsampling flavors whose preimage follows the same
+# ``(enc_max - 1) * factor + 1`` recurrence (kernel=3 or compatible,
+# stride=2, symmetric padding, non-causal).  ``stacking`` and friends
+# use different math and are not included.
+_CONV_SUBSAMPLINGS = frozenset(
+    {"dw_striding", "striding", "vggnet", "striding_conv1d"}
+)
+
+
+def _encoder_frame_bound(encoder_cfg: T.Any) -> T.Optional[int]:
+    """Max encoder-internal frame count imposed by the positional table.
+
+    NeMo's ``RelPositionalEncoding`` builds a PE table of size
+    ``pos_emb_max_len`` and extends it at runtime if the sequence is
+    longer -- but a dynamic extension is not representable as a static
+    NNEF graph, so tract requires ``encoder_frames <= pos_emb_max_len``.
+    Returns ``None`` if the attention variant is not in the bounded set.
+    """
+    sa = str(encoder_cfg.self_attention_model)
+    if sa not in _REL_POS_ATTENTIONS:
+        return None
+    return int(encoder_cfg.pos_emb_max_len)
+
+
+def _subsampling_preimage(
+    encoder_max: int,
+    subsampling: str,
+    subsampling_factor: int,
+) -> T.Optional[int]:
+    """Max pre-subsampling mel frames given encoder-frame upper bound.
+
+    Uses the naive ``(enc_max - 1) * factor + 1`` inversion, which is
+    up to ``factor - 1`` frames tighter than NeMo's ``calc_length``
+    true preimage.  Matches the committed hardcodes and is strictly
+    safe (never exceeds the true max).  Returns ``None`` for
+    subsamplings we have not validated.
+    """
+    if subsampling not in _CONV_SUBSAMPLINGS:
+        return None
+    return (encoder_max - 1) * subsampling_factor + 1
+
+
+def derive_encoder_time_bound(encoder_cfg: T.Any) -> T.Optional[int]:
+    """Compute the mel-frame upper bound for this encoder, or ``None``.
+
+    ``None`` when either the attention variant or the subsampling
+    flavor is not in the supported set -- in that case the caller
+    should fall back to the slug override registry.
+    """
+    enc_max = _encoder_frame_bound(encoder_cfg)
+    if enc_max is None:
+        return None
+    return _subsampling_preimage(
+        enc_max,
+        str(encoder_cfg.subsampling),
+        int(encoder_cfg.subsampling_factor),
+    )
+
+
+def derive_extensions(asr_model: T.Any) -> T.Dict[str, T.List[str]]:
+    """Per-subnet tract extensions derived from a loaded ``ASRModel``.
+
+    Empty dict when the encoder architecture has no derivable bounds.
+    """
+    bound = derive_encoder_time_bound(asr_model.cfg.encoder)
+    if bound is None:
+        return {}
+    return {"encoder": [f"tract_assert AUDIO_SIGNAL__TIME<={bound}"]}

--- a/packages/nemo-asr/torch_to_nnef_nemo/derived_constraints.py
+++ b/packages/nemo-asr/torch_to_nnef_nemo/derived_constraints.py
@@ -89,9 +89,13 @@ def derive_encoder_time_bound(encoder_cfg: T.Any) -> T.Optional[int]:
 def derive_extensions(asr_model: T.Any) -> T.Dict[str, T.List[str]]:
     """Per-subnet tract extensions derived from a loaded ``ASRModel``.
 
-    Empty dict when the encoder architecture has no derivable bounds.
+    Empty dict when the model has no ``encoder`` section or the encoder
+    architecture has no derivable bounds.
     """
-    bound = derive_encoder_time_bound(asr_model.cfg.encoder)
+    cfg = getattr(asr_model, "cfg", None)
+    if cfg is None or not hasattr(cfg, "encoder"):
+        return {}
+    bound = derive_encoder_time_bound(cfg.encoder)
     if bound is None:
         return {}
     return {"encoder": [f"tract_assert AUDIO_SIGNAL__TIME<={bound}"]}

--- a/packages/nemo-asr/torch_to_nnef_nemo/slug_extensions.py
+++ b/packages/nemo-asr/torch_to_nnef_nemo/slug_extensions.py
@@ -12,14 +12,31 @@ Structure::
             "<subnet>": ["<extension-string>", ...],
         },
     }
+
+For local ``.nemo`` files (finetunes), the HuggingFace slug is not stored
+inside the archive.  A parallel ``slug_fingerprints.json`` file maps each
+known slug to an ``EncoderFingerprint`` derived from its pretrained
+``model_config.yaml``.  Finetuning does not alter the architecture fields
+in the fingerprint, so a finetune of a known pretrained will match the
+same fingerprint and inherit its extensions.
+
+Maintainer flow: add a slug to ``SLUG_EXTENSIONS`` then run
+``python -m torch_to_nnef_nemo.tools.refresh_slug_fingerprints`` to
+regenerate the JSON from ``ASRModel.from_pretrained``.
 """
 
+import json
+import logging
 import typing as T
+from dataclasses import dataclass, fields
+from pathlib import Path
 
 from torch_to_nnef_nemo.model_loader import (
     NEMOTRON_0_6B,
     PARAKEET_V3_SLUG,
 )
+
+LOGGER = logging.getLogger(__name__)
 
 # -- registry ----------------------------------------------------------------
 # Extend this mapping as new models are validated for pulsified export.
@@ -44,3 +61,166 @@ def get_extensions_for_slug(
     Returns an empty dict when the slug has no registered extensions.
     """
     return SLUG_EXTENSIONS.get(slug, {})
+
+
+# -- fingerprints ------------------------------------------------------------
+# Auto-filled by ``tools/refresh_slug_fingerprints.py``.  Do not edit by hand.
+
+FINGERPRINTS_PATH = Path(__file__).with_name("slug_fingerprints.json")
+
+
+@dataclass(frozen=True)
+class EncoderFingerprint:
+    """Architecture-level identity of a NeMo ASR encoder.
+
+    Compared for exact equality during slug resolution.  Fields are
+    chosen to be stable across finetuning (training only touches
+    weights, not these config entries) while discriminative across the
+    pretrained slugs we track.
+    """
+
+    model_class: str
+    encoder_class: str
+    feat_in: int
+    d_model: int
+    n_layers: int
+    subsampling: str
+    subsampling_factor: int
+    conv_kernel_size: int
+    self_attention_model: str
+    att_context_size: T.Tuple[T.Tuple[int, int], ...]
+    num_tdt_durations: T.Optional[int]
+
+    @classmethod
+    def from_dict(cls, d: T.Mapping[str, T.Any]) -> "EncoderFingerprint":
+        return cls(
+            model_class=str(d["model_class"]),
+            encoder_class=str(d["encoder_class"]),
+            feat_in=int(d["feat_in"]),
+            d_model=int(d["d_model"]),
+            n_layers=int(d["n_layers"]),
+            subsampling=str(d["subsampling"]),
+            subsampling_factor=int(d["subsampling_factor"]),
+            conv_kernel_size=int(d["conv_kernel_size"]),
+            self_attention_model=str(d["self_attention_model"]),
+            att_context_size=_normalize_att_context_size(d["att_context_size"]),
+            num_tdt_durations=(
+                int(d["num_tdt_durations"])
+                if d.get("num_tdt_durations") is not None
+                else None
+            ),
+        )
+
+    def to_dict(self) -> T.Dict[str, T.Any]:
+        return {
+            "model_class": self.model_class,
+            "encoder_class": self.encoder_class,
+            "feat_in": self.feat_in,
+            "d_model": self.d_model,
+            "n_layers": self.n_layers,
+            "subsampling": self.subsampling,
+            "subsampling_factor": self.subsampling_factor,
+            "conv_kernel_size": self.conv_kernel_size,
+            "self_attention_model": self.self_attention_model,
+            "att_context_size": [list(p) for p in self.att_context_size],
+            "num_tdt_durations": self.num_tdt_durations,
+        }
+
+
+def _normalize_att_context_size(
+    value: T.Any,
+) -> T.Tuple[T.Tuple[int, int], ...]:
+    """Coerce a yaml ``att_context_size`` into a tuple-of-pairs.
+
+    NeMo encodes this field two ways: as a flat ``[left, right]`` pair
+    for offline models, or as a list of pairs for multi-context
+    streaming models.  We normalize both to the same shape so the
+    fingerprint dataclass has a single type.
+    """
+    seq = list(value)
+    if not seq:
+        return ()
+    # Flat pair ``[left, right]`` (offline) vs list of pairs (streaming).
+    # OmegaConf's ``ListConfig`` is not a ``list``, so detect the leaf
+    # shape by checking whether the first element is an integer.
+    if isinstance(seq[0], int):
+        return ((int(seq[0]), int(seq[1])),)
+    return tuple((int(p[0]), int(p[1])) for p in seq)
+
+
+def fingerprint_from_model_cfg(
+    model_cfg: T.Any,
+    model_class: str,
+    encoder_class: str,
+) -> EncoderFingerprint:
+    """Build a fingerprint from an OmegaConf ``asr_model.cfg``.
+
+    ``model_class`` and ``encoder_class`` are passed in separately
+    because we read them from the runtime class rather than from the
+    cfg's ``_target_`` strings -- ``target`` is stripped from
+    ``asr_model.cfg`` after instantiation, and we want the same values
+    whether we ran through ``from_pretrained`` or ``restore_from``.
+    """
+    enc = model_cfg.encoder
+    md = (
+        model_cfg.get("model_defaults", None)
+        if hasattr(model_cfg, "get")
+        else None
+    )
+    num_tdt: T.Optional[int] = None
+    if md is not None:
+        raw = md.get("num_tdt_durations", None) if hasattr(md, "get") else None
+        if raw is not None:
+            num_tdt = int(raw)
+    return EncoderFingerprint(
+        model_class=model_class,
+        encoder_class=encoder_class,
+        feat_in=int(enc.feat_in),
+        d_model=int(enc.d_model),
+        n_layers=int(enc.n_layers),
+        subsampling=str(enc.subsampling),
+        subsampling_factor=int(enc.subsampling_factor),
+        conv_kernel_size=int(enc.conv_kernel_size),
+        self_attention_model=str(enc.self_attention_model),
+        att_context_size=_normalize_att_context_size(enc.att_context_size),
+        num_tdt_durations=num_tdt,
+    )
+
+
+def fingerprint_from_asr_model(asr_model: T.Any) -> EncoderFingerprint:
+    """Build a fingerprint from a loaded NeMo ``ASRModel``."""
+    return fingerprint_from_model_cfg(
+        asr_model.cfg,
+        model_class=type(asr_model).__name__,
+        encoder_class=type(asr_model.encoder).__name__,
+    )
+
+
+def load_slug_fingerprints() -> T.Dict[str, EncoderFingerprint]:
+    """Load the committed slug -> fingerprint map.
+
+    Returns an empty dict when the JSON is missing (fresh clone that
+    hasn't run the refresh script yet).
+    """
+    if not FINGERPRINTS_PATH.exists():
+        return {}
+    raw = json.loads(FINGERPRINTS_PATH.read_text())
+    return {slug: EncoderFingerprint.from_dict(v) for slug, v in raw.items()}
+
+
+def resolve_slug_from_asr_model(asr_model: T.Any) -> T.Optional[str]:
+    """Reverse-lookup: arch fingerprint -> known pretrained slug.
+
+    Returns ``None`` if no known slug matches.  Logs the computed
+    fingerprint at DEBUG level so maintainers can paste it into a
+    regen when adding a new slug.
+    """
+    fp = fingerprint_from_asr_model(asr_model)
+    for slug, known in load_slug_fingerprints().items():
+        if known == fp:
+            return slug
+    LOGGER.debug(
+        "no slug fingerprint matched; computed=%s",
+        {f.name: getattr(fp, f.name) for f in fields(fp)},
+    )
+    return None

--- a/packages/nemo-asr/torch_to_nnef_nemo/slug_extensions.py
+++ b/packages/nemo-asr/torch_to_nnef_nemo/slug_extensions.py
@@ -187,12 +187,25 @@ def fingerprint_from_model_cfg(
     )
 
 
-def fingerprint_from_asr_model(asr_model: T.Any) -> EncoderFingerprint:
-    """Build a fingerprint from a loaded NeMo ``ASRModel``."""
+def fingerprint_from_asr_model(
+    asr_model: T.Any,
+) -> T.Optional[EncoderFingerprint]:
+    """Build a fingerprint from a loaded NeMo ``ASRModel``.
+
+    Returns ``None`` when the model has no ``encoder`` submodule or its
+    cfg lacks an ``encoder`` section -- the fingerprint targets Conformer
+    encoder architectures specifically.
+    """
+    encoder = getattr(asr_model, "encoder", None)
+    if encoder is None:
+        return None
+    cfg = asr_model.cfg
+    if not hasattr(cfg, "encoder"):
+        return None
     return fingerprint_from_model_cfg(
-        asr_model.cfg,
+        cfg,
         model_class=type(asr_model).__name__,
-        encoder_class=type(asr_model.encoder).__name__,
+        encoder_class=type(encoder).__name__,
     )
 
 
@@ -216,6 +229,8 @@ def resolve_slug_from_asr_model(asr_model: T.Any) -> T.Optional[str]:
     regen when adding a new slug.
     """
     fp = fingerprint_from_asr_model(asr_model)
+    if fp is None:
+        return None
     for slug, known in load_slug_fingerprints().items():
         if known == fp:
             return slug

--- a/packages/nemo-asr/torch_to_nnef_nemo/slug_fingerprints.json
+++ b/packages/nemo-asr/torch_to_nnef_nemo/slug_fingerprints.json
@@ -1,0 +1,50 @@
+{
+  "nvidia/nemotron-speech-streaming-en-0.6b": {
+    "att_context_size": [
+      [
+        70,
+        13
+      ],
+      [
+        70,
+        6
+      ],
+      [
+        70,
+        1
+      ],
+      [
+        70,
+        0
+      ]
+    ],
+    "conv_kernel_size": 9,
+    "d_model": 1024,
+    "encoder_class": "ConformerEncoder",
+    "feat_in": 128,
+    "model_class": "EncDecRNNTBPEModel",
+    "n_layers": 24,
+    "num_tdt_durations": null,
+    "self_attention_model": "rel_pos",
+    "subsampling": "dw_striding",
+    "subsampling_factor": 8
+  },
+  "nvidia/parakeet-tdt-0.6b-v3": {
+    "att_context_size": [
+      [
+        -1,
+        -1
+      ]
+    ],
+    "conv_kernel_size": 9,
+    "d_model": 1024,
+    "encoder_class": "ConformerEncoder",
+    "feat_in": 128,
+    "model_class": "EncDecRNNTBPEModel",
+    "n_layers": 24,
+    "num_tdt_durations": 5,
+    "self_attention_model": "rel_pos",
+    "subsampling": "dw_striding",
+    "subsampling_factor": 8
+  }
+}

--- a/packages/nemo-asr/torch_to_nnef_nemo/tools/refresh_slug_fingerprints.py
+++ b/packages/nemo-asr/torch_to_nnef_nemo/tools/refresh_slug_fingerprints.py
@@ -1,0 +1,50 @@
+"""Regenerate ``slug_fingerprints.json`` from the slugs in SLUG_EXTENSIONS.
+
+Run this after adding a new slug to ``SLUG_EXTENSIONS`` (in
+``slug_extensions.py``) so that local ``.nemo`` finetunes of that slug
+can be auto-resolved by architecture fingerprint.
+
+Each slug is loaded via ``ASRModel.from_pretrained`` (downloading from
+HuggingFace on first use; subsequent runs reuse the cached ``.nemo``)
+and introspected to produce a fingerprint.  The JSON file is then
+rewritten in place.
+
+Usage::
+
+    python -m torch_to_nnef_nemo.tools.refresh_slug_fingerprints
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import sys
+
+from torch_to_nnef_nemo.model_loader import load_asr_model_from_nemo_slug
+from torch_to_nnef_nemo.slug_extensions import (
+    FINGERPRINTS_PATH,
+    SLUG_EXTENSIONS,
+    fingerprint_from_asr_model,
+)
+
+LOGGER = logging.getLogger(__name__)
+
+
+def main() -> int:
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
+    out: dict = {}
+    for slug in sorted(SLUG_EXTENSIONS):
+        LOGGER.info("loading %s", slug)
+        asr_model = load_asr_model_from_nemo_slug(slug)
+        fp = fingerprint_from_asr_model(asr_model)
+        LOGGER.info("  -> %s", fp)
+        out[slug] = fp.to_dict()
+    FINGERPRINTS_PATH.write_text(
+        json.dumps(out, indent=2, sort_keys=True) + "\n"
+    )
+    LOGGER.info("wrote %s", FINGERPRINTS_PATH)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Features

- Architecture fingerprint resolver: local `.nemo` finetunes auto-match their pretrained slug via encoder config (no more extensions silently skipped for finetunes).
- Principled tract extension deriver: `tract_assert AUDIO_SIGNAL__TIME<=N` is now computed from `pos_emb_max_len` and the subsampling flavor instead of hardcoded per slug. Matches the existing `39993` for parakeet-tdt-0.6b-v3 and nemotron-speech-streaming-en-0.6b.
- `SLUG_EXTENSIONS` registry kept as an override/quirks path; both sources merge with dedup.
- Committed `slug_fingerprints.json` covers both currently-supported slugs, regenerable via `python -m torch_to_nnef_nemo.tools.refresh_slug_fingerprints`.
- 13 new tests: fingerprint roundtrip, resolver coverage, parity with hardcoded bounds, parametric scaling, unknown-arch fallbacks.

## Test plan

- [x] `pytest packages/nemo-asr/tests/test_extensions.py` green (20/20 today)
- [x] Export a finetuned parakeet-v3 `.nemo` via `t2n_export_nemo -p <file>` and confirm the encoder graph contains the derived `tract_assert AUDIO_SIGNAL__TIME<=39993`
- [x] Export via `--model-slug` (HF path) remains unchanged