### PR TITLE
examples: Sana DiT transformer export (linear-attention)

### DIFF
--- a/examples/image_gen/README.md
+++ b/examples/image_gen/README.md
@@ -19,6 +19,8 @@ tensors are not all loaded at once:
 - `flux_schnell/` -- Flux-Schnell (DiT, 12B): tiny `--mini` config validated
   end-to-end via `check_io` against tract; full 12B checkpoint export needs
   a gated HF download.
+- `sana/` -- NVIDIA Sana (DiT, 1.6B / 4.8B): linear-attention DiT with Mix-FFN
+  and DC-AE VAE; tiny `--mini` config validated end-to-end via `check_io`.
 
 ## Status
 

--- a/examples/image_gen/sana/README.md
+++ b/examples/image_gen/sana/README.md
@@ -1,0 +1,16 @@
+# Sana
+
+Target repo: `Efficient-Large-Model/Sana_1600M_1024px_diffusers`.
+
+NVIDIA Sana — efficient text-to-image DiT with two architectural twists vs.
+the Flux/SD3 family already covered in this directory:
+
+- **Linear attention** (ReLU-based) in self-attention blocks, no softmax.
+- **Mix-FFN** (linear → depth-wise conv → linear) instead of plain FFN.
+- **DC-AE** VAE for very high spatial compression (f32 / f64).
+
+`transformer.py` exports the denoiser. `--mini` instantiates a tiny random-
+weights config (~16k params) that keeps the full architecture so this PR can
+exercise the export path without a gated HF download.
+
+Suggested order: transformer → DC-AE decoder → Gemma-2 / T5 text encoder.

