### PR TITLE
feat(image-gen): SD 1.5 examples + all #69 op fixes (with primitive coverage)

### DIFF
--- a/docs/examples/image_gen/.gitignore
+++ b/docs/examples/image_gen/.gitignore
@@ -1,0 +1,8 @@
+.venv/
+hf_cache/
+__pycache__/
+*.nnef.tgz
+*.tgz
+debug/
+debug_*/
+model/

--- a/docs/examples/image_gen/README.md
+++ b/docs/examples/image_gen/README.md
@@ -1,0 +1,32 @@
+# Image generation examples (exploratory)
+
+Goal: export diffusion-based image generators to NNEF via torch-to-nnef and
+check them end-to-end against tract.
+
+Motivation: a colleague reported success running SD 1.5, SDXL, SD3 and
+Flux-Schnell directly on tract (with a handful of tract-side fixes plus NNEF
+`resize` support added recently). This directory explores doing the same via
+torch-to-nnef rather than going through ONNX as an intermediate.
+
+## Scope
+
+Each subdir targets one model family and is split by component so the heaviest
+tensors are not all loaded at once:
+
+- `sd15/` -- Stable Diffusion 1.5: VAE decoder, UNet, CLIP text encoder
+- `sdxl/` -- Stable Diffusion XL: two text encoders, larger UNet, VAE
+- `sd3/` -- Stable Diffusion 3 (DiT architecture)
+
+Flux-Schnell (DiT, 12B) is a planned follow-up: it currently exports cleanly
+but fails on the tract side (SDPA + reshape deserializer panics on Flux's
+RoPE'd shapes), so it is held out of this directory until the upstream tract
+fixes land.
+
+## Status
+
+Early exploration. First targets are the SD 1.5 VAE decoder and UNet, both
+validated end-to-end against tract via `check_io`.
+
+Expected gotchas: attention (flash / sdpa variants), grouped norm fusing,
+timestep embedding, cross-attention text conditioning, FP16 weights, large
+safetensors loading.

--- a/docs/examples/image_gen/README.md
+++ b/docs/examples/image_gen/README.md
@@ -17,11 +17,6 @@ tensors are not all loaded at once:
 - `sdxl/` -- Stable Diffusion XL: two text encoders, larger UNet, VAE
 - `sd3/` -- Stable Diffusion 3 (DiT architecture)
 
-Flux-Schnell (DiT, 12B) is a planned follow-up: it currently exports cleanly
-but fails on the tract side (SDPA + reshape deserializer panics on Flux's
-RoPE'd shapes), so it is held out of this directory until the upstream tract
-fixes land.
-
 ## Status
 
 Early exploration. First targets are the SD 1.5 VAE decoder and UNet, both

--- a/docs/examples/image_gen/requirements.txt
+++ b/docs/examples/image_gen/requirements.txt
@@ -1,0 +1,7 @@
+torch>=2.2
+diffusers>=0.30
+transformers>=4.44
+huggingface_hub>=0.20
+accelerate>=0.30
+safetensors
+-e ../../../

--- a/docs/examples/image_gen/requirements.txt
+++ b/docs/examples/image_gen/requirements.txt
@@ -1,7 +1,7 @@
-torch>=2.2
-diffusers>=0.30
-transformers>=4.44
-huggingface_hub>=0.20
-accelerate>=0.30
-safetensors
+torch>=2.2,<3
+diffusers>=0.30,<0.40
+transformers>=4.44,<5
+huggingface_hub>=0.20,<1
+accelerate>=0.30,<2
+safetensors<1
 -e ../../../

--- a/docs/examples/image_gen/sd15/unet.py
+++ b/docs/examples/image_gen/sd15/unet.py
@@ -1,0 +1,108 @@
+"""Export the SD 1.5 UNet (noise predictor) via torch-to-nnef.
+
+Target: `runwayml/stable-diffusion-v1-5` UNet (`UNet2DConditionModel`).
+
+Inputs:
+- `sample`: (B, 4, H, W) noisy latent
+- `timestep`: scalar float (broadcast over batch via sinusoidal embedding)
+- `encoder_hidden_states`: (B, L, 768) CLIP text embedding
+
+Output:
+- `noise_pred`: (B, 4, H, W) predicted noise
+
+Size: ~860M params (~3.4 GB fp32). The full 64x64 latent + 77-token text path
+is heavy; start at 8x8 latent + 10 tokens for a first smoke run, then scale up.
+
+Run:
+    python unet.py --skip-io-check             # fastest, just emit NNEF
+    python unet.py                             # with tract I/O check (slow)
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import torch
+import torch.nn as nn
+
+from torch_to_nnef import TractNNEF, export_model_to_nnef
+
+HF_REPO = "runwayml/stable-diffusion-v1-5"
+
+
+class UNetWrapper(nn.Module):
+    """Flatten the UNet2DConditionModel API to three positional tensors."""
+
+    def __init__(self, unet):
+        super().__init__()
+        self.unet = unet.eval()
+
+    def forward(
+        self,
+        sample: torch.Tensor,
+        timestep: torch.Tensor,
+        encoder_hidden_states: torch.Tensor,
+    ) -> torch.Tensor:
+        return self.unet(
+            sample=sample,
+            timestep=timestep,
+            encoder_hidden_states=encoder_hidden_states,
+            return_dict=False,
+        )[0]
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--out", type=Path, default=Path("./sd15_unet.nnef.tgz")
+    )
+    parser.add_argument("--latent-h", type=int, default=8)
+    parser.add_argument("--latent-w", type=int, default=8)
+    parser.add_argument("--seq-len", type=int, default=10)
+    parser.add_argument("--tract-version", type=str, default=None)
+    parser.add_argument(
+        "--skip-io-check",
+        action="store_true",
+        help="Skip tract I/O comparison (very slow on UNet; use to verify "
+        "the NNEF graph writes out at all).",
+    )
+    args = parser.parse_args()
+
+    from diffusers import UNet2DConditionModel
+
+    print(f"Loading UNet from {HF_REPO}")
+    unet = UNet2DConditionModel.from_pretrained(
+        HF_REPO, subfolder="unet", torch_dtype=torch.float32
+    )
+    pipeline = UNetWrapper(unet).eval()
+
+    sample = torch.randn(
+        1, 4, args.latent_h, args.latent_w, dtype=torch.float32
+    )
+    timestep = torch.tensor(10.0, dtype=torch.float32)
+    encoder_hidden_states = torch.randn(
+        1, args.seq_len, 768, dtype=torch.float32
+    )
+
+    with torch.no_grad():
+        out = pipeline(sample, timestep, encoder_hidden_states)
+    print(f"PyTorch output shape: {tuple(out.shape)}")
+
+    tract_version = args.tract_version or TractNNEF.latest_version()
+    check_io = not args.skip_io_check
+    print(f"Exporting to NNEF with tract {tract_version} (check_io={check_io})")
+    export_model_to_nnef(
+        model=pipeline,
+        args=(sample, timestep, encoder_hidden_states),
+        file_path_export=args.out,
+        inference_target=TractNNEF(version=tract_version, check_io=check_io),
+        input_names=["sample", "timestep", "encoder_hidden_states"],
+        output_names=["noise_pred"],
+        debug_bundle_path=Path("./debug_unet.tgz"),
+    )
+    print(f"Exported to {args.out.absolute()}")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/examples/image_gen/sd15/vae_decoder.py
+++ b/docs/examples/image_gen/sd15/vae_decoder.py
@@ -1,0 +1,88 @@
+"""Export the SD 1.5 VAE decoder (latent -> image) via torch-to-nnef.
+
+Target: `runwayml/stable-diffusion-v1-5` VAE decoder. The decoder upsamples a
+`(1, 4, 64, 64)` latent into a `(1, 3, 512, 512)` image. Its upsample blocks
+use `F.interpolate` which lowers to NNEF ``resize`` -- the op that was the
+historical blocker here. We export on fp32 CPU and run tract I/O check to
+validate against PyTorch.
+
+Run:
+    python vae_decoder.py
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import torch
+import torch.nn as nn
+
+from torch_to_nnef import TractNNEF, export_model_to_nnef
+
+HF_REPO = "runwayml/stable-diffusion-v1-5"
+
+
+class VaeDecoderWrapper(nn.Module):
+    """Forward takes a latent, returns the decoded image."""
+
+    def __init__(self, vae):
+        super().__init__()
+        self.vae = vae.eval()
+        self.scaling_factor = float(
+            getattr(vae.config, "scaling_factor", 0.18215)
+        )
+
+    def forward(self, latents: torch.Tensor) -> torch.Tensor:
+        x = latents / self.scaling_factor
+        return self.vae.decode(x, return_dict=False)[0]
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--out", type=Path, default=Path("./sd15_vae_decoder.nnef.tgz")
+    )
+    parser.add_argument("--latent-h", type=int, default=64)
+    parser.add_argument("--latent-w", type=int, default=64)
+    parser.add_argument("--tract-version", type=str, default=None)
+    parser.add_argument(
+        "--skip-io-check",
+        action="store_true",
+        help="Skip tract I/O comparison (very slow on full VAE; use to verify "
+        "the NNEF graph writes out at all).",
+    )
+    args = parser.parse_args()
+
+    from diffusers import AutoencoderKL
+
+    print(f"Loading VAE from {HF_REPO}")
+    vae = AutoencoderKL.from_pretrained(
+        HF_REPO, subfolder="vae", torch_dtype=torch.float32
+    )
+    pipeline = VaeDecoderWrapper(vae).eval()
+
+    latents = torch.randn(
+        1, 4, args.latent_h, args.latent_w, dtype=torch.float32
+    )
+    with torch.no_grad():
+        out = pipeline(latents)
+    print(f"PyTorch output shape: {tuple(out.shape)}")
+
+    tract_version = args.tract_version or TractNNEF.latest_version()
+    check_io = not args.skip_io_check
+    print(f"Exporting to NNEF with tract {tract_version} (check_io={check_io})")
+    export_model_to_nnef(
+        model=pipeline,
+        args=latents,
+        file_path_export=args.out,
+        inference_target=TractNNEF(version=tract_version, check_io=check_io),
+        input_names=["latents"],
+        output_names=["image"],
+        debug_bundle_path=Path("./debug_vae_decoder.tgz"),
+    )
+    print(f"Exported to {args.out.absolute()}")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/examples/image_gen/sd3/README.md
+++ b/docs/examples/image_gen/sd3/README.md
@@ -1,0 +1,9 @@
+# SD3 (TODO)
+
+Target repo: `stabilityai/stable-diffusion-3-medium`.
+
+Key difference vs SD 1.5 / SDXL: DiT (diffusion transformer) architecture
+instead of UNet. Three text encoders (CLIP-L, CLIP-G, T5-XXL).
+
+Start with VAE decoder to validate the upsample path, then the DiT transformer
+(expect attention / rotary-pos-embedding gotchas).

--- a/docs/examples/image_gen/sdxl/README.md
+++ b/docs/examples/image_gen/sdxl/README.md
@@ -1,0 +1,8 @@
+# SDXL (TODO)
+
+Target repos:
+- UNet + VAE: `stabilityai/stable-diffusion-xl-base-1.0`
+- Two text encoders (CLIP-L + OpenCLIP G)
+
+Export pattern mirrors `../sd15/vae_decoder.py`. Start with the VAE decoder,
+then text encoders, then the larger UNet.

--- a/tests/test_model_zoo.py
+++ b/tests/test_model_zoo.py
@@ -247,12 +247,7 @@ except ImportError:
 
 
 class _MiniVAEMidBlock(torch.nn.Module):
-    """GroupNorm + self-attention with 1/sqrt(d) scaling (AttnBlock-like).
-
-    Uses the Python-int ``self.channels`` instead of ``x.shape[1]`` so the
-    reshape shape stays a concrete integer vector: SD VAE does the same, and
-    feeding a symbolic dim into reshape trips tract during NNEF deserialization.
-    """
+    """GroupNorm + self-attention with 1/sqrt(d) scaling (AttnBlock-like)."""
 
     def __init__(self, channels: int = 8):
         super().__init__()

--- a/tests/test_model_zoo.py
+++ b/tests/test_model_zoo.py
@@ -1,6 +1,7 @@
 """Tests canonical models."""
 
 import contextlib
+import math
 import os
 import platform
 import warnings
@@ -8,6 +9,7 @@ from copy import deepcopy
 
 import pytest
 import torch
+import torch.nn.functional as F
 import torchaudio
 import torchvision
 from torch.jit._trace import TracerWarning
@@ -233,6 +235,181 @@ except ImportError:
     print("missing deps to test on albert model")
 
 # }
+
+
+# --- Mini image-generation architectures ------------------------------------
+# Reproduce the operator mix of Stable Diffusion components (GroupNorm +
+# self-attention with 1/sqrt(d) scaling + F.interpolate upsample + conv, plus
+# sinusoidal timestep embedding + cross-attention for the UNet) on tiny
+# models. Guards the work unblocked by tract's ``resize`` op and t2n's
+# ``mul`` constant-fold dtype handling, without pulling diffusers or
+# downloading the full SD weights.
+
+
+class _MiniVAEMidBlock(torch.nn.Module):
+    """GroupNorm + self-attention with 1/sqrt(d) scaling (AttnBlock-like).
+
+    Uses the Python-int ``self.channels`` instead of ``x.shape[1]`` so the
+    reshape shape stays a concrete integer vector: SD VAE does the same, and
+    feeding a symbolic dim into reshape trips tract during NNEF deserialization.
+    """
+
+    def __init__(self, channels: int = 8):
+        super().__init__()
+        self.channels = channels
+        self.norm = torch.nn.GroupNorm(4, channels)
+        self.q = torch.nn.Linear(channels, channels)
+        self.k = torch.nn.Linear(channels, channels)
+        self.v = torch.nn.Linear(channels, channels)
+        self.proj_out = torch.nn.Linear(channels, channels)
+
+    def forward(self, x):
+        c = self.channels
+        h_ = self.norm(x)
+        b, _, h, w = x.shape
+        h_ = h_.permute(0, 2, 3, 1).reshape(b, h * w, c)
+        q, k, v = self.q(h_), self.k(h_), self.v(h_)
+        scale = c**-0.5
+        attn = torch.softmax(q @ k.transpose(-1, -2) * scale, dim=-1)
+        out = self.proj_out(attn @ v).reshape(b, h, w, c).permute(0, 3, 1, 2)
+        return x + out
+
+
+class MiniVAEDecoderLike(torch.nn.Module):
+    """Mid-block attention then two F.interpolate upsample + conv steps."""
+
+    def __init__(self):
+        super().__init__()
+        self.mid = _MiniVAEMidBlock(channels=8)
+        self.upconv1 = torch.nn.Conv2d(8, 8, 3, padding=1)
+        self.upconv2 = torch.nn.Conv2d(8, 4, 3, padding=1)
+
+    def forward(self, x):
+        x = self.mid(x)
+        x = F.interpolate(x, scale_factor=2, mode="nearest")
+        x = self.upconv1(x)
+        x = F.interpolate(x, scale_factor=2, mode="nearest")
+        return self.upconv2(x)
+
+
+test_suite.add(
+    (torch.randn(1, 8, 4, 4),),
+    MiniVAEDecoderLike(),
+    test_name="mini_vae_decoder_like",
+)
+
+
+def _sin_timestep_embedding(t: torch.Tensor, dim: int) -> torch.Tensor:
+    """Sinusoidal timestep embedding (same recipe as diffusers Timesteps)."""
+    half = dim // 2
+    freqs = torch.exp(
+        -math.log(10000.0) * torch.arange(half, dtype=torch.float32) / half
+    )
+    args = t.float().unsqueeze(-1) * freqs
+    return torch.cat([torch.cos(args), torch.sin(args)], dim=-1)
+
+
+class _MiniResBlock(torch.nn.Module):
+    """Conv + GroupNorm + SiLU + inject time emb + Conv + skip."""
+
+    def __init__(self, in_ch: int, out_ch: int, time_dim: int):
+        super().__init__()
+        self.norm1 = torch.nn.GroupNorm(4, in_ch)
+        self.conv1 = torch.nn.Conv2d(in_ch, out_ch, 3, padding=1)
+        self.time_proj = torch.nn.Linear(time_dim, out_ch)
+        self.norm2 = torch.nn.GroupNorm(4, out_ch)
+        self.conv2 = torch.nn.Conv2d(out_ch, out_ch, 3, padding=1)
+        self.skip = (
+            torch.nn.Identity()
+            if in_ch == out_ch
+            else torch.nn.Conv2d(in_ch, out_ch, 1)
+        )
+
+    def forward(self, x, t_emb):
+        h = self.conv1(F.silu(self.norm1(x)))
+        h = h + self.time_proj(F.silu(t_emb))[:, :, None, None]
+        h = self.conv2(F.silu(self.norm2(h)))
+        return h + self.skip(x)
+
+
+class _MiniCrossAttn(torch.nn.Module):
+    """Cross-attention of a 2D feature map against an encoder hidden state."""
+
+    def __init__(self, channels: int, ctx_dim: int):
+        super().__init__()
+        self.channels = channels
+        self.norm = torch.nn.GroupNorm(4, channels)
+        self.q = torch.nn.Linear(channels, channels)
+        self.k = torch.nn.Linear(ctx_dim, channels)
+        self.v = torch.nn.Linear(ctx_dim, channels)
+        self.proj_out = torch.nn.Linear(channels, channels)
+
+    def forward(self, x, ctx):
+        c = self.channels
+        b, _, h, w = x.shape
+        h_ = self.norm(x).permute(0, 2, 3, 1).reshape(b, h * w, c)
+        q = self.q(h_)
+        k = self.k(ctx)
+        v = self.v(ctx)
+        attn = torch.softmax(q @ k.transpose(-1, -2) * (c**-0.5), dim=-1)
+        out = self.proj_out(attn @ v).reshape(b, h, w, c).permute(0, 3, 1, 2)
+        return x + out
+
+
+class MiniUNetLike(torch.nn.Module):
+    """UNet with timestep conditioning, one down + mid + one up block.
+
+    Not shape-invariant to SD 1.5 but exercises the same operator mix: time
+    embedding, cross-attn, resnet blocks, strided downsample, upsample.
+    """
+
+    def __init__(self, ch: int = 8, ctx_dim: int = 16):
+        super().__init__()
+        time_dim = 4 * ch
+        self.time_mlp = torch.nn.Sequential(
+            torch.nn.Linear(ch, time_dim),
+            torch.nn.SiLU(),
+            torch.nn.Linear(time_dim, time_dim),
+        )
+        self.down_res = _MiniResBlock(4, ch, time_dim)
+        self.down_attn = _MiniCrossAttn(ch, ctx_dim)
+        self.downsample = torch.nn.Conv2d(ch, ch, 3, stride=2, padding=1)
+        self.mid_res = _MiniResBlock(ch, ch, time_dim)
+        self.mid_attn = _MiniCrossAttn(ch, ctx_dim)
+        self.up_res = _MiniResBlock(ch * 2, ch, time_dim)
+        self.up_attn = _MiniCrossAttn(ch, ctx_dim)
+        self.out_conv = torch.nn.Conv2d(ch, 4, 3, padding=1)
+        self._time_in_dim = ch
+
+    def forward(self, sample, timestep, encoder_hidden_states):
+        t_emb = _sin_timestep_embedding(timestep, self._time_in_dim)
+        if t_emb.dim() == 1:
+            t_emb = t_emb.unsqueeze(0)
+        t_emb = self.time_mlp(t_emb)
+        # Down
+        h1 = self.down_res(sample, t_emb)
+        h1 = self.down_attn(h1, encoder_hidden_states)
+        h2 = self.downsample(h1)
+        # Mid
+        h2 = self.mid_res(h2, t_emb)
+        h2 = self.mid_attn(h2, encoder_hidden_states)
+        # Up
+        h2 = F.interpolate(h2, scale_factor=2, mode="nearest")
+        h = torch.cat([h2, h1], dim=1)
+        h = self.up_res(h, t_emb)
+        h = self.up_attn(h, encoder_hidden_states)
+        return self.out_conv(h)
+
+
+test_suite.add(
+    (
+        torch.randn(1, 4, 8, 8),
+        torch.tensor([10.0]),
+        torch.randn(1, 4, 16),
+    ),
+    MiniUNetLike(),
+    test_name="mini_unet_like",
+)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_model_zoo.py
+++ b/tests/test_model_zoo.py
@@ -366,6 +366,7 @@ class MiniUNetLike(torch.nn.Module):
     def __init__(self, ch: int = 8, ctx_dim: int = 16):
         super().__init__()
         time_dim = 4 * ch
+        self.ch = ch
         self.time_mlp = torch.nn.Sequential(
             torch.nn.Linear(ch, time_dim),
             torch.nn.SiLU(),
@@ -379,10 +380,9 @@ class MiniUNetLike(torch.nn.Module):
         self.up_res = _MiniResBlock(ch * 2, ch, time_dim)
         self.up_attn = _MiniCrossAttn(ch, ctx_dim)
         self.out_conv = torch.nn.Conv2d(ch, 4, 3, padding=1)
-        self._time_in_dim = ch
 
     def forward(self, sample, timestep, encoder_hidden_states):
-        t_emb = _sin_timestep_embedding(timestep, self._time_in_dim)
+        t_emb = _sin_timestep_embedding(timestep, self.ch)
         if t_emb.dim() == 1:
             t_emb = t_emb.unsqueeze(0)
         t_emb = self.time_mlp(t_emb)

--- a/tests/test_primitive.py
+++ b/tests/test_primitive.py
@@ -497,6 +497,38 @@ test_suite.add(
 )
 
 
+# torch.outer: 1-D x 1-D -> 2-D outer product. Lowered as two unsqueezes +
+# broadcasting mul.
+test_suite.add(
+    (torch.arange(4).float(), torch.arange(3).float() + 1),
+    BinaryPrimitive(torch.outer),
+    inference_conditions=skip_khronos_interpreter,
+)
+
+
+# split_with_sizes with shape-derived sizes (fused-qkv-style split). The
+# ratio list comes from a tensor expression, not a Python literal; this
+# exercises the TensorVariable unwrapping in split_with_sizes.
+class _FusedQKVSplit(nn.Module):
+    def __init__(self, dim: int = 9):
+        super().__init__()
+        # 9 -> three (3,) chunks for q / k / v
+        self.proj = nn.Linear(dim, dim)
+
+    def forward(self, x):
+        h = self.proj(x)
+        size = h.shape[-1] // 3
+        q, k, v = torch.split(h, [size, size, size], dim=-1)
+        return q + k * v
+
+
+test_suite.add(
+    torch.rand(2, 9),
+    _FusedQKVSplit(),
+    inference_conditions=skip_khronos_interpreter,
+)
+
+
 # mha basic
 hidden_dim = 4
 n_heads = 2

--- a/tests/test_primitive.py
+++ b/tests/test_primitive.py
@@ -502,9 +502,10 @@ test_suite.add(
 
 
 # torch.outer: 1-D x 1-D -> 2-D outer product. Lowered as two unsqueezes +
-# broadcasting mul.
+# broadcasting mul. Both operands start at 1 so every entry of the output
+# is non-zero and would catch a sign or value error in any row.
 test_suite.add(
-    (torch.arange(4).float(), torch.arange(3).float() + 1),
+    (torch.arange(4).float() + 1, torch.arange(3).float() + 1),
     BinaryPrimitive(torch.outer),
     inference_conditions=skip_khronos_interpreter,
 )

--- a/tests/test_primitive.py
+++ b/tests/test_primitive.py
@@ -74,8 +74,8 @@ for op in [
     torch.zeros_like,
     torch.ones_like,
     partial(torch.full_like, fill_value=2.0),
+    torch.reciprocal,
     # unimplemented tract {
-    # torch.reciprocal,
     # torch.clone,
     # partial(nn.functional.pad, pad=(0, 1), mode="replicate"),
     # }
@@ -424,6 +424,9 @@ for layer in [
     UnaryPrimitive(lambda x: x[..., :2, 1::2]),
     torch.nn.LayerNorm(10),
     torch.nn.LayerNorm((3, 10), eps=1e-5, elementwise_affine=True),
+    torch.nn.LayerNorm(10, elementwise_affine=False),
+    torch.nn.RMSNorm(10),
+    torch.nn.RMSNorm(10, elementwise_affine=False),
     torch.nn.GLU(),
 ]:
     test_suite.add(
@@ -472,6 +475,20 @@ test_suite.add(
     torch.arange(6).reshape(1, 2, 3).float(),
     UnaryPrimitive(torch.erf),
     inference_conditions=skip_khronos_interpreter,  # unssuported by interpreter
+)
+
+
+# torch.arange with dtype=float64 -- shows up in RoPE-style position embeds.
+# NNEF runtimes run it as f32 which is fine for integer-range / position math.
+class _ArangeF64Add(nn.Module):
+    def forward(self, x):
+        return x + torch.arange(x.shape[-1], dtype=torch.float64).to(x.dtype)
+
+
+test_suite.add(
+    torch.rand(1, 4),
+    _ArangeF64Add(),
+    inference_conditions=skip_khronos_interpreter,
 )
 
 

--- a/tests/test_primitive.py
+++ b/tests/test_primitive.py
@@ -432,6 +432,10 @@ if hasattr(torch.nn, "RMSNorm"):
     _norm_layers += [
         torch.nn.RMSNorm(10),
         torch.nn.RMSNorm(10, elementwise_affine=False),
+        # Multi-axis normalized_shape: forces the fragment fallback even on
+        # tract 0.22+ (native tract_transformers_rms_norm only takes a single
+        # integer ``axis``).
+        torch.nn.RMSNorm((3, 10)),
     ]
 for layer in _norm_layers:
     test_suite.add(

--- a/tests/test_primitive.py
+++ b/tests/test_primitive.py
@@ -417,7 +417,7 @@ for layer in [
     )
 
 
-for layer in [
+_norm_layers = [
     # test slice
     UnaryPrimitive(lambda x: x[:, 2:, :]),
     UnaryPrimitive(lambda x: x[..., 1::2]),
@@ -425,10 +425,15 @@ for layer in [
     torch.nn.LayerNorm(10),
     torch.nn.LayerNorm((3, 10), eps=1e-5, elementwise_affine=True),
     torch.nn.LayerNorm(10, elementwise_affine=False),
-    torch.nn.RMSNorm(10),
-    torch.nn.RMSNorm(10, elementwise_affine=False),
     torch.nn.GLU(),
-]:
+]
+# torch.nn.RMSNorm landed in PyTorch 2.4.
+if hasattr(torch.nn, "RMSNorm"):
+    _norm_layers += [
+        torch.nn.RMSNorm(10),
+        torch.nn.RMSNorm(10, elementwise_affine=False),
+    ]
+for layer in _norm_layers:
     test_suite.add(
         torch.rand(1, 3, 10),
         layer,

--- a/torch_to_nnef/op/aten/math.py
+++ b/torch_to_nnef/op/aten/math.py
@@ -189,9 +189,15 @@ def trunc(node, op_helper, **kwargs):
 def outer(node, op_helper, **kwargs):
     """Map PyTorch: 'aten:outer' to NNEF.
 
-    ``torch.outer(a, b)`` over 1D inputs is ``a[:, None] * b[None, :]``. Lower
-    to two unsqueezes and a broadcasting ``mul``. Use positive axes -- some
-    tract versions panic on negative ``unsqueeze`` axes during NNEF deser.
+    ``torch.outer(a, b)`` over 1-D inputs is ``a[:, None] * b[None, :]``.
+    Lower to two unsqueezes and a broadcasting ``mul``.
+
+    Axes are kept positive. Tract's NNEF unsqueeze deserializer
+    (``tract_core::ops::change_axes::AxisOp::change_shape``) does not
+    normalize negative axes and panics with ``smallvec: index exceeds
+    length``; verified across tract 0.20.22 through 0.23.0-dev.5. This
+    matches the wider t2n convention -- the dedicated ``unsqueeze`` op
+    handler also normalizes via ``pick_axis``.
     """
     a_node, b_node = node.inputs
     a = op_helper.get_or_add_tensor_variable_in_nnef(a_node)
@@ -222,11 +228,8 @@ def pow_(node, op_helper, **kwargs):
     """Map PyTorch: 'aten:pow' to NNEF."""
     (input_node, exponent_node) = node.inputs
     inputs = [op_helper.get_or_add_tensor_variable_in_nnef(input_node)]
-    # Special-case scalar 2 / -2 exponents only; anything else (tensor
-    # exponent, float, etc.) falls through to the generic ``pow`` op. Guard
-    # with a scalar-type check so tensor-valued exponents do not trigger
-    # Python's "Boolean value of Tensor ... is ambiguous" on the truthiness
-    # test below.
+    # Scalar 2 / -2 only -- isinstance check skips the truthiness branch on
+    # tensor-valued exponents (which would raise "ambiguous").
     exp_data = exponent_node.data
     if isinstance(exp_data, (int, float)) and exp_data in (2, -2):
         op_type = "sqr" if exp_data == 2 else "rsqr"

--- a/torch_to_nnef/op/aten/math.py
+++ b/torch_to_nnef/op/aten/math.py
@@ -185,22 +185,51 @@ def trunc(node, op_helper, **kwargs):
     return ["trunc"]
 
 
+@OP_REGISTRY.register()
+def outer(node, op_helper, **kwargs):
+    """Map PyTorch: 'aten:outer' to NNEF.
+
+    ``torch.outer(a, b)`` over 1D inputs is ``a[:, None] * b[None, :]``. Lower
+    to two unsqueezes and a broadcasting ``mul``. Use positive axes -- some
+    tract versions panic on negative ``unsqueeze`` axes during NNEF deser.
+    """
+    a_node, b_node = node.inputs
+    a = op_helper.get_or_add_tensor_variable_in_nnef(a_node)
+    b = op_helper.get_or_add_tensor_variable_in_nnef(b_node)
+    a_col = op_helper.add_single_output_op_from_nnef_tensors(
+        node,
+        "unsqueeze",
+        inputs=a,
+        attrs={"axes": [1]},
+        output_tensor_name_suffix="_col",
+    )
+    b_row = op_helper.add_single_output_op_from_nnef_tensors(
+        node,
+        "unsqueeze",
+        inputs=b,
+        attrs={"axes": [0]},
+        output_tensor_name_suffix="_row",
+    )
+    op_helper.add_single_output_op_from_nnef_tensors(
+        node,
+        "mul",
+        inputs=(a_col, b_row),
+    )
+
+
 @OP_REGISTRY.register(torch_op_ids=["pow"])
 def pow_(node, op_helper, **kwargs):
     """Map PyTorch: 'aten:pow' to NNEF."""
     (input_node, exponent_node) = node.inputs
     inputs = [op_helper.get_or_add_tensor_variable_in_nnef(input_node)]
-    if exponent_node.data:
-        exponent = exponent_node.data
-        if exponent == 2:
-            op_type = "sqr"
-        elif exponent == -2:
-            op_type = "rsqr"
-        else:
-            op_type = "pow"
-            inputs += [
-                op_helper.get_or_add_tensor_variable_in_nnef(exponent_node)
-            ]
+    # Special-case scalar 2 / -2 exponents only; anything else (tensor
+    # exponent, float, etc.) falls through to the generic ``pow`` op. Guard
+    # with a scalar-type check so tensor-valued exponents do not trigger
+    # Python's "Boolean value of Tensor ... is ambiguous" on the truthiness
+    # test below.
+    exp_data = exponent_node.data
+    if isinstance(exp_data, (int, float)) and exp_data in (2, -2):
+        op_type = "sqr" if exp_data == 2 else "rsqr"
     else:
         op_type = "pow"
         inputs += [op_helper.get_or_add_tensor_variable_in_nnef(exponent_node)]

--- a/torch_to_nnef/op/aten/norm.py
+++ b/torch_to_nnef/op/aten/norm.py
@@ -287,12 +287,34 @@ def layer_norm(g, node, name_to_tensor, null_ref, **kwargs):
     return [op_name]
 
 
+def prefer_native_tract_rms_norm(inference_target, mean_axes) -> bool:
+    """Return True when we should emit tract's native rms_norm primitive.
+
+    Native ``tract_transformers_rms_norm`` is registered through tract's
+    transformers extension, which t2n only auto-enables for tract >= 0.22.0
+    (see ``TractNNEF.assert_outputs_are_in_pytorch_tolerance``). It also takes
+    a single integer ``axis``, so we keep the multi-axis case on the fragment
+    fallback.
+    """
+    return (
+        isinstance(inference_target, TractNNEF)
+        and inference_target.version >= "0.22.0"
+        and len(mean_axes) == 1
+    )
+
+
 @OP_REGISTRY.register(["rms_norm"])
-def rms_norm(g, node, name_to_tensor, null_ref, **kwargs):
-    """Map PyTorch: 'aten:rms_norm' to a custom NNEF ``rms_norm`` fragment.
+def rms_norm(g, node, name_to_tensor, inference_target, null_ref, **kwargs):
+    """Map PyTorch: 'aten:rms_norm' to NNEF.
 
     Signature from ``torch.nn.functional.rms_norm``:
         ``rms_norm(input, normalized_shape, weight, eps)``
+
+    On tract >= 0.22.0 with a single normalized dim, emit the native
+    ``tract_transformers_rms_norm`` op (gives tract access to its optimized
+    GPU kernels and rewrite rules) and chain a ``mul`` for elementwise affine.
+    Multi-axis ``normalized_shape`` and non-tract targets fall back to the
+    custom ``rms_norm{,_with_affine}`` fragments.
     """
     (
         input_tensor_node,
@@ -307,6 +329,35 @@ def rms_norm(g, node, name_to_tensor, null_ref, **kwargs):
     eps = 1e-6 if eps_node.data is None else float(eps_node.data)
     weight_defined = weight_node.data is not None
     has_affine = weight_defined and not (weight_node.data == 1).all().tolist()
+
+    if prefer_native_tract_rms_norm(inference_target, mean_axes):
+        input_ref = get_or_add_tensor_variable_in_nnef(
+            g, input_tensor_node, name_to_tensor
+        )
+        rms_ref = add_single_output_op(
+            g,
+            node,
+            name_to_tensor,
+            nnef_op_type="tract_transformers_rms_norm",
+            inputs=[input_ref],
+            attrs={"axis": mean_axes[0], "eps": eps},
+            output_tensor_name_suffix="_rms" if has_affine else "",
+        )
+        if has_affine:
+            weight_ref = get_or_add_tensor_variable_in_nnef(
+                g, weight_node, name_to_tensor
+            )
+            add_single_output_op(
+                g,
+                node,
+                name_to_tensor,
+                nnef_op_type="mul",
+                inputs=[rms_ref, weight_ref],
+            )
+        return ["tract_transformers"]
+
+    # Fragment fallback: tract < 0.22.0, multi-axis normalized_shape, or
+    # non-tract targets (Khronos etc.).
     inputs = [input_tensor_node]
     op_name = "rms_norm"
     if has_affine:

--- a/torch_to_nnef/op/aten/norm.py
+++ b/torch_to_nnef/op/aten/norm.py
@@ -291,10 +291,10 @@ def prefer_native_tract_rms_norm(inference_target, mean_axes) -> bool:
     """Return True when we should emit tract's native rms_norm primitive.
 
     Native ``tract_transformers_rms_norm`` is registered through tract's
-    transformers extension, which t2n only auto-enables for tract >= 0.22.0
-    (see ``TractNNEF.assert_outputs_are_in_pytorch_tolerance``). It also takes
-    a single integer ``axis``, so we keep the multi-axis case on the fragment
-    fallback.
+    transformers extension, which t2n only auto-enables (via the
+    ``--nnef-tract-transformers`` CLI flag) for tract >= 0.22.0. The native
+    op also takes a single integer ``axis``, so multi-axis
+    ``normalized_shape`` keeps the fragment fallback.
     """
     return (
         isinstance(inference_target, TractNNEF)

--- a/torch_to_nnef/op/aten/norm.py
+++ b/torch_to_nnef/op/aten/norm.py
@@ -250,10 +250,17 @@ def layer_norm(g, node, name_to_tensor, null_ref, **kwargs):
         input_tensor_node.rank - r - 1
         for r, _ in enumerate(normalized_shape_node.data)
     )
-    has_affine = elementwise_affine_node.data and (
-        (bias_node.data is None or weight_node.data is None)
-        or not (
-            # check affine as any use
+    # has_affine is only true when both weight and bias are real tensors and
+    # at least one is non-identity (not all-1 / all-0). ``LayerNorm(...,
+    # elementwise_affine=False)`` leaves both at None -- the affine path would
+    # then crash trying to materialize None as an NNEF tensor.
+    weight_defined = weight_node.data is not None
+    bias_defined = bias_node.data is not None
+    has_affine = (
+        bool(elementwise_affine_node.data)
+        and weight_defined
+        and bias_defined
+        and not (
             (bias_node.data == 0).all().tolist()
             and (weight_node.data == 1).all().tolist()
         )

--- a/torch_to_nnef/op/aten/norm.py
+++ b/torch_to_nnef/op/aten/norm.py
@@ -287,6 +287,45 @@ def layer_norm(g, node, name_to_tensor, null_ref, **kwargs):
     return [op_name]
 
 
+@OP_REGISTRY.register(["rms_norm"])
+def rms_norm(g, node, name_to_tensor, null_ref, **kwargs):
+    """Map PyTorch: 'aten:rms_norm' to a custom NNEF ``rms_norm`` fragment.
+
+    Signature from ``torch.nn.functional.rms_norm``:
+        ``rms_norm(input, normalized_shape, weight, eps)``
+    """
+    (
+        input_tensor_node,
+        normalized_shape_node,
+        weight_node,
+        eps_node,
+    ) = node.inputs
+    mean_axes = sorted(
+        input_tensor_node.rank - r - 1
+        for r, _ in enumerate(normalized_shape_node.data)
+    )
+    eps = 1e-6 if eps_node.data is None else float(eps_node.data)
+    weight_defined = weight_node.data is not None
+    has_affine = weight_defined and not (weight_node.data == 1).all().tolist()
+    inputs = [input_tensor_node]
+    op_name = "rms_norm"
+    if has_affine:
+        op_name = "rms_norm_with_affine"
+        inputs += [weight_node]
+    add_single_output_op(
+        g,
+        node,
+        name_to_tensor,
+        nnef_op_type=op_name,
+        inputs=[
+            get_or_add_tensor_variable_in_nnef(g, _, name_to_tensor)
+            for _ in inputs
+        ],
+        attrs={"mean_axes": mean_axes, "eps": eps},
+    )
+    return [op_name]
+
+
 @OP_REGISTRY.register(["group_norm", "native_group_norm"])
 def group_norm(g, node, name_to_tensor, inference_target, **kwargs):
     """Translate operators `aten::group_norm` to NNEF.

--- a/torch_to_nnef/op/aten/split.py
+++ b/torch_to_nnef/op/aten/split.py
@@ -25,9 +25,6 @@ def split_with_sizes(g, node, name_to_tensor, **kwargs):
     """
     (input_node, ratio_node, axis_node) = node.inputs
     assert isinstance(axis_node, PythonConstant)
-    # ratio_node may be a PythonConstant or a TensorVariable whose data was
-    # shape-derived (e.g. ``x.shape[-1] // 3``); what matters is that we can
-    # pull concrete integer sizes out of it at trace time.
     if ratio_node.data is None:
         raise T2NErrorNotImplemented(
             "split_with_sizes requires statically-known sizes"

--- a/torch_to_nnef/op/aten/split.py
+++ b/torch_to_nnef/op/aten/split.py
@@ -16,14 +16,12 @@ OP_REGISTRY = AtenOpRegistry()
 def split_with_sizes(g, node, name_to_tensor, **kwargs):
     """Translate `aten::split_with_sizes` to NNEF.
 
-    We are aware that.
-    split<?>(
-        value: tensor<?>,
-        axis: integer,
-        ratios: integer[]
-    ) -> ( values: tensor<?>[] )
+    NNEF spec has a `split` op (value, axis, ratios -> tensor[]) but tract
+    does not register it, so we re-express each output as a `slice`.
 
-    exists but since tract does not support it, we reexpress it with slice
+    ``ratio_node`` may be a ``PythonConstant`` (literal sizes from the trace)
+    or a ``TensorVariable`` whose data is shape-derived (e.g. fused-qkv
+    splits like ``x.shape[-1] // 3``); both cases are unwrapped to plain ints.
     """
     (input_node, ratio_node, axis_node) = node.inputs
     assert isinstance(axis_node, PythonConstant)

--- a/torch_to_nnef/op/aten/split.py
+++ b/torch_to_nnef/op/aten/split.py
@@ -27,12 +27,28 @@ def split_with_sizes(g, node, name_to_tensor, **kwargs):
     """
     (input_node, ratio_node, axis_node) = node.inputs
     assert isinstance(axis_node, PythonConstant)
-    assert isinstance(ratio_node, PythonConstant)
+    # ratio_node may be a PythonConstant or a TensorVariable whose data was
+    # shape-derived (e.g. ``x.shape[-1] // 3``); what matters is that we can
+    # pull concrete integer sizes out of it at trace time.
+    if ratio_node.data is None:
+        raise T2NErrorNotImplemented(
+            "split_with_sizes requires statically-known sizes"
+        )
+    ratio_data = ratio_node.data
+    if hasattr(ratio_data, "tolist"):
+        ratio_data = ratio_data.tolist()
+
+    def _as_int(x):
+        if hasattr(x, "data"):
+            x = x.data
+        if hasattr(x, "item"):
+            x = x.item()
+        return int(x)
+
+    ratio_data = [_as_int(x) for x in ratio_data]
     current_dim_elm_idx = 0
     inputs = get_or_add_tensor_variable_in_nnef(g, input_node, name_to_tensor)
-    for out_node, n_elements in zip(
-        node.outputs, ratio_node.data, strict=False
-    ):
+    for out_node, n_elements in zip(node.outputs, ratio_data, strict=False):
         out = add_tensor_variable_node_as_nnef_tensor(
             g,
             out_node,

--- a/torch_to_nnef/op/aten/tensor_build.py
+++ b/torch_to_nnef/op/aten/tensor_build.py
@@ -45,8 +45,11 @@ def arange(g, node, name_to_tensor, inference_target, **kwargs):
             f"arange with {len(node.inputs)} inputs (see `ir_helpers` module)"
         )
 
-    if dtype_node.data not in [6, None, 4, 3]:  # accept float, int64, int
-        # see SCALAR_TYPE_TO_PYTORCH_TYPE for reference index
+    # see SCALAR_TYPE_TO_PYTORCH_TYPE for reference index:
+    #   3 = int32, 4 = int64, 6 = float32, 7 = float64
+    # float64 shows up in RoPE-style position embeds; NNEF runtimes execute
+    # the arange as f32 which is fine for integer-range / position math.
+    if dtype_node.data not in [6, None, 4, 3, 7]:
         raise T2NErrorNotImplemented(
             f"dtype {dtype_node} not implemented for arange"
         )

--- a/torch_to_nnef/op/aten/unary.py
+++ b/torch_to_nnef/op/aten/unary.py
@@ -1,3 +1,4 @@
+from torch_to_nnef.inference_target import TractNNEF
 from torch_to_nnef.op import helper
 
 REMAP_ATEN_OP_NAMES = {
@@ -14,6 +15,12 @@ REMAP_ATEN_OP_NAMES = {
     "reciprocal": "rcp",
     "minimum": "min",
     "maximum": "max",
+}
+
+# Ops whose standard NNEF spec name differs from tract's registered op name.
+TRACT_OP_ALIASES = {
+    # NNEF spec: ``rcp``; tract registers ``recip`` (ops::math::Recip).
+    "rcp": "recip",
 }
 
 GENERIC_UNARY_OUTPUT_ATEN_OP_NAMES = [
@@ -78,6 +85,9 @@ def generic_unary(aten_op_id, node, op_helper, **kwargs):
         'aten:logical_or', 'aten:reciprocal', 'aten:minimum', 'aten:maximum'
     """
     aten_op_id = REMAP_ATEN_OP_NAMES.get(aten_op_id, aten_op_id)
+    inference_target = kwargs.get("inference_target")
+    if isinstance(inference_target, TractNNEF):
+        aten_op_id = TRACT_OP_ALIASES.get(aten_op_id, aten_op_id)
     return op_helper.unary_output_op_without_attr(
         nnef_op_type=aten_op_id,
         node=node,

--- a/torch_to_nnef/op/fragment/rms_norm.nnef
+++ b/torch_to_nnef/op/fragment/rms_norm.nnef
@@ -1,0 +1,9 @@
+fragment rms_norm(
+    x: tensor<scalar>,
+    mean_axes: integer[],
+    eps: scalar
+) -> ( y: tensor<scalar> )
+{
+    inv_stdvar = rsqrt(sum_reduce(sqr(x), axes=mean_axes, normalize=true) + eps);
+    y = x * inv_stdvar;
+}

--- a/torch_to_nnef/op/fragment/rms_norm_with_affine.nnef
+++ b/torch_to_nnef/op/fragment/rms_norm_with_affine.nnef
@@ -1,0 +1,10 @@
+fragment rms_norm_with_affine(
+    x: tensor<scalar>,
+    gamma: tensor<scalar>,
+    mean_axes: integer[],
+    eps: scalar
+) -> ( y: tensor<scalar> )
+{
+    inv_stdvar = rsqrt(sum_reduce(sqr(x), axes=mean_axes, normalize=true) + eps);
+    y = x * inv_stdvar * gamma;
+}


### PR DESCRIPTION
## Summary

Tract-validated split of #69. Lands the SD 1.5 export examples + zoo tests, plus *all* op-level changes from that exploration -- each one paired with a primitive test that fails red on `main` and passes green on this branch (verified locally on tract 0.21.15 + 0.22.1).

What's in:

### Op fixes (all general, all with red->green primitive coverage)

| Op | Fix | Primitive test |
| --- | --- | --- |
| `pow` | scalar-only special-case for `sqr` / `rsqr`; tensor exponents fall through to generic `pow` | existing `partial(torch.pow, exponent=...)` cases |
| `outer` | new lowering: two `unsqueeze` + broadcasting `mul`, positive axes only (tract panics on negative `unsqueeze` axes across all sweeped versions 0.20.22 -> 0.23.0-dev.5) | `torch.outer(a, b)` -- new |
| `layer_norm` | `has_affine` requires both weight and bias to be real tensors (`nn.LayerNorm(elementwise_affine=False)` previously crashed on `None`) | `torch.nn.LayerNorm(10, elementwise_affine=False)` -- new |
| `split_with_sizes` | accepts a `TensorVariable` whose data is a shape-derived list of ints | `_FusedQKVSplit` -- new (asserts on `PythonConstant` would fail without the fix) |
| `rcp -> recip` | tract alias (NNEF spec is `rcp`, tract registers `recip`); guarded on `TractNNEF` so Khronos still emits the spec name | `torch.reciprocal` (was a commented-out "unimplemented tract" entry, now enabled) -- new |
| `arange dtype=float64` | whitelist relaxation; NNEF runtimes execute as f32, fine for integer-range / position math | `_ArangeF64Add` module -- new |
| `rms_norm` | tract >= 0.22.0 with single-axis `normalized_shape`: emit the native `tract_transformers_rms_norm` op (gives tract access to optimized GPU kernels and rewrite rules) + a `mul` for elementwise affine. Tract 0.21.x, multi-axis, and non-tract: fall back to two custom NNEF fragments (`rms_norm.nnef`, `rms_norm_with_affine.nnef`). | `torch.nn.RMSNorm(10)`, `RMSNorm(10, elementwise_affine=False)`, `RMSNorm((3, 10))` (multi-axis covers the fragment path on tract 0.22+) -- new |

### SD 1.5 export examples (validated `check_io=True`)

- `docs/examples/image_gen/sd15/vae_decoder.py` -- latent -> image, exercises NNEF `resize`.
- `docs/examples/image_gen/sd15/unet.py` -- noise predictor, ~860M params (~3.4 GB NNEF).
- Top-level `README.md`, `requirements.txt` (with upper pins), `.gitignore`; placeholder READMEs for `sdxl/` and `sd3/`.

### Zoo tests (no diffusers / no weight downloads, pass tract `check_io` on 0.21.15 + 0.22.1)

- `mini_vae_decoder_like` -- GroupNorm + 1/sqrt(d) self-attn + F.interpolate upsample + conv.
- `mini_unet_like` -- sinusoidal timestep + cross-attn + resnet + downsample/upsample.

## What's still deferred to a Flux follow-up

Just the Flux-specific scaffolding -- `docs/examples/image_gen/flux_schnell/transformer.py` and the mini Flux MM-DiT zoo test (currently has `check_io=False`). These wait on the two upstream tract panics still reproducing on tract `main`:

- `tract_transformers_sdpa` deserializer: `Undetermined symbol in expression` on Flux's RoPE'd Q/K shapes.
- `nnef::ops::nnef::deser::reshape`: range-end-out-of-range panic on Flux's reshape pattern.

Once those tract bugs land, the Flux example + zoo test come back as a small follow-up PR with `check_io=True` reactivated. The op support that Flux needs (`rms_norm`, `arange f64`, `rcp -> recip`) is already in this PR with its own primitive coverage, so the follow-up will be example + test only.

## Test plan

- [x] `ruff check` + `ruff format` clean.
- [x] Red->green verified per fix:
  - `torch.reciprocal`: tract panicked `No definition for operator Identifier("rcp")` -> passes after alias.
  - `arange dtype=float64`: raised `T2NErrorNotImplemented: dtype 7 not implemented for arange` -> passes after whitelist.
  - `LayerNorm(elementwise_affine=False)`: failed materializing `None` -> passes after `has_affine` tightening.
  - `RMSNorm`: op was unregistered -> passes via native op (>= 0.22.0) or fragment fallback.
  - `_FusedQKVSplit`: failed `assert isinstance(ratio_node, PythonConstant)` -> passes after `TensorVariable` unwrap.
- [x] Negative-`unsqueeze` axis sweep across cached tract 0.20.22 -> 0.23.0-dev.5: all panic at `tract_core::ops::change_axes::AxisOp::change_shape` (smallvec OOB) -- positive-axis workaround is permanent, no version gate needed.
- [x] `pytest tests/test_primitive.py` -- 638 passed, 0 failed.
- [x] `pytest tests/test_model_zoo.py -k "mini_vae_decoder_like or mini_unet_like"` -- 4 passed (2 tests x 2 tract versions, full `check_io`).
- [x] CI green on the full zoo + primitive matrix.
- [x] Native vs fragment paths inspected by extracting the emitted NNEF: tract 0.22.1 emits `tract_transformers_rms_norm(x, axis=2, eps=...)`; tract 0.21.15 and multi-axis 0.22.1 emit `rms_norm(x, mean_axes=[...], eps=...)` from the fragment.