### PR TITLE
Make LLM export flow more modular

### DIFF
--- a/packages/llm/tests/test_llama.py
+++ b/packages/llm/tests/test_llama.py
@@ -3,8 +3,6 @@ from functools import partial
 
 import pytest
 import torch
-from transformers import AutoModelForCausalLM, AutoTokenizer
-
 from tests.utils import (  # noqa: E402
     TRACT_INFERENCES_TO_TESTS_APPROX,
     TestSuiteInferenceExactnessBuilder,
@@ -13,8 +11,10 @@ from tests.utils import (  # noqa: E402
     set_seed,
     transformers_tract_export_test_condition,
 )
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
 from torch_to_nnef.utils import torch_version
-from torch_to_nnef_llm.config import LlamaSlugs
+from torch_to_nnef_llm.config import HFConfigHelper, LlamaSlugs
 from torch_to_nnef_llm.models.base import BaseCausal
 
 set_seed(int(os.environ.get("SEED", 25)))
@@ -34,7 +34,12 @@ if torch_version() > "1.13.0":
     DEFAULT_MODEL_SLUG = os.environ.get("LLAMA_SLUG", LlamaSlugs.DUMMY.value)
     tokenizer = AutoTokenizer.from_pretrained(DEFAULT_MODEL_SLUG)
     causal_llama = AutoModelForCausalLM.from_pretrained(DEFAULT_MODEL_SLUG)
-    striped_model = BaseCausal(causal_llama)
+    model_infos = HFConfigHelper(causal_llama.config)
+    striped_model = BaseCausal(
+        causal_llama,
+        handler=model_infos.handler,
+        with_dyn_cache=model_infos.handler.with_dyn_cache,
+    )
     inputs = tokenizer("Hello, I am happy", return_tensors="pt")
 
     S = 10

--- a/packages/llm/tests/test_llama.py
+++ b/packages/llm/tests/test_llama.py
@@ -3,6 +3,8 @@ from functools import partial
 
 import pytest
 import torch
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
 from tests.utils import (  # noqa: E402
     TRACT_INFERENCES_TO_TESTS_APPROX,
     TestSuiteInferenceExactnessBuilder,
@@ -11,13 +13,9 @@ from tests.utils import (  # noqa: E402
     set_seed,
     transformers_tract_export_test_condition,
 )
-from transformers import AutoModelForCausalLM, AutoTokenizer
-
 from torch_to_nnef.utils import torch_version
 from torch_to_nnef_llm.config import LlamaSlugs
-from torch_to_nnef_llm.models.base import (
-    BaseCausalWithDynCacheAndTriu,
-)
+from torch_to_nnef_llm.models.base import BaseCausal
 
 set_seed(int(os.environ.get("SEED", 25)))
 
@@ -36,7 +34,7 @@ if torch_version() > "1.13.0":
     DEFAULT_MODEL_SLUG = os.environ.get("LLAMA_SLUG", LlamaSlugs.DUMMY.value)
     tokenizer = AutoTokenizer.from_pretrained(DEFAULT_MODEL_SLUG)
     causal_llama = AutoModelForCausalLM.from_pretrained(DEFAULT_MODEL_SLUG)
-    striped_model = BaseCausalWithDynCacheAndTriu(causal_llama)
+    striped_model = BaseCausal(causal_llama)
     inputs = tokenizer("Hello, I am happy", return_tensors="pt")
 
     S = 10

--- a/packages/llm/torch_to_nnef_llm/config.py
+++ b/packages/llm/torch_to_nnef_llm/config.py
@@ -161,16 +161,14 @@ class HFConfigHelper:
         self.conf = conf
         handler_class = handlers.get_handler(conf.model_type)
         self.handler = handler_class()
-        self.wrapper_class = self.handler.get_wrapper_class()
         if conf.model_type == "openelm":
             self.max_position_embeddings = conf.max_context_length
         else:
             self.max_position_embeddings = conf.max_position_embeddings
 
         LOGGER.info(
-            "detected arch:'%s' using wrapper '%s' from handler '%s'",
+            "detected arch:'%s' using handler '%s'",
             conf.model_type,
-            self.wrapper_class,
             handler_class.__name__,
         )
 

--- a/packages/llm/torch_to_nnef_llm/config.py
+++ b/packages/llm/torch_to_nnef_llm/config.py
@@ -2,16 +2,12 @@
 import logging
 import typing as T
 from enum import Enum
-from functools import partial
 
 import torch
 from transformers import AutoConfig, AutoTokenizer
 
 from torch_to_nnef.exceptions import T2NErrorNotImplemented
-from torch_to_nnef_llm.models.base import (
-    BaseCausal,
-    BaseCausalWithDynCacheAndTriu,
-)
+from torch_to_nnef_llm.models import handlers
 
 LOGGER = logging.getLogger(__name__)
 
@@ -163,21 +159,19 @@ class HFConfigHelper:
 
     def __init__(self, conf):
         self.conf = conf
+        handler_class = handlers.get_hander(conf.model_type)
+        self.handler = handler_class()
+        self.wrapper_class = self.handler.get_wrapper_class()
         if conf.model_type == "openelm":
             self.max_position_embeddings = conf.max_context_length
         else:
             self.max_position_embeddings = conf.max_position_embeddings
 
-        if conf.model_type in ["phi"]:
-            self.wrapper_class = BaseCausalWithDynCacheAndTriu
-        elif conf.model_type in ["openelm"]:
-            self.wrapper_class = partial(BaseCausal, with_dyn_cache=False)
-        else:
-            self.wrapper_class = BaseCausal
         LOGGER.info(
-            "detected arch:'%s' using wrapper '%s'",
+            "detected arch:'%s' using wrapper '%s' from handler '%s'",
             conf.model_type,
             self.wrapper_class,
+            handler_class.__name__,
         )
 
     def get_head_dim(self):

--- a/packages/llm/torch_to_nnef_llm/config.py
+++ b/packages/llm/torch_to_nnef_llm/config.py
@@ -159,7 +159,7 @@ class HFConfigHelper:
 
     def __init__(self, conf):
         self.conf = conf
-        handler_class = handlers.get_hander(conf.model_type)
+        handler_class = handlers.get_handler(conf.model_type)
         self.handler = handler_class()
         self.wrapper_class = self.handler.get_wrapper_class()
         if conf.model_type == "openelm":

--- a/packages/llm/torch_to_nnef_llm/exporter.py
+++ b/packages/llm/torch_to_nnef_llm/exporter.py
@@ -47,6 +47,7 @@ from torch_to_nnef_llm.config import (
 )
 from torch_to_nnef_llm.loader import load_model, load_tokenizer
 from torch_to_nnef_llm.models.base import (
+    BaseCausal,
     dyn_cache_to_legacy,
     use_dtype_dyn_cache,
 )
@@ -204,9 +205,10 @@ class LLMExporter:
 
         self.model_infos = HFConfigHelper(self.hf_model_causal.config)
 
-        self.wrapped_model = self.model_infos.wrapper_class(
+        self.wrapped_model = BaseCausal(
             self.hf_model_causal,
             handler=self.model_infos.handler,
+            with_dyn_cache=self.model_infos.handler.with_dyn_cache,
             num_logits_to_keep=num_logits_to_keep
         )
         force_module_dtype = (

--- a/packages/llm/torch_to_nnef_llm/exporter.py
+++ b/packages/llm/torch_to_nnef_llm/exporter.py
@@ -194,7 +194,9 @@ class LLMExporter:
         self.model_infos = HFConfigHelper(self.hf_model_causal.config)
 
         self.wrapped_model = self.model_infos.wrapper_class(
-            self.hf_model_causal, num_logits_to_keep=num_logits_to_keep
+            self.hf_model_causal,
+            handler=self.model_infos.handler,
+            num_logits_to_keep=num_logits_to_keep
         )
         force_module_dtype = (
             DtypeStr(force_module_dtype) if force_module_dtype else None

--- a/packages/llm/torch_to_nnef_llm/exporter.py
+++ b/packages/llm/torch_to_nnef_llm/exporter.py
@@ -430,7 +430,7 @@ class LLMExporter:
                 err_check(kv_name, ref, cand)
             LOGGER.info(
                 "In PyTorch wrapped_model:%s provide same results as %s",
-                self.model_infos.wrapper_class,
+                self.wrapped_model.__class__,
                 self.hf_model_causal.__class__,
             )
 

--- a/packages/llm/torch_to_nnef_llm/exporter.py
+++ b/packages/llm/torch_to_nnef_llm/exporter.py
@@ -263,6 +263,85 @@ class LLMExporter:
     def model_n_params(self) -> int:
         return sum(_.numel() for _ in self.hf_model_causal.parameters())
 
+    def _build_model_input_spec(
+        self,
+        n_input_tokens: int = 1,
+        n_past_input_tokens: int = 2,
+        real_kv_cache: T.Optional[T.List[torch.Tensor]] = None,
+    ):
+        return self.model_infos.handler.build_input_spec(
+            tokenizer=self.tokenizer,
+            config_helper=self.model_infos,
+            inputs_dtype=self.inputs_dtype,
+            sample_text=EN_SAMPLE_TEXT,
+            n_input_tokens=n_input_tokens,
+            n_past_input_tokens=n_past_input_tokens,
+            real_kv_cache=real_kv_cache,
+        )
+
+    def _prepare_hf_model_inputs(
+        self,
+        inputs: T.Tuple[torch.Tensor, ...],
+    ) -> T.Dict[str, T.Any]:
+        return self.model_infos.handler.prepare_inputs_for_model(
+            inputs=inputs,
+            wrapper=self.wrapped_model,
+        )
+
+    def _export_layout_dirs(
+        self,
+        export_dirpath: Path,
+        export_dir_struct: ExportDirStruct,
+    ) -> T.Tuple[Path, Path]:
+        if export_dir_struct == ExportDirStruct.DEEP:
+            model_dir = export_dirpath / "model"
+            tok_dir = export_dirpath / "tokenizer"
+            model_dir.mkdir(parents=True, exist_ok=True)
+            tok_dir.mkdir(parents=True, exist_ok=True)
+            return model_dir, tok_dir
+        if export_dir_struct == ExportDirStruct.FLAT:
+            export_dirpath.mkdir(parents=True, exist_ok=True)
+            return export_dirpath, export_dirpath
+        raise T2NErrorNotImplemented()
+
+    def _dump_modes_json(
+        self,
+        export_dirpath: Path,
+        test_dir: Path,
+        sample_generation_total_size: int,
+    ) -> None:
+        if sample_generation_total_size <= 0:
+            LOGGER.info("'inference mode' evaluation skipped")
+            return
+
+        LOGGER.info(
+            "'inference mode' evaluation started with "
+            "sample_generation_total_size=%d",
+            sample_generation_total_size,
+        )
+        pairs = self.dump_all_io_npz_kind(
+            test_dir, size=sample_generation_total_size
+        )
+        modes = []
+        for in_p, _ in pairs:
+            base = in_p.stem
+            for suff in ("_inputs", "_outputs", "_io"):
+                if base.endswith(suff):
+                    base = base[: -len(suff)]
+                    break
+            modes.append(base)
+        with (export_dirpath / "modes.json").open("w", encoding="utf8") as fh:
+            json.dump({"pytorch_supported_modes": modes}, fh)
+        LOGGER.info("'inference mode' evaluation data generated")
+
+    def _normalize_dump_kwargs(self, kwargs: T.Dict[str, T.Any]) -> T.Dict[str, T.Any]:
+        dump_kwargs = dict(kwargs)
+        if isinstance(dump_kwargs.get("tract_check_io_tolerance"), str):
+            dump_kwargs["tract_check_io_tolerance"] = TractCheckTolerance(
+                dump_kwargs["tract_check_io_tolerance"]
+            )
+        return dump_kwargs
+
     @staticmethod
     @require_extra_decorator(extra=T2NExtra.LLM_TRACT, module="huggingface_hub")
     def load(
@@ -301,10 +380,7 @@ class LLMExporter:
             _,
         ) = self.generate_inputs_io_names_and_dynaxes()
         wrapped_outs = self.wrapped_model(*inputs)
-        model_inputs = self.model_infos.handler.prepare_inputs_for_model(
-            inputs=inputs,
-            wrapper=self.wrapped_model,
-        )
+        model_inputs = self._prepare_hf_model_inputs(inputs)
         outs = self.hf_model_causal(
             return_dict=True,
             **model_inputs,
@@ -359,11 +435,7 @@ class LLMExporter:
         n_past_input_tokens: int = 2,
         real_kv_cache: T.Optional[T.List[torch.Tensor]] = None,
     ):
-        input_spec = self.model_infos.handler.build_input_spec(
-            tokenizer=self.tokenizer,
-            config_helper=self.model_infos,
-            inputs_dtype=self.inputs_dtype,
-            sample_text=EN_SAMPLE_TEXT,
+        input_spec = self._build_model_input_spec(
             n_input_tokens=n_input_tokens,
             n_past_input_tokens=n_past_input_tokens,
             real_kv_cache=real_kv_cache,
@@ -601,42 +673,16 @@ class LLMExporter:
             test_dir = export_dirpath / "tests"
             test_dir.mkdir(parents=True)
 
-            if check_inference_modes and sample_generation_total_size > 0:
-                LOGGER.info(
-                    "'inference mode' evaluation started with "
-                    "sample_generation_total_size=%d",
-                    sample_generation_total_size,
+            if check_inference_modes:
+                self._dump_modes_json(
+                    export_dirpath, test_dir, sample_generation_total_size
                 )
-                pairs = self.dump_all_io_npz_kind(
-                    test_dir, size=sample_generation_total_size
-                )
-                modes = []
-                for in_p, _ in pairs:
-                    base = in_p.stem
-                    for suff in ("_inputs", "_outputs", "_io"):
-                        if base.endswith(suff):
-                            base = base[: -len(suff)]
-                            break
-                    modes.append(base)
-                with (export_dirpath / "modes.json").open(
-                    "w", encoding="utf8"
-                ) as fh:
-                    json.dump({"pytorch_supported_modes": modes}, fh)
-                LOGGER.info("'inference mode' evaluation data generated")
             else:
                 LOGGER.info("'inference mode' evaluation skipped")
 
-            if export_dir_struct == ExportDirStruct.DEEP:
-                model_dir = export_dirpath / "model"
-                model_dir.mkdir(parents=True, exist_ok=True)
-                tok_dir = export_dirpath / "tokenizer"
-                tok_dir.mkdir(parents=True, exist_ok=True)
-            elif export_dir_struct == ExportDirStruct.FLAT:
-                model_dir = export_dirpath
-                tok_dir = export_dirpath
-                tok_dir.mkdir(parents=True, exist_ok=True)
-            else:
-                raise T2NErrorNotImplemented()
+            model_dir, tok_dir = self._export_layout_dirs(
+                export_dirpath, export_dir_struct
+            )
 
             if dump_with_tokenizer_and_conf:
                 # export_dir_struct
@@ -939,12 +985,9 @@ def dump_llm(
         num_logits_to_keep=num_logits_to_keep,
         device_map=device_map,
     )
-    if isinstance(kwargs.get("tract_check_io_tolerance"), str):
-        kwargs["tract_check_io_tolerance"] = TractCheckTolerance(
-            kwargs["tract_check_io_tolerance"]
-        )
-    exporter.dump(**kwargs)
-    export_path = kwargs.get("export_dirpath")
+    dump_kwargs = exporter._normalize_dump_kwargs(kwargs)
+    exporter.dump(**dump_kwargs)
+    export_path = dump_kwargs.get("export_dirpath")
     return (
         Path(export_path) if export_path else None,
         exporter,

--- a/packages/llm/torch_to_nnef_llm/exporter.py
+++ b/packages/llm/torch_to_nnef_llm/exporter.py
@@ -296,7 +296,7 @@ class LLMExporter:
         self,
         inputs: T.Tuple[torch.Tensor, ...],
     ) -> T.Dict[str, T.Any]:
-        return self.model_infos.handler.prepare_inputs_for_model(
+        return self.model_infos.handler.build_forward_inputs(
             inputs=inputs,
             wrapper=self.wrapped_model,
         )

--- a/packages/llm/torch_to_nnef_llm/exporter.py
+++ b/packages/llm/torch_to_nnef_llm/exporter.py
@@ -106,9 +106,7 @@ def is_forced_half_precision_model(
     )
 
 
-def _normalize_dump_kwargs(
-    kwargs: T.Dict[str, T.Any]
-) -> T.Dict[str, T.Any]:
+def _normalize_dump_kwargs(kwargs: T.Dict[str, T.Any]) -> T.Dict[str, T.Any]:
     dump_kwargs = dict(kwargs)
     if isinstance(dump_kwargs.get("tract_check_io_tolerance"), str):
         dump_kwargs["tract_check_io_tolerance"] = TractCheckTolerance(
@@ -209,7 +207,7 @@ class LLMExporter:
             self.hf_model_causal,
             handler=self.model_infos.handler,
             with_dyn_cache=self.model_infos.handler.with_dyn_cache,
-            num_logits_to_keep=num_logits_to_keep
+            num_logits_to_keep=num_logits_to_keep,
         )
         force_module_dtype = (
             DtypeStr(force_module_dtype) if force_module_dtype else None
@@ -942,6 +940,7 @@ class LLMExporter:
             export_dir_struct=export_dir_struct,
             debug_bundle_path=debug_bundle_path,
         )
+
 
 class StateLessF32LayerNorm(nn.Module):
     def forward(  # pylint: disable=too-many-positional-arguments

--- a/packages/llm/torch_to_nnef_llm/exporter.py
+++ b/packages/llm/torch_to_nnef_llm/exporter.py
@@ -47,8 +47,6 @@ from torch_to_nnef_llm.config import (
 )
 from torch_to_nnef_llm.loader import load_model, load_tokenizer
 from torch_to_nnef_llm.models.base import (
-    build_past_kv_dyn_cache,
-    build_past_kv_list,
     dyn_cache_to_legacy,
     use_dtype_dyn_cache,
 )
@@ -301,15 +299,13 @@ class LLMExporter:
             _,
         ) = self.generate_inputs_io_names_and_dynaxes()
         wrapped_outs = self.wrapped_model(*inputs)
-        if self.wrapped_model.with_dyn_cache:
-            past_key_values = build_past_kv_dyn_cache(inputs[1:])
-        else:
-            past_key_values = build_past_kv_list(inputs[1:])
+        model_inputs = self.model_infos.handler.prepare_inputs_for_model(
+            inputs=inputs,
+            wrapper=self.wrapped_model,
+        )
         outs = self.hf_model_causal(
-            input_ids=inputs[0],
-            past_key_values=past_key_values,
-            use_cache=True,
             return_dict=True,
+            **model_inputs,
             **self.wrapped_model.forward_kwargs,
         )
 
@@ -361,24 +357,19 @@ class LLMExporter:
         n_past_input_tokens: int = 2,
         real_kv_cache: T.Optional[T.List[torch.Tensor]] = None,
     ):
-        test_input = self.tokenizer(EN_SAMPLE_TEXT, return_tensors="pt")
-        assert test_input.input_ids.shape[1] >= n_input_tokens
-        (
-            in_cache_names,
-            out_cache_names,
-            past_key_values,
-            dynamic_axes,
-        ) = self.model_infos.build_kv_cache_infos(
+        input_spec = self.model_infos.handler.build_input_spec(
+            tokenizer=self.tokenizer,
+            config_helper=self.model_infos,
+            inputs_dtype=self.inputs_dtype,
+            sample_text=EN_SAMPLE_TEXT,
+            n_input_tokens=n_input_tokens,
             n_past_input_tokens=n_past_input_tokens,
-            force_inputs_dtype=self.inputs_dtype,
             real_kv_cache=real_kv_cache,
         )
-
-        input_names = ["input_ids"] + in_cache_names
-        output_names = ["outputs"] + out_cache_names
-        inputs = tuple(
-            [test_input.input_ids[:, :n_input_tokens]] + past_key_values
-        )
+        inputs = input_spec.inputs
+        input_names = input_spec.input_names
+        output_names = input_spec.output_names
+        dynamic_axes = input_spec.dynamic_axes
         assert len(inputs) == len(input_names) == len(output_names), (
             f"{len(inputs)} == {len(input_names)} == {len(output_names)}"
         )

--- a/packages/llm/torch_to_nnef_llm/exporter.py
+++ b/packages/llm/torch_to_nnef_llm/exporter.py
@@ -1,7 +1,5 @@
 import json
 import logging
-import os
-import tempfile
 import typing as T
 from collections import Counter
 from pathlib import Path
@@ -17,7 +15,6 @@ from torch_to_nnef.compress import (
 from torch_to_nnef.exceptions import (
     T2NErrorConsistency,
     T2NErrorMisuse,
-    T2NErrorNotFoundFile,
     T2NErrorNotImplemented,
     T2NErrorRuntime,
 )
@@ -28,17 +25,11 @@ from torch_to_nnef.inference_target.tract import (
     TractNNEF,
     build_io,
 )
-from torch_to_nnef.tensor.offload import (
-    AUTO_DEVICE_MAP_KEY,
-    ON_DISK_DEVICE_MAP_KEY,
-    t2n_load_checkpoint_and_dispatch,
-)
 from torch_to_nnef.torch_graph.ir_naming import VariableNamingScheme
 from torch_to_nnef.utils import (
     INJECTED,
     SemanticVersion,
     T2NExtra,
-    init_empty_weights,
     require_extra_decorator,
     torch_version,
 )
@@ -50,12 +41,11 @@ from torch_to_nnef_llm._optional_types import (
     TransformersModule,
 )
 from torch_to_nnef_llm.config import (
-    CUSTOM_CONFIGS,
-    REMAP_MODEL_TYPE_TO_TOKENIZER_SLUG,
     DtypeStr,
     ExportDirStruct,
     HFConfigHelper,
 )
+from torch_to_nnef_llm.loader import load_model, load_tokenizer
 from torch_to_nnef_llm.models.base import (
     build_past_kv_dyn_cache,
     build_past_kv_list,
@@ -908,266 +898,6 @@ class LLMExporter:
             export_dir_struct=export_dir_struct,
             debug_bundle_path=debug_bundle_path,
         )
-
-
-def find_subdir_with_filename_in(dirpath: Path, filename: str) -> Path:
-    """Find a subdir with filename in it."""
-    found_dirs = {p.parent for p in dirpath.glob(f"**/{filename}")}
-    if not 0 < len(found_dirs) < 2:
-        raise T2NErrorNotFoundFile(
-            f"Found {len(found_dirs)} dirs for with '{filename}' file. "
-            f"found_dirs={found_dirs}. "
-            + (
-                "Unable to decide which one should selected..."
-                if len(found_dirs) > 1
-                else "Is it a valid model directory ?"
-            )
-        )
-    return found_dirs.pop()
-
-
-@require_extra_decorator(extra=T2NExtra.LLM_TRACT, module="transformers")
-def load_tokenizer(
-    config,
-    hf_model_slug: T.Optional[str] = None,
-    local_dir: T.Optional[Path] = None,
-    *,
-    transformers: InjectedTransformersModule = INJECTED,
-):
-    os.environ["TOKENIZERS_PARALLELISM"] = "false"
-    tokenizer_slug = REMAP_MODEL_TYPE_TO_TOKENIZER_SLUG.get(
-        config.model_type, hf_model_slug
-    )
-    if tokenizer_slug is None:
-        assert local_dir is not None
-    if local_dir is not None:
-        local_dir = find_subdir_with_filename_in(local_dir, "tokenizer.json")
-    return transformers.AutoTokenizer.from_pretrained(
-        local_dir or tokenizer_slug, trust_remote_code=True
-    )
-
-
-@require_extra_decorator(extra=T2NExtra.LLM_TRACT, module="transformers")
-@require_extra_decorator(extra=T2NExtra.PEFT, module="peft")
-def _try_load_peft(
-    dir_path,
-    kwargs,
-    exp,
-    *,
-    transformers: InjectedTransformersModule = INJECTED,
-    peft: InjectedPeftModule = INJECTED,
-):
-    # likely an embedding issue with added tokens
-    with (dir_path / "adapter_config.json").open("r", encoding="utf8") as fh:
-        dic = json.load(fh)
-    hf_model_causal = transformers.AutoModelForCausalLM.from_pretrained(
-        dic["base_model_name_or_path"], **kwargs
-    )
-    msg = "Error(s) in loading state_dict for"
-    if exp.args[0].startswith(msg) and "size mismatch for" in exp.args[0]:
-        new_tokenizer_len = int(exp.args[0].split("[")[1].split(",")[0])
-        hf_model_causal.resize_token_embeddings(new_tokenizer_len)
-        print("new_tokenizer_len:", new_tokenizer_len)
-
-    hf_model_causal = peft.PeftModel.from_pretrained(hf_model_causal, dir_path)
-    LOGGER.info("loaded a PEFT model with resized token embeddings")
-    return hf_model_causal
-
-
-def assert_model_safetensors_exists(dir_path):
-    assert (
-        "model" in p.name and p.name.endswith(".safetensors")
-        for p in dir_path.iterdir()
-    ), dir_path
-
-
-@require_extra_decorator(extra=T2NExtra.LLM_TRACT, module="transformers")
-def load_peft_model(
-    local_dir,
-    kwargs,
-    *,
-    transformers: InjectedTransformersModule = INJECTED,
-):
-    """Load PEFT adapted models.
-
-    Try to avoid direct reference to tokenizer object/config
-    to limit dependencies of the function
-
-    While also trying to be robust to 'wrong' key/values
-
-    """
-    dir_path = find_subdir_with_filename_in(local_dir, "adapter_config.json")
-    assert dir_path.is_dir(), dir_path
-    assert_model_safetensors_exists(dir_path)
-
-    while True:
-        try:
-            hf_model_causal = transformers.AutoModelForCausalLM.from_pretrained(
-                dir_path, **kwargs
-            )
-        except ValueError as exp:
-            msg = "Should have a `model_type` key in its config.json,"
-            if msg in exp.args[0]:
-                return _try_load_peft(dir_path, kwargs, exp)
-            raise T2NErrorMisuse(msg) from exp
-        except RuntimeError as exp:
-            msg = "Error(s) in loading state_dict for"
-            if (
-                exp.args[0].startswith(msg)
-                and "size mismatch for" in exp.args[0]
-            ):
-                return _try_load_peft(dir_path, kwargs, exp)
-            raise T2NErrorMisuse(msg) from exp
-        except TypeError as exp:
-            msg = "__init__() got an unexpected keyword argument '"
-            if exp.args[0].startswith(msg):
-                with (dir_path / "adapter_config.json").open(
-                    "r", encoding="utf8"
-                ) as fh:
-                    dic = json.load(fh)
-                key = exp.args[0].split(msg)[-1][:-1]
-                del dic[key]
-                with (dir_path / "adapter_config.json").open(
-                    "w", encoding="utf8"
-                ) as fh:
-                    json.dump(dic, fh, indent=2)
-                continue
-            raise T2NErrorMisuse(msg) from exp
-        return hf_model_causal
-
-
-@require_extra_decorator(extra=T2NExtra.LLM_TRACT, module="huggingface_hub")
-@require_extra_decorator(extra=T2NExtra.LLM_TRACT, module="transformers")
-def _from_pretrained(
-    slug_or_dir: T.Union[str, Path],
-    *,
-    huggingface_hub: InjectedHuggingFaceHubModule = INJECTED,
-    transformers: InjectedTransformersModule = INJECTED,
-    **kwargs,
-):
-    if "device_map" in kwargs and kwargs["device_map"] is not None:
-        device_map = kwargs.pop("device_map")
-        if Path(slug_or_dir).exists():
-            weights_location = Path(slug_or_dir)
-        else:
-            hf_repo_files = huggingface_hub.list_repo_files(slug_or_dir)
-            weights_location = Path(
-                huggingface_hub.hf_hub_download(
-                    slug_or_dir, hf_repo_files[-1]
-                )  # assume at least 1 file is in targeted repo
-            ).parent
-
-        # use 'local' init_empty_weights to init weights devices
-        # to avoid 'accelerate' deps if un-needed
-        with init_empty_weights():
-            model = transformers.AutoModelForCausalLM.from_pretrained(
-                slug_or_dir, **kwargs
-            )
-
-        if device_map == "auto":
-            # pylint: disable-next=import-outside-toplevel
-            import accelerate
-
-            device_map = accelerate.infer_auto_device_map(model)
-            LOGGER.info("device map selected: %s", device_map)
-        if any(
-            _ in device_map
-            for _ in [
-                AUTO_DEVICE_MAP_KEY,
-                ON_DISK_DEVICE_MAP_KEY,
-            ]
-        ):
-            t2n_load_checkpoint_and_dispatch(
-                model,
-                weights_location,
-                device_map=device_map,
-                offload_dir=Path(tempfile.mkdtemp(suffix="offload_t2n")),
-            )
-        elif device_map:
-            # pylint: disable-next=import-outside-toplevel
-            import accelerate
-
-            model = accelerate.load_checkpoint_and_dispatch(
-                model,
-                weights_location,
-                device_map=device_map,
-                offload_folder=tempfile.mkdtemp(suffix="offload_accelerate"),
-            )
-        return model
-    return transformers.AutoModelForCausalLM.from_pretrained(
-        slug_or_dir, **kwargs
-    )
-
-
-@require_extra_decorator(extra=T2NExtra.LLM_TRACT, module="transformers")
-def load_model(
-    hf_model_slug: T.Optional[str] = None,
-    local_dir: T.Optional[Path] = None,
-    force_module_dtype: T.Optional[DtypeStr] = None,
-    merge_peft: T.Optional[bool] = None,
-    device_map: TYPE_OPTIONAL_DEVICE_MAP = None,
-    *,
-    transformers: InjectedTransformersModule = INJECTED,
-):
-    kwargs: T.Dict[str, T.Any] = {"trust_remote_code": True}
-    if force_module_dtype is not None:
-        key = "torch_dtype"
-        if SemanticVersion.from_str(transformers.__version__) >= "4.57.0":
-            key = "dtype"
-        kwargs[key] = DtypeStr(force_module_dtype).torch_dtype
-
-    if device_map is not None:
-        kwargs["device_map"] = device_map
-
-    custom_config = CUSTOM_CONFIGS.get(hf_model_slug or "")
-    if custom_config is not None:
-        hf_model_causal = transformers.AutoModelForCausalLM.from_config(
-            custom_config, **kwargs
-        )
-        LOGGER.info(
-            "load custom config: '%s', un-initialized weights", hf_model_slug
-        )
-    elif local_dir:
-        try:
-            dir_path = find_subdir_with_filename_in(local_dir, "config.json")
-            assert dir_path.is_dir(), dir_path
-            assert_model_safetensors_exists(dir_path)
-            hf_model_causal = _from_pretrained(dir_path, **kwargs)
-            LOGGER.info(
-                "load '%s' from local directory: %s",
-                hf_model_causal.config.model_type,
-                dir_path,
-            )
-        except (T2NErrorNotFoundFile, OSError):
-            hf_model_causal = load_peft_model(local_dir, kwargs)
-
-    elif hf_model_slug is not None:
-        hf_model_causal = _from_pretrained(hf_model_slug, **kwargs)
-        LOGGER.info(
-            "load default trained model from huggingface: '%s'", hf_model_slug
-        )
-    else:
-        raise T2NErrorNotImplemented(
-            "No local nor Huggingface slug, nor custom conf ?"
-        )
-    if merge_peft:
-        # pylint: disable-next=import-outside-toplevel
-        from peft import PeftModel
-
-        if isinstance(hf_model_causal, PeftModel):
-            hf_model_causal = hf_model_causal.merge_and_unload()
-        else:
-            LOGGER.warning(
-                "no 'Peft' model found: %s (so no merge applied)",
-                hf_model_causal.__class__,
-            )
-
-    if force_module_dtype is not None:
-        force_dtype = DtypeStr(force_module_dtype).torch_dtype
-        hf_model_causal = hf_model_causal.to(force_dtype)
-        LOGGER.info("force casted model internals to: '%s'", force_module_dtype)
-    return hf_model_causal
-
 
 class StateLessF32LayerNorm(nn.Module):
     def forward(  # pylint: disable=too-many-positional-arguments

--- a/packages/llm/torch_to_nnef_llm/exporter.py
+++ b/packages/llm/torch_to_nnef_llm/exporter.py
@@ -105,6 +105,17 @@ def is_forced_half_precision_model(
     )
 
 
+def _normalize_dump_kwargs(
+    kwargs: T.Dict[str, T.Any]
+) -> T.Dict[str, T.Any]:
+    dump_kwargs = dict(kwargs)
+    if isinstance(dump_kwargs.get("tract_check_io_tolerance"), str):
+        dump_kwargs["tract_check_io_tolerance"] = TractCheckTolerance(
+            dump_kwargs["tract_check_io_tolerance"]
+        )
+    return dump_kwargs
+
+
 def _load_exporter_from(
     hf_model_slug: T.Optional[str] = None,
     local_dir: T.Optional[Path] = None,
@@ -333,14 +344,6 @@ class LLMExporter:
         with (export_dirpath / "modes.json").open("w", encoding="utf8") as fh:
             json.dump({"pytorch_supported_modes": modes}, fh)
         LOGGER.info("'inference mode' evaluation data generated")
-
-    def _normalize_dump_kwargs(self, kwargs: T.Dict[str, T.Any]) -> T.Dict[str, T.Any]:
-        dump_kwargs = dict(kwargs)
-        if isinstance(dump_kwargs.get("tract_check_io_tolerance"), str):
-            dump_kwargs["tract_check_io_tolerance"] = TractCheckTolerance(
-                dump_kwargs["tract_check_io_tolerance"]
-            )
-        return dump_kwargs
 
     @staticmethod
     @require_extra_decorator(extra=T2NExtra.LLM_TRACT, module="huggingface_hub")
@@ -985,7 +988,7 @@ def dump_llm(
         num_logits_to_keep=num_logits_to_keep,
         device_map=device_map,
     )
-    dump_kwargs = exporter._normalize_dump_kwargs(kwargs)
+    dump_kwargs = _normalize_dump_kwargs(kwargs)
     exporter.dump(**dump_kwargs)
     export_path = dump_kwargs.get("export_dirpath")
     return (

--- a/packages/llm/torch_to_nnef_llm/loader.py
+++ b/packages/llm/torch_to_nnef_llm/loader.py
@@ -1,0 +1,294 @@
+"""Loader helpers for Hugging Face LLM exports."""
+
+import json
+import logging
+import os
+import tempfile
+import typing as T
+from pathlib import Path
+
+import torch
+
+from torch_to_nnef.exceptions import (
+    T2NErrorMisuse,
+    T2NErrorNotFoundFile,
+    T2NErrorNotImplemented,
+)
+from torch_to_nnef.tensor.offload import (
+    AUTO_DEVICE_MAP_KEY,
+    ON_DISK_DEVICE_MAP_KEY,
+    t2n_load_checkpoint_and_dispatch,
+)
+from torch_to_nnef.utils import (
+    INJECTED,
+    SemanticVersion,
+    T2NExtra,
+    init_empty_weights,
+    require_extra_decorator,
+)
+from torch_to_nnef_llm._optional_types import (
+    InjectedHuggingFaceHubModule,
+    InjectedPeftModule,
+    InjectedTransformersModule,
+)
+from torch_to_nnef_llm.config import (
+    CUSTOM_CONFIGS,
+    REMAP_MODEL_TYPE_TO_TOKENIZER_SLUG,
+    DtypeStr,
+)
+
+LOGGER = logging.getLogger(__name__)
+
+TYPE_OPTIONAL_DEVICE_MAP = T.Optional[
+    T.Union[
+        str,
+        T.Dict[str, T.Union[int, str, torch.device]],
+        int,
+        torch.device,
+    ]
+]
+
+
+def find_subdir_with_filename_in(dirpath: Path, filename: str) -> Path:
+    """Find a subdir with filename in it."""
+    found_dirs = {p.parent for p in dirpath.glob(f"**/{filename}")}
+    if not 0 < len(found_dirs) < 2:
+        raise T2NErrorNotFoundFile(
+            f"Found {len(found_dirs)} dirs for with '{filename}' file. "
+            f"found_dirs={found_dirs}. "
+            + (
+                "Unable to decide which one should selected..."
+                if len(found_dirs) > 1
+                else "Is it a valid model directory ?"
+            )
+        )
+    return found_dirs.pop()
+
+
+@require_extra_decorator(extra=T2NExtra.LLM_TRACT, module="transformers")
+def load_tokenizer(
+    config,
+    hf_model_slug: T.Optional[str] = None,
+    local_dir: T.Optional[Path] = None,
+    *,
+    transformers: InjectedTransformersModule = INJECTED,
+):
+    os.environ["TOKENIZERS_PARALLELISM"] = "false"
+    tokenizer_slug = REMAP_MODEL_TYPE_TO_TOKENIZER_SLUG.get(
+        config.model_type, hf_model_slug
+    )
+    if tokenizer_slug is None:
+        assert local_dir is not None
+    if local_dir is not None:
+        local_dir = find_subdir_with_filename_in(local_dir, "tokenizer.json")
+    return transformers.AutoTokenizer.from_pretrained(
+        local_dir or tokenizer_slug, trust_remote_code=True
+    )
+
+
+@require_extra_decorator(extra=T2NExtra.LLM_TRACT, module="transformers")
+@require_extra_decorator(extra=T2NExtra.PEFT, module="peft")
+def _try_load_peft(
+    dir_path,
+    kwargs,
+    exp,
+    *,
+    transformers: InjectedTransformersModule = INJECTED,
+    peft: InjectedPeftModule = INJECTED,
+):
+    # likely an embedding issue with added tokens
+    with (dir_path / "adapter_config.json").open("r", encoding="utf8") as fh:
+        dic = json.load(fh)
+    hf_model_causal = transformers.AutoModelForCausalLM.from_pretrained(
+        dic["base_model_name_or_path"], **kwargs
+    )
+    msg = "Error(s) in loading state_dict for"
+    if exp.args[0].startswith(msg) and "size mismatch for" in exp.args[0]:
+        new_tokenizer_len = int(exp.args[0].split("[")[1].split(",")[0])
+        hf_model_causal.resize_token_embeddings(new_tokenizer_len)
+        print("new_tokenizer_len:", new_tokenizer_len)
+
+    hf_model_causal = peft.PeftModel.from_pretrained(hf_model_causal, dir_path)
+    LOGGER.info("loaded a PEFT model with resized token embeddings")
+    return hf_model_causal
+
+
+def assert_model_safetensors_exists(dir_path):
+    assert (
+        "model" in p.name and p.name.endswith(".safetensors")
+        for p in dir_path.iterdir()
+    ), dir_path
+
+
+@require_extra_decorator(extra=T2NExtra.LLM_TRACT, module="transformers")
+def load_peft_model(
+    local_dir,
+    kwargs,
+    *,
+    transformers: InjectedTransformersModule = INJECTED,
+):
+    """Load PEFT adapted models."""
+    dir_path = find_subdir_with_filename_in(local_dir, "adapter_config.json")
+    assert dir_path.is_dir(), dir_path
+    assert_model_safetensors_exists(dir_path)
+
+    while True:
+        try:
+            hf_model_causal = transformers.AutoModelForCausalLM.from_pretrained(
+                dir_path, **kwargs
+            )
+        except ValueError as exp:
+            msg = "Should have a `model_type` key in its config.json,"
+            if msg in exp.args[0]:
+                return _try_load_peft(dir_path, kwargs, exp)
+            raise T2NErrorMisuse(msg) from exp
+        except RuntimeError as exp:
+            msg = "Error(s) in loading state_dict for"
+            if (
+                exp.args[0].startswith(msg)
+                and "size mismatch for" in exp.args[0]
+            ):
+                return _try_load_peft(dir_path, kwargs, exp)
+            raise T2NErrorMisuse(msg) from exp
+        except TypeError as exp:
+            msg = "__init__() got an unexpected keyword argument '"
+            if exp.args[0].startswith(msg):
+                with (dir_path / "adapter_config.json").open(
+                    "r", encoding="utf8"
+                ) as fh:
+                    dic = json.load(fh)
+                key = exp.args[0].split(msg)[-1][:-1]
+                del dic[key]
+                with (dir_path / "adapter_config.json").open(
+                    "w", encoding="utf8"
+                ) as fh:
+                    json.dump(dic, fh, indent=2)
+                continue
+            raise T2NErrorMisuse(msg) from exp
+        return hf_model_causal
+
+
+@require_extra_decorator(extra=T2NExtra.LLM_TRACT, module="huggingface_hub")
+@require_extra_decorator(extra=T2NExtra.LLM_TRACT, module="transformers")
+def _from_pretrained(
+    slug_or_dir: T.Union[str, Path],
+    *,
+    huggingface_hub: InjectedHuggingFaceHubModule = INJECTED,
+    transformers: InjectedTransformersModule = INJECTED,
+    **kwargs,
+):
+    if "device_map" in kwargs and kwargs["device_map"] is not None:
+        device_map = kwargs.pop("device_map")
+        if Path(slug_or_dir).exists():
+            weights_location = Path(slug_or_dir)
+        else:
+            hf_repo_files = huggingface_hub.list_repo_files(slug_or_dir)
+            weights_location = Path(
+                huggingface_hub.hf_hub_download(
+                    slug_or_dir, hf_repo_files[-1]
+                )
+            ).parent
+
+        with init_empty_weights():
+            model = transformers.AutoModelForCausalLM.from_pretrained(
+                slug_or_dir, **kwargs
+            )
+
+        if device_map == "auto":
+            # pylint: disable-next=import-outside-toplevel
+            import accelerate
+
+            device_map = accelerate.infer_auto_device_map(model)
+            LOGGER.info("device map selected: %s", device_map)
+        if any(_ in device_map for _ in [AUTO_DEVICE_MAP_KEY, ON_DISK_DEVICE_MAP_KEY]):
+            t2n_load_checkpoint_and_dispatch(
+                model,
+                weights_location,
+                device_map=device_map,
+                offload_dir=Path(tempfile.mkdtemp(suffix="offload_t2n")),
+            )
+        elif device_map:
+            # pylint: disable-next=import-outside-toplevel
+            import accelerate
+
+            model = accelerate.load_checkpoint_and_dispatch(
+                model,
+                weights_location,
+                device_map=device_map,
+                offload_folder=tempfile.mkdtemp(suffix="offload_accelerate"),
+            )
+        return model
+    return transformers.AutoModelForCausalLM.from_pretrained(
+        slug_or_dir, **kwargs
+    )
+
+
+@require_extra_decorator(extra=T2NExtra.LLM_TRACT, module="transformers")
+def load_model(
+    hf_model_slug: T.Optional[str] = None,
+    local_dir: T.Optional[Path] = None,
+    force_module_dtype: T.Optional[DtypeStr] = None,
+    merge_peft: T.Optional[bool] = None,
+    device_map: TYPE_OPTIONAL_DEVICE_MAP = None,
+    *,
+    transformers: InjectedTransformersModule = INJECTED,
+):
+    """Load a model from a slug, local checkpoint, or custom config."""
+    kwargs: T.Dict[str, T.Any] = {"trust_remote_code": True}
+    if force_module_dtype is not None:
+        key = "torch_dtype"
+        if SemanticVersion.from_str(transformers.__version__) >= "4.57.0":
+            key = "dtype"
+        kwargs[key] = DtypeStr(force_module_dtype).torch_dtype
+
+    if device_map is not None:
+        kwargs["device_map"] = device_map
+
+    custom_config = CUSTOM_CONFIGS.get(hf_model_slug or "")
+    if custom_config is not None:
+        hf_model_causal = transformers.AutoModelForCausalLM.from_config(
+            custom_config, **kwargs
+        )
+        LOGGER.info(
+            "load custom config: '%s', un-initialized weights", hf_model_slug
+        )
+    elif local_dir:
+        try:
+            dir_path = find_subdir_with_filename_in(local_dir, "config.json")
+            assert dir_path.is_dir(), dir_path
+            assert_model_safetensors_exists(dir_path)
+            hf_model_causal = _from_pretrained(dir_path, **kwargs)
+            LOGGER.info(
+                "load '%s' from local directory: %s",
+                hf_model_causal.config.model_type,
+                dir_path,
+            )
+        except (T2NErrorNotFoundFile, OSError):
+            hf_model_causal = load_peft_model(local_dir, kwargs)
+    elif hf_model_slug is not None:
+        hf_model_causal = _from_pretrained(hf_model_slug, **kwargs)
+        LOGGER.info(
+            "load default trained model from huggingface: '%s'", hf_model_slug
+        )
+    else:
+        raise T2NErrorNotImplemented(
+            "No local nor Huggingface slug, nor custom conf ?"
+        )
+
+    if merge_peft:
+        # pylint: disable-next=import-outside-toplevel
+        from peft import PeftModel
+
+        if isinstance(hf_model_causal, PeftModel):
+            hf_model_causal = hf_model_causal.merge_and_unload()
+        else:
+            LOGGER.warning(
+                "no 'Peft' model found: %s (so no merge applied)",
+                hf_model_causal.__class__,
+            )
+
+    if force_module_dtype is not None:
+        force_dtype = DtypeStr(force_module_dtype).torch_dtype
+        hf_model_causal = hf_model_causal.to(force_dtype)
+        LOGGER.info("force casted model internals to: '%s'", force_module_dtype)
+    return hf_model_causal

--- a/packages/llm/torch_to_nnef_llm/loader.py
+++ b/packages/llm/torch_to_nnef_llm/loader.py
@@ -1,5 +1,3 @@
-"""Loader helpers for Hugging Face LLM exports."""
-
 import json
 import logging
 import os

--- a/packages/llm/torch_to_nnef_llm/loader.py
+++ b/packages/llm/torch_to_nnef_llm/loader.py
@@ -182,9 +182,7 @@ def _from_pretrained(
         else:
             hf_repo_files = huggingface_hub.list_repo_files(slug_or_dir)
             weights_location = Path(
-                huggingface_hub.hf_hub_download(
-                    slug_or_dir, hf_repo_files[-1]
-                )
+                huggingface_hub.hf_hub_download(slug_or_dir, hf_repo_files[-1])
             ).parent
 
         with init_empty_weights():
@@ -198,7 +196,10 @@ def _from_pretrained(
 
             device_map = accelerate.infer_auto_device_map(model)
             LOGGER.info("device map selected: %s", device_map)
-        if any(_ in device_map for _ in [AUTO_DEVICE_MAP_KEY, ON_DISK_DEVICE_MAP_KEY]):
+        if any(
+            _ in device_map
+            for _ in [AUTO_DEVICE_MAP_KEY, ON_DISK_DEVICE_MAP_KEY]
+        ):
             t2n_load_checkpoint_and_dispatch(
                 model,
                 weights_location,

--- a/packages/llm/torch_to_nnef_llm/models/base.py
+++ b/packages/llm/torch_to_nnef_llm/models/base.py
@@ -356,7 +356,7 @@ class BaseCausal(TorchToNNEFWrappedLLM):
     @use_dtype_dyn_cache
     def forward(self, input_ids: torch.Tensor, *args):
         inputs = (input_ids, *args)
-        model_inputs = self.handler.prepare_inputs_for_model(
+        model_inputs = self.handler.build_forward_inputs(
             inputs=inputs,
             wrapper=self,
         )
@@ -365,7 +365,7 @@ class BaseCausal(TorchToNNEFWrappedLLM):
             model_inputs=model_inputs,
             wrapper=self,
         )
-        outputs = self.handler.prepare_outputs_for_export(
+        outputs = self.handler.build_forward_outputs(
             model=self.model,
             model_outputs=model_outputs,
             model_inputs=model_inputs,

--- a/packages/llm/torch_to_nnef_llm/models/base.py
+++ b/packages/llm/torch_to_nnef_llm/models/base.py
@@ -397,13 +397,19 @@ class BaseCausal(TorchToNNEFWrappedLLM):
     def __init__(
         self,
         model,
-        handler: ArchitectureHandler,
+        handler: T.Optional[ArchitectureHandler] = None,
         with_dyn_cache: bool = True,
         num_logits_to_keep: int = 1,
         force_causal_mask: T.Optional[bool] = None,
     ):
         super().__init__()
         self.model = model
+        if handler is None:
+            from torch_to_nnef_llm.models.handlers.default import (
+                DefaultArchitectureHandler,
+            )
+
+            handler = DefaultArchitectureHandler()
         self.handler = handler
         self.with_dyn_cache = with_dyn_cache
         self.num_logits_to_keep = num_logits_to_keep

--- a/packages/llm/torch_to_nnef_llm/models/base.py
+++ b/packages/llm/torch_to_nnef_llm/models/base.py
@@ -17,7 +17,6 @@ from torch_to_nnef_llm._optional_types import (
     InjectedTransformersCacheUtilsModule,
     InjectedTransformersModule,
     TransformersCacheUtils,
-    TransformersModule,
 )
 from torch_to_nnef_llm.models.handlers.base import ArchitectureHandler
 
@@ -280,74 +279,6 @@ class TorchToNNEFWrappedLLM(torch.nn.Module):
         self.forward_kwargs = {}
 
 
-class BaseCausalWithDynCacheAndTriu(TorchToNNEFWrappedLLM):
-    """Assume common AutoModelForCausalLM arch.
-
-    with :
-    - .model
-    - .lm_head
-
-    """
-
-    with_dyn_cache: bool = True
-
-    def __init__(
-        self,
-        model: TransformersModule.AutoModelForCausalLM,
-        handler: T.Optional[ArchitectureHandler] = None,
-        num_logits_to_keep: int = 1,
-    ):
-        super().__init__()
-        self.model = model
-        if handler is None:
-            from torch_to_nnef_llm.models.handlers.phi import (
-                PhiArchitectureHandler,
-            )
-
-            handler = PhiArchitectureHandler()
-        self.handler = handler
-        self.num_logits_to_keep = num_logits_to_keep
-        update_forward_signature(self)
-
-    @property
-    def device(self):
-        return self.model.device
-
-    def tie_weights(self):
-        return self.model.tie_weights()
-
-    @use_dtype_dyn_cache
-    def forward(self, input_ids: torch.Tensor, *args):
-        """Forward of BaseCausalWithDynCacheAndTriu.
-
-        Same as calling without any smart caching mechanism
-        self.model.model+lm_head and softmax.
-
-        This export module is extremly ineficient because
-        no caching can be provided ...
-
-        """
-        inputs = (input_ids, *args)
-        model_inputs = self.handler.prepare_inputs_for_model(
-            inputs=inputs,
-            wrapper=self,
-        )
-        outputs = self.model.model(**model_inputs)
-        hidden_states = outputs[0]
-        logits = self.model.lm_head(
-            hidden_states[:, -self.num_logits_to_keep :, :]
-        )
-
-        # Extract cache {
-        kv_cache_flat_list = [
-            t
-            for kv in dyn_cache_to_legacy(model_inputs["past_key_values"])
-            for t in kv
-        ]
-        # }
-        return [logits] + kv_cache_flat_list
-
-
 def _slice_hidden_state_to_lasts(
     mod, inputs, outputs, num_logits_to_keep: int = 1
 ):
@@ -429,22 +360,18 @@ class BaseCausal(TorchToNNEFWrappedLLM):
             inputs=inputs,
             wrapper=self,
         )
-        out_dic = self.model(
-            **model_inputs,
-            **self.forward_kwargs,
+        model_outputs = self.handler.call_model(
+            model=self.model,
+            model_inputs=model_inputs,
+            wrapper=self,
         )
-
-        if self.with_dyn_cache:
-            kvs = [
-                t
-                for kv in dyn_cache_to_legacy(
-                    model_inputs["past_key_values"]
-                )
-                for t in kv
-            ]
-        else:
-            kvs = [k_or_v for kv in out_dic["past_key_values"] for k_or_v in kv]
-
-        assert len(args) == len(kvs), f"{len(args) * 2} == {len(kvs)}"
+        outputs = self.handler.prepare_outputs_for_export(
+            model=self.model,
+            model_outputs=model_outputs,
+            model_inputs=model_inputs,
+            num_logits_to_keep=self.num_logits_to_keep,
+        )
+        kvs = outputs[1:]
+        assert len(args) == len(kvs), f"{len(args)} == {len(kvs)}"
         # key values, (32 tensors) of shape (1, 3, S, 64)
-        return [out_dic["logits"]] + kvs
+        return outputs

--- a/packages/llm/torch_to_nnef_llm/models/base.py
+++ b/packages/llm/torch_to_nnef_llm/models/base.py
@@ -19,6 +19,7 @@ from torch_to_nnef_llm._optional_types import (
     TransformersCacheUtils,
     TransformersModule,
 )
+from torch_to_nnef_llm.models.handlers.base import ArchitectureHandler
 
 LOGGER = logging.getLogger(__name__)
 
@@ -294,6 +295,7 @@ class BaseCausalWithDynCacheAndTriu(TorchToNNEFWrappedLLM):
         self,
         model: TransformersModule.AutoModelForCausalLM,
         num_logits_to_keep: int = 1,
+        **_,
     ):
         super().__init__()
         self.model = model
@@ -395,12 +397,14 @@ class BaseCausal(TorchToNNEFWrappedLLM):
     def __init__(
         self,
         model,
+        handler: ArchitectureHandler,
         with_dyn_cache: bool = True,
         num_logits_to_keep: int = 1,
         force_causal_mask: T.Optional[bool] = None,
     ):
         super().__init__()
         self.model = model
+        self.handler = handler
         self.with_dyn_cache = with_dyn_cache
         self.num_logits_to_keep = num_logits_to_keep
         sign = inspect.signature(model.forward)
@@ -440,41 +444,20 @@ class BaseCausal(TorchToNNEFWrappedLLM):
 
     @use_dtype_dyn_cache
     def forward(self, input_ids: torch.Tensor, *args):
-        # input_ids: [1, S] with torch.int64
-        # past_key_values: Optional[List[torch.FloatTensor]] = None
-        # # type annotation in code WRONG
-        if self.with_dyn_cache:
-            past_key_values = build_past_kv_dyn_cache(args)
-        else:
-            past_key_values = build_past_kv_list(args)
-
-        if self.force_causal_mask:
-            attn_mask_dtype = torch.float32
-            seq_length = args[0].shape[0]
-            attention_mask = (
-                torch.triu(
-                    torch.full(
-                        [seq_length, seq_length],
-                        torch.finfo(attn_mask_dtype).min,
-                    ),
-                    diagonal=1,
-                )
-                .unsqueeze(0)
-                .unsqueeze(0)
-            ).to(attn_mask_dtype)
-        else:
-            attention_mask = None
-
+        inputs = (input_ids, *args)
+        model_inputs = self.handler.prepare_inputs_for_model(
+            inputs=inputs,
+            wrapper=self,
+        )
         out_dic = self.model(
-            input_ids,
-            past_key_values=past_key_values,
-            use_cache=True,
-            attention_mask=attention_mask,
+            **model_inputs,
             **self.forward_kwargs,
         )
 
         if self.with_dyn_cache:
-            kvs = [t for kv in dyn_cache_to_legacy(past_key_values) for t in kv]
+            kvs = [
+                t for kv in dyn_cache_to_legacy(model_inputs["past_key_values"]) for t in kv
+            ]
         else:
             kvs = [k_or_v for kv in out_dic["past_key_values"] for k_or_v in kv]
 

--- a/packages/llm/torch_to_nnef_llm/models/base.py
+++ b/packages/llm/torch_to_nnef_llm/models/base.py
@@ -294,11 +294,18 @@ class BaseCausalWithDynCacheAndTriu(TorchToNNEFWrappedLLM):
     def __init__(
         self,
         model: TransformersModule.AutoModelForCausalLM,
+        handler: T.Optional[ArchitectureHandler] = None,
         num_logits_to_keep: int = 1,
-        **_,
     ):
         super().__init__()
         self.model = model
+        if handler is None:
+            from torch_to_nnef_llm.models.handlers.phi import (
+                PhiArchitectureHandler,
+            )
+
+            handler = PhiArchitectureHandler()
+        self.handler = handler
         self.num_logits_to_keep = num_logits_to_keep
         update_forward_signature(self)
 
@@ -320,47 +327,12 @@ class BaseCausalWithDynCacheAndTriu(TorchToNNEFWrappedLLM):
         no caching can be provided ...
 
         """
-        _, seq_length = input_ids.shape[:2]
-
-        # BUILD cache {
-        cache = build_past_kv_dyn_cache(args)
-        # }
-        past_key_values_length = cache.get_seq_length()
-
-        # get pos ids {
-        cache_position = torch.arange(
-            past_key_values_length,
-            seq_length + past_key_values_length,
-            dtype=torch.long,
-            device=input_ids.device,
+        inputs = (input_ids, *args)
+        model_inputs = self.handler.prepare_inputs_for_model(
+            inputs=inputs,
+            wrapper=self,
         )
-        position_ids = cache_position.unsqueeze(0)
-        inputs_embeds = self.model.model.embed_tokens(input_ids)
-
-        attention_mask = (
-            torch.triu(
-                torch.full(
-                    [seq_length, seq_length],
-                    torch.finfo(inputs_embeds.dtype).min,
-                ),
-                diagonal=1,
-            )
-            .unsqueeze(0)
-            .unsqueeze(0)
-        ).to(inputs_embeds.dtype)
-        # }
-
-        hidden_states = inputs_embeds
-
-        outputs = self.model.model(
-            inputs_embeds=hidden_states,
-            attention_mask=attention_mask,
-            position_ids=position_ids,
-            past_key_values=cache,
-            output_attentions=False,
-            use_cache=True,
-            cache_position=cache_position,
-        )
+        outputs = self.model.model(**model_inputs)
         hidden_states = outputs[0]
         logits = self.model.lm_head(
             hidden_states[:, -self.num_logits_to_keep :, :]
@@ -368,7 +340,9 @@ class BaseCausalWithDynCacheAndTriu(TorchToNNEFWrappedLLM):
 
         # Extract cache {
         kv_cache_flat_list = [
-            t for kv in dyn_cache_to_legacy(cache) for t in kv
+            t
+            for kv in dyn_cache_to_legacy(model_inputs["past_key_values"])
+            for t in kv
         ]
         # }
         return [logits] + kv_cache_flat_list
@@ -462,7 +436,11 @@ class BaseCausal(TorchToNNEFWrappedLLM):
 
         if self.with_dyn_cache:
             kvs = [
-                t for kv in dyn_cache_to_legacy(model_inputs["past_key_values"]) for t in kv
+                t
+                for kv in dyn_cache_to_legacy(
+                    model_inputs["past_key_values"]
+                )
+                for t in kv
             ]
         else:
             kvs = [k_or_v for kv in out_dic["past_key_values"] for k_or_v in kv]

--- a/packages/llm/torch_to_nnef_llm/models/base.py
+++ b/packages/llm/torch_to_nnef_llm/models/base.py
@@ -302,19 +302,13 @@ class BaseCausal(TorchToNNEFWrappedLLM):
     def __init__(
         self,
         model,
-        handler: T.Optional[ArchitectureHandler] = None,
+        handler: ArchitectureHandler,
         with_dyn_cache: bool = True,
         num_logits_to_keep: int = 1,
         force_causal_mask: T.Optional[bool] = None,
     ):
         super().__init__()
         self.model = model
-        if handler is None:
-            from torch_to_nnef_llm.models.handlers.default import (
-                DefaultArchitectureHandler,
-            )
-
-            handler = DefaultArchitectureHandler()
         self.handler = handler
         self.with_dyn_cache = with_dyn_cache
         self.num_logits_to_keep = num_logits_to_keep

--- a/packages/llm/torch_to_nnef_llm/models/handlers/__init__.py
+++ b/packages/llm/torch_to_nnef_llm/models/handlers/__init__.py
@@ -1,0 +1,29 @@
+"""Architecture handler registry"""
+from typing import Dict, Type
+
+from .base import ArchitectureHandler
+from .default import DefaultArchitectureHandler
+from .openelm import OpenELMArchitectureHandler
+from .phi import PhiArchitectureHandler
+
+_HANDLER_REGISTRY: Dict[str, Type[ArchitectureHandler]] = {
+    arch_name: handler
+    for handler in (
+        DefaultArchitectureHandler,
+        OpenELMArchitectureHandler,
+        PhiArchitectureHandler,
+    )
+    for arch_name in handler.ARCH_NAMES
+}
+
+def get_handler(model_type: str) -> Type[ArchitectureHandler]:
+    """Return the registered handler for a model_type."""
+    return _HANDLER_REGISTRY.get(model_type, DefaultArchitectureHandler)
+
+__all__ = [
+    "ArchitectureHandler",
+    "DefaultArchitectureHandler",
+    "OpenELMArchitectureHandler",
+    "PhiArchitectureHandler",
+    "get_handler",
+]

--- a/packages/llm/torch_to_nnef_llm/models/handlers/__init__.py
+++ b/packages/llm/torch_to_nnef_llm/models/handlers/__init__.py
@@ -1,23 +1,42 @@
 from typing import Dict, Type
 
+from torch_to_nnef.exceptions import T2NErrorConsistency
+
 from .base import ArchitectureHandler
 from .default import DefaultArchitectureHandler
 from .openelm import OpenELMArchitectureHandler
 from .phi import PhiArchitectureHandler
 
-_HANDLER_REGISTRY: Dict[str, Type[ArchitectureHandler]] = {
-    arch_name: handler
-    for handler in (
-        DefaultArchitectureHandler,
-        OpenELMArchitectureHandler,
-        PhiArchitectureHandler,
-    )
-    for arch_name in handler.ARCH_NAMES
-}
+_HANDLER_REGISTRY: Dict[str, Type[ArchitectureHandler]] = {}
+
+
+def register_handler(
+    handler_cls: Type[ArchitectureHandler],
+) -> Type[ArchitectureHandler]:
+    """Register an architecture handler class for its declared names."""
+    for arch_name in handler_cls.ARCH_NAMES:
+        if arch_name in _HANDLER_REGISTRY:
+            raise T2NErrorConsistency(
+                f"duplicate handler for {arch_name!r}: "
+                f"{handler_cls.__name__} vs "
+                f"{_HANDLER_REGISTRY[arch_name].__name__}"
+            )
+        _HANDLER_REGISTRY[arch_name] = handler_cls
+    return handler_cls
+
+
+for cls in (
+    DefaultArchitectureHandler,
+    OpenELMArchitectureHandler,
+    PhiArchitectureHandler,
+):
+    register_handler(cls)
+
 
 def get_handler(model_type: str) -> Type[ArchitectureHandler]:
-    """Return the registered handler for a model_type"""
+    """Return the registered handler for a model type."""
     return _HANDLER_REGISTRY.get(model_type, DefaultArchitectureHandler)
+
 
 __all__ = [
     "ArchitectureHandler",
@@ -25,4 +44,5 @@ __all__ = [
     "OpenELMArchitectureHandler",
     "PhiArchitectureHandler",
     "get_handler",
+    "register_handler",
 ]

--- a/packages/llm/torch_to_nnef_llm/models/handlers/__init__.py
+++ b/packages/llm/torch_to_nnef_llm/models/handlers/__init__.py
@@ -1,4 +1,3 @@
-"""Architecture handler registry"""
 from typing import Dict, Type
 
 from .base import ArchitectureHandler
@@ -17,7 +16,7 @@ _HANDLER_REGISTRY: Dict[str, Type[ArchitectureHandler]] = {
 }
 
 def get_handler(model_type: str) -> Type[ArchitectureHandler]:
-    """Return the registered handler for a model_type."""
+    """Return the registered handler for a model_type"""
     return _HANDLER_REGISTRY.get(model_type, DefaultArchitectureHandler)
 
 __all__ = [

--- a/packages/llm/torch_to_nnef_llm/models/handlers/__init__.py
+++ b/packages/llm/torch_to_nnef_llm/models/handlers/__init__.py
@@ -1,42 +1,8 @@
-from typing import Dict, Type
-
-from torch_to_nnef.exceptions import T2NErrorConsistency
-
 from .base import ArchitectureHandler
 from .default import DefaultArchitectureHandler
 from .openelm import OpenELMArchitectureHandler
 from .phi import PhiArchitectureHandler
-
-_HANDLER_REGISTRY: Dict[str, Type[ArchitectureHandler]] = {}
-
-
-def register_handler(
-    handler_cls: Type[ArchitectureHandler],
-) -> Type[ArchitectureHandler]:
-    """Register an architecture handler class for its declared names."""
-    for arch_name in handler_cls.ARCH_NAMES:
-        if arch_name in _HANDLER_REGISTRY:
-            raise T2NErrorConsistency(
-                f"duplicate handler for {arch_name!r}: "
-                f"{handler_cls.__name__} vs "
-                f"{_HANDLER_REGISTRY[arch_name].__name__}"
-            )
-        _HANDLER_REGISTRY[arch_name] = handler_cls
-    return handler_cls
-
-
-for cls in (
-    DefaultArchitectureHandler,
-    OpenELMArchitectureHandler,
-    PhiArchitectureHandler,
-):
-    register_handler(cls)
-
-
-def get_handler(model_type: str) -> Type[ArchitectureHandler]:
-    """Return the registered handler for a model type."""
-    return _HANDLER_REGISTRY.get(model_type, DefaultArchitectureHandler)
-
+from .registry import get_handler, register_handler
 
 __all__ = [
     "ArchitectureHandler",

--- a/packages/llm/torch_to_nnef_llm/models/handlers/base.py
+++ b/packages/llm/torch_to_nnef_llm/models/handlers/base.py
@@ -1,5 +1,17 @@
+from dataclasses import dataclass
 import typing as T
 from abc import ABC, abstractmethod
+
+import torch
+
+@dataclass
+class InputSpec:
+    """Defines the exported input/output signature for one decoder graph"""
+
+    inputs: T.Tuple[torch.Tensor, ...]
+    input_names: T.List[str]
+    output_names: T.List[str]
+    dynamic_axes: T.Dict[str, T.Dict[int, str]]
 
 class ArchitectureHandler(ABC):
     """Base type for architecture-specific export behavior"""
@@ -10,3 +22,26 @@ class ArchitectureHandler(ABC):
     @abstractmethod
     def get_wrapper_class():
         """Return the wrapper class or factory for this architecture"""
+
+    @abstractmethod
+    def build_input_spec(
+        self,
+        *,
+        tokenizer,
+        config_helper,
+        inputs_dtype: torch.dtype,
+        sample_text: str,
+        n_input_tokens: int,
+        n_past_input_tokens: int,
+        real_kv_cache: T.Optional[T.List[torch.Tensor]] = None,
+    ) -> InputSpec:
+        """Build exported inputs plus names/dynamic axes for the decoder"""
+
+    @abstractmethod
+    def prepare_inputs_for_model(
+        self,
+        *,
+        inputs: T.Tuple[torch.Tensor, ...],
+        wrapper,
+    ) -> T.Dict[str, T.Any]:
+        """Convert exported inputs into kwargs expected by the HF model"""

--- a/packages/llm/torch_to_nnef_llm/models/handlers/base.py
+++ b/packages/llm/torch_to_nnef_llm/models/handlers/base.py
@@ -35,7 +35,7 @@ class ArchitectureHandler(ABC):
         """Build exported inputs plus names/dynamic axes for the decoder."""
 
     @abstractmethod
-    def prepare_inputs_for_model(
+    def build_forward_inputs(
         self,
         *,
         inputs: T.Tuple[torch.Tensor, ...],
@@ -56,7 +56,7 @@ class ArchitectureHandler(ABC):
             **wrapper.forward_kwargs,
         )
 
-    def prepare_outputs_for_export(
+    def build_forward_outputs(
         self,
         *,
         model,

--- a/packages/llm/torch_to_nnef_llm/models/handlers/base.py
+++ b/packages/llm/torch_to_nnef_llm/models/handlers/base.py
@@ -1,0 +1,12 @@
+import typing as T
+from abc import ABC, abstractmethod
+
+class ArchitectureHandler(ABC):
+    """Base type for architecture-specific export behavior"""
+
+    ARCH_NAMES: T.Tuple[str, ...] = ()
+
+    @staticmethod
+    @abstractmethod
+    def get_wrapper_class():
+        """Return the wrapper class or factory for this architecture"""

--- a/packages/llm/torch_to_nnef_llm/models/handlers/base.py
+++ b/packages/llm/torch_to_nnef_llm/models/handlers/base.py
@@ -18,11 +18,7 @@ class ArchitectureHandler(ABC):
     """Base type for architecture-specific export behavior."""
 
     ARCH_NAMES: T.Tuple[str, ...] = ()
-
-    @staticmethod
-    @abstractmethod
-    def get_wrapper_class():
-        """Return the wrapper class or factory for this architecture."""
+    with_dyn_cache: bool = True
 
     @abstractmethod
     def build_input_spec(
@@ -46,3 +42,40 @@ class ArchitectureHandler(ABC):
         wrapper,
     ) -> T.Dict[str, T.Any]:
         """Convert exported inputs into kwargs expected by the HF model."""
+
+    def call_model(
+        self,
+        *,
+        model,
+        model_inputs: T.Dict[str, T.Any],
+        wrapper,
+    ) -> T.Any:
+        """Run the underlying model with prepared inputs."""
+        return model(
+            **model_inputs,
+            **wrapper.forward_kwargs,
+        )
+
+    def prepare_outputs_for_export(
+        self,
+        *,
+        model,
+        model_outputs: T.Any,
+        model_inputs: T.Dict[str, T.Any],
+        num_logits_to_keep: int,
+    ) -> T.List[torch.Tensor]:
+        """Build exported outputs matching InputSpec.output_names."""
+        del model, num_logits_to_keep
+        if self.with_dyn_cache:
+            kvs = [
+                t
+                for kv in model_inputs["past_key_values"].to_legacy_cache()
+                for t in kv
+            ]
+        else:
+            kvs = [
+                k_or_v
+                for kv in model_outputs["past_key_values"]
+                for k_or_v in kv
+            ]
+        return [model_outputs["logits"]] + kvs

--- a/packages/llm/torch_to_nnef_llm/models/handlers/base.py
+++ b/packages/llm/torch_to_nnef_llm/models/handlers/base.py
@@ -14,6 +14,7 @@ class InputSpec:
     output_names: T.List[str]
     dynamic_axes: T.Dict[str, T.Dict[int, str]]
 
+
 class ArchitectureHandler(ABC):
     """Base type for architecture-specific export behavior."""
 
@@ -67,15 +68,12 @@ class ArchitectureHandler(ABC):
         """Build exported outputs matching InputSpec.output_names."""
         del model, num_logits_to_keep
         if self.with_dyn_cache:
-            from torch_to_nnef_llm.models.base import dyn_cache_to_legacy
-
-            kvs = [
-                t
-                for kv in dyn_cache_to_legacy(
-                    model_inputs["past_key_values"]
-                )
-                for t in kv
-            ]
+            past_key_values = model_inputs["past_key_values"]
+            if hasattr(past_key_values, "to_legacy_cache"):
+                pkv = past_key_values.to_legacy_cache()
+            else:
+                pkv = [(kv[0], kv[1]) for kv in past_key_values]
+            kvs = [t for kv in pkv for t in kv]
         else:
             kvs = [
                 k_or_v

--- a/packages/llm/torch_to_nnef_llm/models/handlers/base.py
+++ b/packages/llm/torch_to_nnef_llm/models/handlers/base.py
@@ -67,9 +67,13 @@ class ArchitectureHandler(ABC):
         """Build exported outputs matching InputSpec.output_names."""
         del model, num_logits_to_keep
         if self.with_dyn_cache:
+            from torch_to_nnef_llm.models.base import dyn_cache_to_legacy
+
             kvs = [
                 t
-                for kv in model_inputs["past_key_values"].to_legacy_cache()
+                for kv in dyn_cache_to_legacy(
+                    model_inputs["past_key_values"]
+                )
                 for t in kv
             ]
         else:

--- a/packages/llm/torch_to_nnef_llm/models/handlers/base.py
+++ b/packages/llm/torch_to_nnef_llm/models/handlers/base.py
@@ -1,12 +1,13 @@
-from dataclasses import dataclass
 import typing as T
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
 
 import torch
 
+
 @dataclass
 class InputSpec:
-    """Defines the exported input/output signature for one decoder graph"""
+    """Define the exported input/output signature for one decoder graph."""
 
     inputs: T.Tuple[torch.Tensor, ...]
     input_names: T.List[str]
@@ -14,14 +15,14 @@ class InputSpec:
     dynamic_axes: T.Dict[str, T.Dict[int, str]]
 
 class ArchitectureHandler(ABC):
-    """Base type for architecture-specific export behavior"""
+    """Base type for architecture-specific export behavior."""
 
     ARCH_NAMES: T.Tuple[str, ...] = ()
 
     @staticmethod
     @abstractmethod
     def get_wrapper_class():
-        """Return the wrapper class or factory for this architecture"""
+        """Return the wrapper class or factory for this architecture."""
 
     @abstractmethod
     def build_input_spec(
@@ -35,7 +36,7 @@ class ArchitectureHandler(ABC):
         n_past_input_tokens: int,
         real_kv_cache: T.Optional[T.List[torch.Tensor]] = None,
     ) -> InputSpec:
-        """Build exported inputs plus names/dynamic axes for the decoder"""
+        """Build exported inputs plus names/dynamic axes for the decoder."""
 
     @abstractmethod
     def prepare_inputs_for_model(
@@ -44,4 +45,4 @@ class ArchitectureHandler(ABC):
         inputs: T.Tuple[torch.Tensor, ...],
         wrapper,
     ) -> T.Dict[str, T.Any]:
-        """Convert exported inputs into kwargs expected by the HF model"""
+        """Convert exported inputs into kwargs expected by the HF model."""

--- a/packages/llm/torch_to_nnef_llm/models/handlers/default.py
+++ b/packages/llm/torch_to_nnef_llm/models/handlers/default.py
@@ -56,6 +56,21 @@ class DefaultArchitectureHandler(ArchitectureHandler):
         inputs: T.Tuple[torch.Tensor, ...],
         wrapper,
     ) -> T.Dict[str, T.Any]:
+        attention_mask = None
+        if wrapper.force_causal_mask:
+            attn_mask_dtype = torch.float32
+            seq_length = inputs[1].shape[0]
+            attention_mask = (
+                torch.triu(
+                    torch.full(
+                        [seq_length, seq_length],
+                        torch.finfo(attn_mask_dtype).min,
+                    ),
+                    diagonal=1,
+                )
+                .unsqueeze(0)
+                .unsqueeze(0)
+            ).to(attn_mask_dtype)
         if wrapper.with_dyn_cache:
             past_key_values = build_past_kv_dyn_cache(inputs[1:])
         else:
@@ -64,4 +79,5 @@ class DefaultArchitectureHandler(ArchitectureHandler):
             "input_ids": inputs[0],
             "past_key_values": past_key_values,
             "use_cache": True,
+            "attention_mask": attention_mask,
         }

--- a/packages/llm/torch_to_nnef_llm/models/handlers/default.py
+++ b/packages/llm/torch_to_nnef_llm/models/handlers/default.py
@@ -3,7 +3,6 @@ import typing as T
 import torch
 
 from torch_to_nnef_llm.models.base import (
-    BaseCausal,
     build_past_kv_dyn_cache,
     build_past_kv_list,
 )
@@ -17,10 +16,6 @@ class DefaultArchitectureHandler(ArchitectureHandler):
     """Fallback handler for standard causal decoder models."""
 
     ARCH_NAMES = ("default",)
-
-    @staticmethod
-    def get_wrapper_class():
-        return BaseCausal
 
     def build_input_spec(
         self,

--- a/packages/llm/torch_to_nnef_llm/models/handlers/default.py
+++ b/packages/llm/torch_to_nnef_llm/models/handlers/default.py
@@ -57,7 +57,7 @@ class DefaultArchitectureHandler(ArchitectureHandler):
         wrapper,
     ) -> T.Dict[str, T.Any]:
         attention_mask = None
-        if wrapper.force_causal_mask:
+        if getattr(wrapper, "force_causal_mask", False):
             attn_mask_dtype = torch.float32
             seq_length = inputs[1].shape[0]
             attention_mask = (

--- a/packages/llm/torch_to_nnef_llm/models/handlers/default.py
+++ b/packages/llm/torch_to_nnef_llm/models/handlers/default.py
@@ -52,7 +52,7 @@ class DefaultArchitectureHandler(ArchitectureHandler):
             dynamic_axes=dynamic_axes,
         )
 
-    def prepare_inputs_for_model(
+    def build_forward_inputs(
         self,
         *,
         inputs: T.Tuple[torch.Tensor, ...],

--- a/packages/llm/torch_to_nnef_llm/models/handlers/default.py
+++ b/packages/llm/torch_to_nnef_llm/models/handlers/default.py
@@ -2,14 +2,19 @@ import typing as T
 
 import torch
 
-from torch_to_nnef_llm.models.base import build_past_kv_dyn_cache, build_past_kv_list
-from torch_to_nnef_llm.models.base import BaseCausal
+from torch_to_nnef_llm.models.base import (
+    BaseCausal,
+    build_past_kv_dyn_cache,
+    build_past_kv_list,
+)
 
 from .base import ArchitectureHandler, InputSpec
+from .registry import register_handler
 
 
+@register_handler
 class DefaultArchitectureHandler(ArchitectureHandler):
-    """Fallback handler for standard causal decoder models"""
+    """Fallback handler for standard causal decoder models."""
 
     ARCH_NAMES = ("default",)
 
@@ -40,7 +45,9 @@ class DefaultArchitectureHandler(ArchitectureHandler):
             force_inputs_dtype=inputs_dtype,
             real_kv_cache=real_kv_cache,
         )
-        inputs = tuple([test_input.input_ids[:, :n_input_tokens]] + past_key_values)
+        inputs = tuple(
+            [test_input.input_ids[:, :n_input_tokens]] + past_key_values
+        )
         input_names = ["input_ids"] + in_cache_names
         output_names = ["outputs"] + out_cache_names
         return InputSpec(

--- a/packages/llm/torch_to_nnef_llm/models/handlers/default.py
+++ b/packages/llm/torch_to_nnef_llm/models/handlers/default.py
@@ -1,6 +1,12 @@
+import typing as T
+
+import torch
+
+from torch_to_nnef_llm.models.base import build_past_kv_dyn_cache, build_past_kv_list
 from torch_to_nnef_llm.models.base import BaseCausal
 
-from .base import ArchitectureHandler
+from .base import ArchitectureHandler, InputSpec
+
 
 class DefaultArchitectureHandler(ArchitectureHandler):
     """Fallback handler for standard causal decoder models"""
@@ -10,3 +16,52 @@ class DefaultArchitectureHandler(ArchitectureHandler):
     @staticmethod
     def get_wrapper_class():
         return BaseCausal
+
+    def build_input_spec(
+        self,
+        *,
+        tokenizer,
+        config_helper,
+        inputs_dtype: torch.dtype,
+        sample_text: str,
+        n_input_tokens: int,
+        n_past_input_tokens: int,
+        real_kv_cache: T.Optional[T.List[torch.Tensor]] = None,
+    ) -> InputSpec:
+        test_input = tokenizer(sample_text, return_tensors="pt")
+        assert test_input.input_ids.shape[1] >= n_input_tokens
+        (
+            in_cache_names,
+            out_cache_names,
+            past_key_values,
+            dynamic_axes,
+        ) = config_helper.build_kv_cache_infos(
+            n_past_input_tokens=n_past_input_tokens,
+            force_inputs_dtype=inputs_dtype,
+            real_kv_cache=real_kv_cache,
+        )
+        inputs = tuple([test_input.input_ids[:, :n_input_tokens]] + past_key_values)
+        input_names = ["input_ids"] + in_cache_names
+        output_names = ["outputs"] + out_cache_names
+        return InputSpec(
+            inputs=inputs,
+            input_names=input_names,
+            output_names=output_names,
+            dynamic_axes=dynamic_axes,
+        )
+
+    def prepare_inputs_for_model(
+        self,
+        *,
+        inputs: T.Tuple[torch.Tensor, ...],
+        wrapper,
+    ) -> T.Dict[str, T.Any]:
+        if wrapper.with_dyn_cache:
+            past_key_values = build_past_kv_dyn_cache(inputs[1:])
+        else:
+            past_key_values = build_past_kv_list(inputs[1:])
+        return {
+            "input_ids": inputs[0],
+            "past_key_values": past_key_values,
+            "use_cache": True,
+        }

--- a/packages/llm/torch_to_nnef_llm/models/handlers/default.py
+++ b/packages/llm/torch_to_nnef_llm/models/handlers/default.py
@@ -1,0 +1,12 @@
+from torch_to_nnef_llm.models.base import BaseCausal
+
+from .base import ArchitectureHandler
+
+class DefaultArchitectureHandler(ArchitectureHandler):
+    """Fallback handler for standard causal decoder models"""
+
+    ARCH_NAMES = ("default",)
+
+    @staticmethod
+    def get_wrapper_class():
+        return BaseCausal

--- a/packages/llm/torch_to_nnef_llm/models/handlers/openelm.py
+++ b/packages/llm/torch_to_nnef_llm/models/handlers/openelm.py
@@ -1,0 +1,15 @@
+from functools import partial
+
+from torch_to_nnef_llm.models.base import BaseCausal
+
+from .base import ArchitectureHandler
+
+
+class OpenELMArchitectureHandler(ArchitectureHandler):
+    """Handler for OpenELM models."""
+
+    ARCH_NAMES = ("openelm",)
+
+    @staticmethod
+    def get_wrapper_class():
+        return partial(BaseCausal, with_dyn_cache=False)

--- a/packages/llm/torch_to_nnef_llm/models/handlers/openelm.py
+++ b/packages/llm/torch_to_nnef_llm/models/handlers/openelm.py
@@ -2,10 +2,9 @@ from functools import partial
 
 from torch_to_nnef_llm.models.base import BaseCausal
 
-from .base import ArchitectureHandler
+from .default import DefaultArchitectureHandler
 
-
-class OpenELMArchitectureHandler(ArchitectureHandler):
+class OpenELMArchitectureHandler(DefaultArchitectureHandler):
     """Handler for OpenELM models."""
 
     ARCH_NAMES = ("openelm",)

--- a/packages/llm/torch_to_nnef_llm/models/handlers/openelm.py
+++ b/packages/llm/torch_to_nnef_llm/models/handlers/openelm.py
@@ -3,9 +3,12 @@ from functools import partial
 from torch_to_nnef_llm.models.base import BaseCausal
 
 from .default import DefaultArchitectureHandler
+from .registry import register_handler
 
+
+@register_handler
 class OpenELMArchitectureHandler(DefaultArchitectureHandler):
-    """Handler for OpenELM models"""
+    """Handler for OpenELM models."""
 
     ARCH_NAMES = ("openelm",)
 

--- a/packages/llm/torch_to_nnef_llm/models/handlers/openelm.py
+++ b/packages/llm/torch_to_nnef_llm/models/handlers/openelm.py
@@ -5,7 +5,7 @@ from torch_to_nnef_llm.models.base import BaseCausal
 from .default import DefaultArchitectureHandler
 
 class OpenELMArchitectureHandler(DefaultArchitectureHandler):
-    """Handler for OpenELM models."""
+    """Handler for OpenELM models"""
 
     ARCH_NAMES = ("openelm",)
 

--- a/packages/llm/torch_to_nnef_llm/models/handlers/openelm.py
+++ b/packages/llm/torch_to_nnef_llm/models/handlers/openelm.py
@@ -1,7 +1,3 @@
-from functools import partial
-
-from torch_to_nnef_llm.models.base import BaseCausal
-
 from .default import DefaultArchitectureHandler
 from .registry import register_handler
 
@@ -11,7 +7,4 @@ class OpenELMArchitectureHandler(DefaultArchitectureHandler):
     """Handler for OpenELM models."""
 
     ARCH_NAMES = ("openelm",)
-
-    @staticmethod
-    def get_wrapper_class():
-        return partial(BaseCausal, with_dyn_cache=False)
+    with_dyn_cache = False

--- a/packages/llm/torch_to_nnef_llm/models/handlers/phi.py
+++ b/packages/llm/torch_to_nnef_llm/models/handlers/phi.py
@@ -1,9 +1,9 @@
 from torch_to_nnef_llm.models.base import BaseCausalWithDynCacheAndTriu
 
-from .base import ArchitectureHandler
+from .default import DefaultArchitectureHandler
 
 
-class PhiArchitectureHandler(ArchitectureHandler):
+class PhiArchitectureHandler(DefaultArchitectureHandler):
     """Handler for Phi-family models"""
 
     ARCH_NAMES = ("phi",)

--- a/packages/llm/torch_to_nnef_llm/models/handlers/phi.py
+++ b/packages/llm/torch_to_nnef_llm/models/handlers/phi.py
@@ -2,7 +2,10 @@ import typing as T
 
 import torch
 
-from torch_to_nnef_llm.models.base import build_past_kv_dyn_cache
+from torch_to_nnef_llm.models.base import (
+    build_past_kv_dyn_cache,
+    dyn_cache_to_legacy,
+)
 
 from .default import DefaultArchitectureHandler
 from .registry import register_handler
@@ -76,7 +79,9 @@ class PhiArchitectureHandler(DefaultArchitectureHandler):
         )
         kvs = [
             t
-            for kv in model_inputs["past_key_values"].to_legacy_cache()
+            for kv in dyn_cache_to_legacy(
+                model_inputs["past_key_values"]
+            )
             for t in kv
         ]
         return [logits] + kvs

--- a/packages/llm/torch_to_nnef_llm/models/handlers/phi.py
+++ b/packages/llm/torch_to_nnef_llm/models/handlers/phi.py
@@ -14,7 +14,7 @@ class PhiArchitectureHandler(DefaultArchitectureHandler):
 
     ARCH_NAMES = ("phi",)
 
-    def prepare_inputs_for_model(
+    def build_forward_inputs(
         self,
         *,
         inputs: T.Tuple[torch.Tensor, ...],
@@ -62,7 +62,7 @@ class PhiArchitectureHandler(DefaultArchitectureHandler):
     ) -> T.Any:
         return model.model(**model_inputs)
 
-    def prepare_outputs_for_export(
+    def build_forward_outputs(
         self,
         *,
         model,

--- a/packages/llm/torch_to_nnef_llm/models/handlers/phi.py
+++ b/packages/llm/torch_to_nnef_llm/models/handlers/phi.py
@@ -1,0 +1,13 @@
+from torch_to_nnef_llm.models.base import BaseCausalWithDynCacheAndTriu
+
+from .base import ArchitectureHandler
+
+
+class PhiArchitectureHandler(ArchitectureHandler):
+    """Handler for Phi-family models"""
+
+    ARCH_NAMES = ("phi",)
+
+    @staticmethod
+    def get_wrapper_class():
+        return BaseCausalWithDynCacheAndTriu

--- a/packages/llm/torch_to_nnef_llm/models/handlers/phi.py
+++ b/packages/llm/torch_to_nnef_llm/models/handlers/phi.py
@@ -74,14 +74,10 @@ class PhiArchitectureHandler(DefaultArchitectureHandler):
         num_logits_to_keep: int,
     ) -> T.List[torch.Tensor]:
         hidden_states = model_outputs[0]
-        logits = model.lm_head(
-            hidden_states[:, -num_logits_to_keep:, :]
-        )
+        logits = model.lm_head(hidden_states[:, -num_logits_to_keep:, :])
         kvs = [
             t
-            for kv in dyn_cache_to_legacy(
-                model_inputs["past_key_values"]
-            )
+            for kv in dyn_cache_to_legacy(model_inputs["past_key_values"])
             for t in kv
         ]
         return [logits] + kvs

--- a/packages/llm/torch_to_nnef_llm/models/handlers/phi.py
+++ b/packages/llm/torch_to_nnef_llm/models/handlers/phi.py
@@ -1,10 +1,12 @@
 from torch_to_nnef_llm.models.base import BaseCausalWithDynCacheAndTriu
 
 from .default import DefaultArchitectureHandler
+from .registry import register_handler
 
 
+@register_handler
 class PhiArchitectureHandler(DefaultArchitectureHandler):
-    """Handler for Phi-family models"""
+    """Handler for Phi-family models."""
 
     ARCH_NAMES = ("phi",)
 

--- a/packages/llm/torch_to_nnef_llm/models/handlers/phi.py
+++ b/packages/llm/torch_to_nnef_llm/models/handlers/phi.py
@@ -2,10 +2,7 @@ import typing as T
 
 import torch
 
-from torch_to_nnef_llm.models.base import (
-    BaseCausalWithDynCacheAndTriu,
-    build_past_kv_dyn_cache,
-)
+from torch_to_nnef_llm.models.base import build_past_kv_dyn_cache
 
 from .default import DefaultArchitectureHandler
 from .registry import register_handler
@@ -16,10 +13,6 @@ class PhiArchitectureHandler(DefaultArchitectureHandler):
     """Handler for Phi-family models."""
 
     ARCH_NAMES = ("phi",)
-
-    @staticmethod
-    def get_wrapper_class():
-        return BaseCausalWithDynCacheAndTriu
 
     def prepare_inputs_for_model(
         self,
@@ -59,3 +52,31 @@ class PhiArchitectureHandler(DefaultArchitectureHandler):
             "use_cache": True,
             "cache_position": cache_position,
         }
+
+    def call_model(
+        self,
+        *,
+        model,
+        model_inputs: T.Dict[str, T.Any],
+        wrapper,
+    ) -> T.Any:
+        return model.model(**model_inputs)
+
+    def prepare_outputs_for_export(
+        self,
+        *,
+        model,
+        model_outputs: T.Any,
+        model_inputs: T.Dict[str, T.Any],
+        num_logits_to_keep: int,
+    ) -> T.List[torch.Tensor]:
+        hidden_states = model_outputs[0]
+        logits = model.lm_head(
+            hidden_states[:, -num_logits_to_keep:, :]
+        )
+        kvs = [
+            t
+            for kv in model_inputs["past_key_values"].to_legacy_cache()
+            for t in kv
+        ]
+        return [logits] + kvs

--- a/packages/llm/torch_to_nnef_llm/models/handlers/phi.py
+++ b/packages/llm/torch_to_nnef_llm/models/handlers/phi.py
@@ -1,4 +1,11 @@
-from torch_to_nnef_llm.models.base import BaseCausalWithDynCacheAndTriu
+import typing as T
+
+import torch
+
+from torch_to_nnef_llm.models.base import (
+    BaseCausalWithDynCacheAndTriu,
+    build_past_kv_dyn_cache,
+)
 
 from .default import DefaultArchitectureHandler
 from .registry import register_handler
@@ -13,3 +20,42 @@ class PhiArchitectureHandler(DefaultArchitectureHandler):
     @staticmethod
     def get_wrapper_class():
         return BaseCausalWithDynCacheAndTriu
+
+    def prepare_inputs_for_model(
+        self,
+        *,
+        inputs: T.Tuple[torch.Tensor, ...],
+        wrapper,
+    ) -> T.Dict[str, T.Any]:
+        input_ids = inputs[0]
+        cache = build_past_kv_dyn_cache(inputs[1:])
+        _, seq_length = input_ids.shape[:2]
+        past_key_values_length = cache.get_seq_length()
+        cache_position = torch.arange(
+            past_key_values_length,
+            seq_length + past_key_values_length,
+            dtype=torch.long,
+            device=input_ids.device,
+        )
+        position_ids = cache_position.unsqueeze(0)
+        inputs_embeds = wrapper.model.model.embed_tokens(input_ids)
+        attention_mask = (
+            torch.triu(
+                torch.full(
+                    [seq_length, seq_length],
+                    torch.finfo(inputs_embeds.dtype).min,
+                ),
+                diagonal=1,
+            )
+            .unsqueeze(0)
+            .unsqueeze(0)
+        ).to(inputs_embeds.dtype)
+        return {
+            "inputs_embeds": inputs_embeds,
+            "attention_mask": attention_mask,
+            "position_ids": position_ids,
+            "past_key_values": cache,
+            "output_attentions": False,
+            "use_cache": True,
+            "cache_position": cache_position,
+        }

--- a/packages/llm/torch_to_nnef_llm/models/handlers/registry.py
+++ b/packages/llm/torch_to_nnef_llm/models/handlers/registry.py
@@ -1,0 +1,35 @@
+from typing import Dict, Type
+
+from torch_to_nnef.exceptions import T2NErrorConsistency, T2NErrorMisuse
+
+from .base import ArchitectureHandler
+
+_HANDLER_REGISTRY: Dict[str, Type[ArchitectureHandler]] = {}
+
+
+def register_handler(
+    handler_cls: Type[ArchitectureHandler],
+) -> Type[ArchitectureHandler]:
+    """Register an architecture handler class for its declared names."""
+    if not issubclass(handler_cls, ArchitectureHandler):
+        raise T2NErrorMisuse(
+            f"{handler_cls!r} must inherit from ArchitectureHandler"
+        )
+    if not handler_cls.ARCH_NAMES:
+        raise T2NErrorMisuse(
+            f"{handler_cls.__name__} must define at least one ARCH_NAMES entry"
+        )
+    for arch_name in handler_cls.ARCH_NAMES:
+        if arch_name in _HANDLER_REGISTRY:
+            raise T2NErrorConsistency(
+                f"duplicate handler for {arch_name!r}: "
+                f"{handler_cls.__name__} vs "
+                f"{_HANDLER_REGISTRY[arch_name].__name__}"
+            )
+        _HANDLER_REGISTRY[arch_name] = handler_cls
+    return handler_cls
+
+
+def get_handler(model_type: str) -> Type[ArchitectureHandler]:
+    """Return the registered handler for a model type."""
+    return _HANDLER_REGISTRY.get(model_type, _HANDLER_REGISTRY["default"])


### PR DESCRIPTION
## Description

This PR proposes a new model-handler layer in the LLM export path to make architecture-specific behavior more modular while preserving existing behavior.

The intent is to separate the core exporter from model-specific logic such as loading, wrapper selection, and input preparation. I’m proposing this as an initial step toward future multimodal/VLM support as discussed in #68 