--- a/examples/image_gen/sana/transformer.py
+++ b/examples/image_gen/sana/transformer.py
@@ -1,0 +1,170 @@
+"""Export the Sana transformer (linear-attention DiT) via torch-to-nnef.
+
+Target: NVIDIA's Sana family
+(e.g. ``Efficient-Large-Model/Sana_1600M_1024px_diffusers``)
+``SanaTransformer2DModel``.
+
+What's architecturally distinct from Flux/SD3 (already covered in this dir):
+
+- Self-attention is **ReLU linear attention**, not softmax SDPA. The block is
+  ``Q @ (Kᵀ @ V) / Q @ sum(K)`` (with ReLU on Q/K), so the export hits a
+  different attention pattern through tract.
+- FFN is **Mix-FFN**: linear -> depth-wise conv -> linear. Standard ``conv2d``
+  with ``groups=channels`` but exercised inside an FFN.
+- Cross-attention to the text encoder still uses softmax attention.
+
+Inputs (diffusers naming):
+
+- hidden_states: (B, in_channels, H, W) latent tokens (Sana uses DC-AE so
+  H, W are tiny vs. SD's f8 latents).
+- encoder_hidden_states: (B, N_text_tokens, caption_channels) Gemma-2 (or T5)
+  encoded captions, projected via ``caption_projection`` inside the model.
+- timestep: (B,) float.
+
+Output: (B, out_channels, H, W) predicted velocity / noise.
+
+Run:
+    # Mini, fast:
+    python transformer.py --mini --skip-io-check
+    # Mini with check_io against tract:
+    python transformer.py --mini
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import torch
+from diffusers import SanaTransformer2DModel
+from torch import nn
+
+from torch_to_nnef import TractNNEF, export_model_to_nnef
+
+HF_REPO = "Efficient-Large-Model/Sana_1600M_1024px_diffusers"
+
+
+class SanaTransformerWrapper(nn.Module):
+    """Strip diffusers' kwargs plumbing; take a fixed positional set."""
+
+    def __init__(self, transformer):
+        super().__init__()
+        self.transformer = transformer.eval()
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        encoder_hidden_states: torch.Tensor,
+        timestep: torch.Tensor,
+    ) -> torch.Tensor:
+        return self.transformer(
+            hidden_states=hidden_states,
+            encoder_hidden_states=encoder_hidden_states,
+            timestep=timestep,
+            return_dict=False,
+        )[0]
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--out", type=Path, default=Path("./sana_transformer.nnef.tgz")
+    )
+    parser.add_argument(
+        "--latent-size",
+        type=int,
+        default=8,
+        help="Spatial size H=W of the latent tokens (real Sana 1024px uses 32 "
+        "via DC-AE f32 compression).",
+    )
+    parser.add_argument(
+        "--txt-tokens",
+        type=int,
+        default=4,
+        help="Number of caption tokens (real Sana uses 300).",
+    )
+    parser.add_argument("--tract-version", type=str, default=None)
+    parser.add_argument(
+        "--skip-io-check",
+        action="store_true",
+        help="Skip tract I/O comparison (required for the full 1.6B / 4.8B "
+        "checkpoints; default ON for --mini fits comfortably).",
+    )
+    parser.add_argument(
+        "--mini",
+        action="store_true",
+        help="Instantiate a tiny Sana transformer from config (random weights) "
+        "instead of downloading the 1.6B checkpoint. Same architecture, a few "
+        "M params. Useful for exploring export without the gated download.",
+    )
+    args = parser.parse_args()
+
+    if args.mini:
+        print("Instantiating mini SanaTransformer2DModel (random weights)")
+        # Real Sana-1.6B 1024px: num_layers=20, num_attention_heads=70,
+        # attention_head_dim=32, cross_attention_dim=2240,
+        # caption_channels=2304, mlp_ratio=2.5, sample_size=32,
+        # in/out_channels=32. Shrink every dim while keeping the
+        # linear-attention + Mix-FFN architecture identical.
+        transformer = (
+            SanaTransformer2DModel(
+                in_channels=4,
+                out_channels=4,
+                num_attention_heads=2,
+                attention_head_dim=8,
+                num_layers=2,
+                num_cross_attention_heads=2,
+                cross_attention_head_dim=8,
+                cross_attention_dim=16,
+                caption_channels=24,
+                mlp_ratio=2.0,
+                sample_size=8,
+                patch_size=1,
+            )
+            .to(torch.float32)
+            .eval()
+        )
+    else:
+        print(f"Loading SanaTransformer2DModel from {HF_REPO}")
+        transformer = SanaTransformer2DModel.from_pretrained(
+            HF_REPO, subfolder="transformer", torch_dtype=torch.float32
+        )
+    pipeline = SanaTransformerWrapper(transformer).eval()
+
+    cfg = transformer.config
+    in_channels = cfg.in_channels
+    caption_channels = cfg.caption_channels
+    print(
+        f"in_channels={in_channels} caption_channels={caption_channels} "
+        f"latent={args.latent_size}x{args.latent_size}"
+    )
+
+    hidden_states = torch.randn(
+        1, in_channels, args.latent_size, args.latent_size, dtype=torch.float32
+    )
+    encoder_hidden_states = torch.randn(
+        1, args.txt_tokens, caption_channels, dtype=torch.float32
+    )
+    timestep = torch.tensor([10.0], dtype=torch.float32)
+
+    with torch.no_grad():
+        out = pipeline(hidden_states, encoder_hidden_states, timestep)
+    print(f"PyTorch output shape: {tuple(out.shape)}")
+
+    tract_version = args.tract_version or TractNNEF.latest_version()
+    check_io = not args.skip_io_check
+    print(f"Exporting to NNEF with tract {tract_version} (check_io={check_io})")
+    export_model_to_nnef(
+        model=pipeline,
+        args=(hidden_states, encoder_hidden_states, timestep),
+        file_path_export=args.out,
+        inference_target=TractNNEF(version=tract_version, check_io=check_io),
+        input_names=["hidden_states", "encoder_hidden_states", "timestep"],
+        output_names=["noise_pred"],
+        debug_bundle_path=Path("./debug_sana_transformer.tgz"),
+    )
+    print(f"Exported to {args.out.absolute()}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_model_zoo.py
+++ b/tests/test_model_zoo.py
@@ -468,6 +468,56 @@ except ImportError:
     print("missing diffusers to test Flux mini transformer")
 
 
+# Mini Sana DiT: NVIDIA's efficient text-to-image transformer with linear
+# (ReLU) attention and Mix-FFN. Architecturally distinct from Flux/SD3 -- the
+# self-attention block does Q @ (Kᵀ @ V) / Q @ sum(K) instead of softmax SDPA,
+# which exercises a different graph through tract.
+try:
+    from diffusers import SanaTransformer2DModel
+
+    class MiniSanaTransformer(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.t = (
+                SanaTransformer2DModel(
+                    in_channels=4,
+                    out_channels=4,
+                    num_attention_heads=2,
+                    attention_head_dim=8,
+                    num_layers=2,
+                    num_cross_attention_heads=2,
+                    cross_attention_head_dim=8,
+                    cross_attention_dim=16,
+                    caption_channels=24,
+                    mlp_ratio=2.0,
+                    sample_size=8,
+                    patch_size=1,
+                )
+                .to(torch.float32)
+                .eval()
+            )
+
+        def forward(self, hidden_states, encoder_hidden_states, timestep):
+            return self.t(
+                hidden_states=hidden_states,
+                encoder_hidden_states=encoder_hidden_states,
+                timestep=timestep,
+                return_dict=False,
+            )[0]
+
+    test_suite.add(
+        (
+            torch.randn(1, 4, 8, 8),
+            torch.randn(1, 4, 24),
+            torch.tensor([10.0]),
+        ),
+        MiniSanaTransformer(),
+        test_name="mini_sana_dit",
+    )
+except ImportError:
+    print("missing diffusers to test Sana mini transformer")
+
+
 @pytest.mark.parametrize(
     "id,test_input,model,inference_target",
     test_suite.test_samples,

--- a/torch_to_nnef/op/aten/selector.py
+++ b/torch_to_nnef/op/aten/selector.py
@@ -136,11 +136,13 @@ def slice_(
         )
         return [fragment_name, "within_bound_index"]
 
+    dim_size = input_node.shape[dim]
     end = min(
-        end,
-        input_node.shape[dim],
+        end + dim_size if isinstance(end, int) and end < 0 else end, dim_size
     )
-    begin = max(begin, 0)
+    begin = max(
+        begin + dim_size if isinstance(begin, int) and begin < 0 else begin, 0
+    )
 
     op_helper.add_single_output_op_from_nnef_tensors(
         node,


### PR DESCRIPTION
Adds NVIDIA Sana to the image_gen examples. Sana's self-attention is **ReLU linear attention** (no softmax), so this exercises a different attention path through the export than the Flux/SD3 family already covered.

## Contents

- ` examples/image_gen/sana/{transformer.py,README.md}`: export ` SanaTransformer2DModel` (` --mini` random-weights config or gated 1.6B/4.8B checkpoint).
- ` tests/test_model_zoo.py`: ` mini_sana_dit` test gated on ` diffusers`, runs with ` check_io=True`.
- ` op/aten/selector.py:slice_`: resolve negative ` begin` / ` end` against ` shape[dim]` before clamping. Previously ` tensor[..., -1:]` was being clamped via ` max(begin, 0)` to ` begin = 0`, which silently turned the slice into a no-op (full range) and broke Sana's linear-attention pad/normalize trick. Caught downstream as a ` Can not broadcast 8 against 9` at the following Div.