### PR TITLE
fix(op): use NNEF `not` for bool `bitwise_not`, keep `tract_core_bitnot` for int

### DIFF
--- a/tests/test_primitive.py
+++ b/tests/test_primitive.py
@@ -235,6 +235,12 @@ test_suite.add(
     UnaryPrimitive(torch.bitwise_not),
     inference_conditions=skip_khronos_interpreter,
 )
+# Integer variant exercises the tract_core_bitnot branch (bit-level inversion).
+test_suite.add(
+    torch.tensor([0, 1, -1, 127], dtype=torch.int8),
+    UnaryPrimitive(torch.bitwise_not),
+    inference_conditions=skip_khronos_interpreter,
+)
 
 for op in [
     (lambda x, y: x & y),  # and

--- a/torch_to_nnef/op/aten/math.py
+++ b/torch_to_nnef/op/aten/math.py
@@ -621,8 +621,19 @@ def bitwise_and(node, op_helper, inference_target, **kwargs):
 
 @OP_REGISTRY.register(["bitwise_not", "bitwise_not_cpu"])
 def bitwise_not(node, op_helper, inference_target, **kwargs):
-    """Map PyTorch: 'aten:bitwise_not', 'aten:bitwise_not_cpu' to NNEF."""
+    """Map PyTorch: 'aten:bitwise_not', 'aten:bitwise_not_cpu' to NNEF.
+
+    On bool inputs, PyTorch's ``~`` is semantically a logical not, so we emit
+    the standard NNEF ``not`` op (keeps the graph portable and self-documenting,
+    rather than relying on tract's bitnot happening to do the right thing on
+    bool). For integer inputs, emit ``tract_core_bitnot`` for true bitwise
+    inversion.
+    """
     assert len(node.outputs) == 1
+    input_node = node.inputs[0]
+    if getattr(input_node, "dtype", None) == torch.bool:
+        op_helper.unary_output_op_without_attr(nnef_op_type="not", node=node)
+        return []
     if not isinstance(inference_target, TractNNEF):
         raise T2NErrorNotImplemented(inference_target)
     op_helper.unary_output_op_without_attr(


### PR DESCRIPTION
PyTorch's `~mask` on a bool tensor traces as `aten::bitwise_not`, which t2n was
unconditionally mapping to `tract_core_bitnot`. On bool, tract's `bitnot`
happens to do the right thing (Rust's `!bool` is logical not), so no numerical
bug — but the resulting NNEF graph reads as a bitwise inversion on a logical
mask, which:

- is surprising to readers (spotted during nemotron review: the
  `maskBitwiseNot0 = tract_core_bitnot(attMask)` line on a bool mask),
- ties the graph to tract (standard NNEF has `not` for booleans).

This change routes bool inputs to the standard NNEF `not` op (already used for
`aten::logical_not`) and keeps `tract_core_bitnot` for integer inputs where it
really does bit-level inversion. Test suite gets an int8 case next to the
existing bool case to exercise both branches.