### PR TITLE
fix(op): cast statically-folded mul result to declared output dtype

### DIFF
--- a/torch_to_nnef/op/aten/math.py
+++ b/torch_to_nnef/op/aten/math.py
@@ -240,7 +240,15 @@ def mul(node, op_helper, torch_graph, **kwargs):
     other_node = node.inputs[1]
 
     if input_node.data is not None and other_node.data is not None:
-        node.outputs[0].set_data(input_node.data * other_node.data)
+        # When one operand is a float scalar (e.g. 1/sqrt(d) attention scaling)
+        # and the other an int64 shape value, torch promotes to float, but the
+        # traced output dtype may still be int64 -- set_data's dtype validation
+        # would then fail. Cast to the declared dtype for tensor results;
+        # Python scalars (int * int -> int) are passed through as-is.
+        result = input_node.data * other_node.data
+        if isinstance(result, torch.Tensor):
+            result = result.to(node.outputs[0].dtype)
+        node.outputs[0].set_data(result)
         return
     if remap_if_neutral_op(
         torch_graph, node, input_node, other_node


### PR DESCRIPTION
Found while exploring SD 1.5 VAE export: static constant folding of
\`aten::mul\` could crash with \`dtype mismatch torch.float32 != torch.int64\`
on nodes like an attention scaling \`1/sqrt(d)\` multiplied against an int64
shape value. The traced output node kept the int64 dtype while the actual
product is float32, and \`set_data\`'s dtype validation rejected it.

Mirror the pattern already used by \`div\`: cast the tensor result to the
declared output dtype before setting it. Python scalars pass through
unchanged (\`int * int -> int\` has no \`.to()\`).

Full \`tests/test_primitive.py\` suite (621 cases) still green.