### PR TITLE
feat: in-progress support for JIT-only PyTorch models

### DIFF
--- a/tests/test_lstm_cell.py
+++ b/tests/test_lstm_cell.py
@@ -1,0 +1,110 @@
+"""Tests for the LSTMCellExtractor and the JIT-derived input handling.
+
+These cover:
+- Standalone `nn.LSTMCell` exported via t2n + tract `check_io`.
+- The Silero-VAD-style case where input_size == hidden_size, which is the
+  trickier shape-disambiguation path in the extractor.
+- The new `strip_assertion_ifs` JIT pass and the constant/getattr extensions
+  (`List[int]` constant + non-Tensor `prim::GetAttr`) by going through an
+  inlined LSTMCell graph end-to-end via `_jit_pass_inline`.
+"""
+
+from copy import deepcopy
+
+import pytest
+import torch
+from torch import nn
+
+from torch_to_nnef.torch_graph import strip_assertion_ifs
+
+from .utils import TRACT_INFERENCES_TO_TESTS_APPROX, check_model_io_test
+
+
+class LSTMCellWrapper(nn.Module):
+    def __init__(self, in_size: int, hidden: int):
+        super().__init__()
+        self.cell = nn.LSTMCell(in_size, hidden)
+
+    def forward(self, x, h, c):
+        h_new, c_new = self.cell(x, (h, c))
+        return h_new, c_new
+
+
+@pytest.mark.parametrize("inference_target", TRACT_INFERENCES_TO_TESTS_APPROX)
+def test_lstm_cell_distinct_sizes(inference_target):
+    """input_size != hidden_size: shape disambiguates input vs (h, c)."""
+    in_size, hidden = 8, 4
+    batch = 2
+    module = LSTMCellWrapper(in_size, hidden)
+    inference_target = deepcopy(inference_target)
+    check_model_io_test(
+        model=module,
+        test_input=(
+            torch.randn(batch, in_size),
+            torch.randn(batch, hidden),
+            torch.randn(batch, hidden),
+        ),
+        input_names=["x", "h", "c"],
+        output_names=["h_new", "c_new"],
+        inference_target=inference_target,
+    )
+
+
+@pytest.mark.parametrize("inference_target", TRACT_INFERENCES_TO_TESTS_APPROX)
+def test_lstm_cell_equal_sizes(inference_target):
+    """Cover input_size == hidden_size (Silero-VAD's 128/128 case).
+
+    Shape alone cannot disambiguate the cell-call inputs; the extractor
+    must rely on positional ordering of the trace.
+    """
+    in_size = hidden = 6
+    batch = 3
+    module = LSTMCellWrapper(in_size, hidden)
+    inference_target = deepcopy(inference_target)
+    check_model_io_test(
+        model=module,
+        test_input=(
+            torch.randn(batch, in_size),
+            torch.randn(batch, hidden),
+            torch.randn(batch, hidden),
+        ),
+        input_names=["x", "h", "c"],
+        output_names=["h_new", "c_new"],
+        inference_target=inference_target,
+    )
+
+
+def test_strip_assertion_ifs_drops_dim_check_branches():
+    """Strip nn.LSTMCell's compiled-in input-dim assertion branch.
+
+    nn.LSTMCell carries `if input.dim() not in (1, 2): raise`, which becomes
+    a `prim::If` whose true branch only raises. After inline + DCE +
+    strip_assertion_ifs the count should drop while the model output stays
+    bitwise-identical.
+    """
+    cell = nn.LSTMCell(8, 4).eval()
+    scripted = torch.jit.script(cell)
+    torch._C._jit_pass_inline(scripted.graph)
+    torch._C._jit_pass_dce(scripted.graph)
+    n_if_before = sum(
+        1 for n in scripted.graph.nodes() if n.kind() == "prim::If"
+    )
+    stripped = strip_assertion_ifs(scripted.graph)
+    torch._C._jit_pass_dce(scripted.graph)
+
+    # We expect at least the input-dim check to have been stripped.
+    assert stripped >= 1, (
+        f"strip_assertion_ifs should fold at least the input.dim() check "
+        f"(stripped={stripped}, n_if_before={n_if_before})"
+    )
+
+    # Output parity vs the un-stripped cell.
+    cell_ref = nn.LSTMCell(8, 4).eval()
+    cell_ref.load_state_dict(cell.state_dict())
+    x = torch.randn(2, 8)
+    h = torch.zeros(2, 4)
+    c = torch.zeros(2, 4)
+    h_ref, c_ref = cell_ref(x, (h, c))
+    h_new, c_new = scripted(x, (h, c))
+    assert torch.allclose(h_new, h_ref, atol=1e-7)
+    assert torch.allclose(c_new, c_ref, atol=1e-7)

--- a/torch_to_nnef/op/custom_extractors/__init__.py
+++ b/torch_to_nnef/op/custom_extractors/__init__.py
@@ -20,6 +20,7 @@ from torch_to_nnef.op.custom_extractors.base import (
 # load default custom registries
 from torch_to_nnef.op.custom_extractors.rnn import (
     GRUExtractor,
+    LSTMCellExtractor,
     LSTMExtractor,
     RNNExtractor,
 )
@@ -29,5 +30,6 @@ __all__ = [
     "ModuleInfoExtractor",
     "RNNExtractor",
     "LSTMExtractor",
+    "LSTMCellExtractor",
     "GRUExtractor",
 ]

--- a/torch_to_nnef/op/custom_extractors/rnn.py
+++ b/torch_to_nnef/op/custom_extractors/rnn.py
@@ -996,3 +996,328 @@ class RNNExtractor(_RNNMixin, ModuleInfoExtractor):
             ],
             **tensor_params_kwargs,
         )
+
+
+class LSTMCellExtractor(ModuleInfoExtractor):
+    """Decompose `nn.LSTMCell` into primitive NNEF ops.
+
+    Unlike `nn.LSTM`, an LSTMCell carries a single time-step. We emit:
+        preact = matmul(input, w_ih, T) + matmul(h, w_hh, T) + b_ih + b_hh
+        i, f, g, o = chunk(preact, 4, axis=-1)
+        c_new = sigmoid(f) * c + sigmoid(i) * tanh(g)
+        h_new = sigmoid(o) * tanh(c_new)
+
+    Input order from the user-facing wrapper is `(input, h, c)` -- the
+    internal nn.LSTMCell call expects `(input, (h, c))` which is handled by
+    `_call_original_mod_with_args`.
+    """
+
+    MODULE_CLASS = nn.LSTMCell
+
+    def ordered_args(self, torch_graph):
+        """Reorder args so the first one is `input` (shape (B, input_size)).
+
+        t2n's IR sometimes reorders the cell's inputs after FixedTensorList /
+        tuple expansion, surfacing them as e.g. (h, input, c). The cell's
+        `input_size` (= weight_ih.shape[1]) lets us pick the input tensor by
+        shape; the relative order of (h, c) follows the JIT graph's
+        prim::ListConstruct that builds hx.
+        """
+        cell = torch_graph.tracer.mod
+        in_size = cell.input_size
+        args = list(torch_graph.tracer.args)
+        if len(args) != 3:
+            return args
+        input_idx = next(
+            (
+                i
+                for i, a in enumerate(args)
+                if hasattr(a, "shape")
+                and len(a.shape) == 2
+                and a.shape[1] == in_size
+            ),
+            None,
+        )
+        if input_idx is None:
+            return args
+        input_arg = args.pop(input_idx)
+        return [input_arg, *args]
+
+    @staticmethod
+    def _reorder_cell_inputs(inputs, cell: nn.LSTMCell):
+        """Identify `input` and the (h, c) state tensors among the IR inputs.
+
+        When `input_size != hidden_size`, shape uniquely identifies `input`.
+        When they are equal (e.g. Silero-VAD's 128/128 cell), we rely on
+        the empirically-observed JIT trace ordering: PyTorch's tracer
+        emits the cell-call args as `(h, input, c)` because the `hx`
+        tuple's first element is spliced before the `input` slot during
+        positional flattening.
+
+        After picking `input`, the other two inputs are returned as (h, c)
+        in their IR list order.
+        """
+        in_size = cell.input_size
+        h_size = cell.hidden_size
+        if len(inputs) != 3:
+            return (
+                inputs[0],
+                inputs[1] if len(inputs) > 1 else None,
+                (inputs[2] if len(inputs) > 2 else None),
+            )
+
+        if in_size != h_size:
+            input_idx = next(
+                (
+                    i
+                    for i, t in enumerate(inputs)
+                    if t.shape and t.shape[-1] == in_size
+                ),
+                None,
+            )
+            if input_idx is None:
+                input_idx = 0
+        else:
+            # Ambiguous shapes -- use position 1 (the empirical (h, input, c)
+            # ordering of the trace).
+            input_idx = 1
+
+        rest = [t for i, t in enumerate(inputs) if i != input_idx]
+        return inputs[input_idx], rest[0], rest[1]
+
+    @staticmethod
+    def _call_original_mod_with_args(mod, *args):
+        return mod(args[0], (args[1], args[2]))
+
+    def _extract_outputs(self, torch_graph, provided_outputs, results):
+        """Override base behavior.
+
+        Base `_extract_outputs` computes `used_outputs_order` from the
+        cell-graph outputs' SSA offsets within their producer nodes; that
+        assumes a single multi-output op (lstm/lstm_cell). nn.LSTMCell
+        traces actually decompose into separate sigmoid/tanh/mul nodes, so
+        offsets all collapse to 0 and the duplicated index corrupts the
+        output mapping. We have a fixed signature `(h_new, c_new)`, so
+        identity mapping is correct.
+        """
+        # pylint: disable-next=import-outside-toplevel
+        from torch_to_nnef import torch_graph as tg
+
+        if (
+            provided_outputs is not None
+            and isinstance(provided_outputs[0], tg.ir_data.TupleTensors)
+            and len(provided_outputs) == 1
+        ):
+            provided_outputs = provided_outputs[0].data
+        expanded_results = self._expand_results(results)
+        outputs = []
+        for idx, result in enumerate(expanded_results):
+            if provided_outputs and idx < len(provided_outputs):
+                tv = provided_outputs[idx]
+            else:
+                tv = tg.TensorVariable(
+                    name=f"{self._cname_slug}_output_{idx}",
+                    shape=list(result.shape),
+                    dtype=result.dtype,
+                    quant=None,
+                    data=None,
+                )
+            outputs.append(tv)
+        return outputs, outputs
+
+    def convert_to_nnef(
+        self,
+        g,
+        node,
+        name_to_tensor,
+        null_ref,
+        torch_graph,
+        inference_target,
+        **kwargs,
+    ):
+        # pylint: disable-next=import-outside-toplevel
+        from torch_to_nnef.op import helper
+
+        cell: nn.LSTMCell = node.op_ref
+        if len(node.inputs) != 3:
+            raise T2NErrorNotImplemented(
+                "LSTMCellExtractor requires (input, h, c); "
+                f"got {len(node.inputs)} inputs"
+            )
+        if len(node.outputs) != 2:
+            raise T2NErrorNotImplemented(
+                "LSTMCellExtractor expects 2 outputs (h_new, c_new); "
+                f"got {len(node.outputs)}"
+            )
+
+        # The t2n IR may surface (input, h, c) in any order after tuple
+        # expansion at the call site. Identify `input` by shape and order
+        # the rest positionally (relying on `_extract_outputs` having mapped
+        # provided_outputs[0] = h_new, [1] = c_new).
+        input_tv, h_prev_tv, c_prev_tv = self._reorder_cell_inputs(
+            node.inputs, cell
+        )
+        h_new_tv, c_new_tv = node.outputs
+
+        hidden = cell.hidden_size
+
+        input_ref = helper.get_or_add_tensor_variable_in_nnef(
+            g, input_tv, name_to_tensor
+        )
+        h_prev_ref = helper.get_or_add_tensor_variable_in_nnef(
+            g, h_prev_tv, name_to_tensor
+        )
+        c_prev_ref = helper.get_or_add_tensor_variable_in_nnef(
+            g, c_prev_tv, name_to_tensor
+        )
+
+        base = node.outputs[0].export_name
+        nnef_dtype = input_ref.dtype
+
+        def add_weight(t: torch.Tensor, name: str) -> NTensor:
+            tv = helper.TensorVariable(
+                name=getattr(t, "nnef_name", f"{base}_{name}"),
+                data=t.detach(),
+                shape=list(t.shape),
+                dtype=t.dtype,
+            )
+            return helper.get_or_add_tensor_variable_in_nnef(
+                g, tv, name_to_tensor, name_suffix=name
+            )
+
+        w_ih_ref = add_weight(cell.weight_ih, "weight_ih")
+        w_hh_ref = add_weight(cell.weight_hh, "weight_hh")
+
+        if cell.bias and cell.bias_ih is not None and cell.bias_hh is not None:
+            # Pre-sum the two biases (PyTorch adds them) and unsqueeze to
+            # (1, 4H) so it broadcasts across the (B, 4H) preactivation.
+            b_combined = (cell.bias_ih + cell.bias_hh).unsqueeze(0)
+            b_ref = add_weight(b_combined, "bias")
+        else:
+            b_ref = None
+
+        def new_tensor(suffix: str, shape: T.Sequence[int]) -> NTensor:
+            t = NTensor(
+                g, name=f"{base}_{suffix}", dtype=nnef_dtype, shape=tuple(shape)
+            )
+            name_to_tensor[t.name] = t
+            return t
+
+        def emit(op_type: str, inputs, attribs, suffix: str, shape):
+            out = new_tensor(suffix, shape)
+            NOperation(
+                graph=g,
+                type=op_type,
+                inputs=inputs if isinstance(inputs, tuple) else tuple(inputs),
+                outputs=out,
+                attribs=attribs,
+            )
+            return out
+
+        batch_dim = (
+            input_tv.shape[0]
+            if input_tv.shape and input_tv.shape[0] is not None
+            else 1
+        )
+        four_h = 4 * hidden
+
+        preact_x = emit(
+            "matmul",
+            (input_ref, w_ih_ref),
+            {"transposeA": False, "transposeB": True},
+            "preact_x",
+            [batch_dim, four_h],
+        )
+        preact_h = emit(
+            "matmul",
+            (h_prev_ref, w_hh_ref),
+            {"transposeA": False, "transposeB": True},
+            "preact_h",
+            [batch_dim, four_h],
+        )
+        if b_ref is not None:
+            preact_xh = emit(
+                "add",
+                (preact_x, preact_h),
+                {},
+                "preact_xh",
+                [batch_dim, four_h],
+            )
+            preact = emit(
+                "add",
+                (preact_xh, b_ref),
+                {},
+                "preact",
+                [batch_dim, four_h],
+            )
+        else:
+            preact = emit(
+                "add",
+                (preact_x, preact_h),
+                {},
+                "preact",
+                [batch_dim, four_h],
+            )
+
+        def slice_gate(idx: int, suffix: str) -> NTensor:
+            return emit(
+                "slice",
+                (preact,),
+                {
+                    "axes": [1],
+                    "begin": [idx * hidden],
+                    "end": [(idx + 1) * hidden],
+                    "stride": [1],
+                },
+                suffix,
+                [batch_dim, hidden],
+            )
+
+        i_pre = slice_gate(0, "i_pre")
+        f_pre = slice_gate(1, "f_pre")
+        g_pre = slice_gate(2, "g_pre")
+        o_pre = slice_gate(3, "o_pre")
+
+        i_t = emit("sigmoid", (i_pre,), {}, "i", [batch_dim, hidden])
+        f_t = emit("sigmoid", (f_pre,), {}, "f", [batch_dim, hidden])
+        g_t = emit("tanh", (g_pre,), {}, "g", [batch_dim, hidden])
+        o_t = emit("sigmoid", (o_pre,), {}, "o", [batch_dim, hidden])
+
+        f_c = emit(
+            "mul", (f_t, c_prev_ref), {}, "f_times_c", [batch_dim, hidden]
+        )
+        i_g = emit("mul", (i_t, g_t), {}, "i_times_g", [batch_dim, hidden])
+
+        # Final outputs: bind to the IR's expected names so downstream graph
+        # consumers wire up correctly.
+        c_new_ref = helper.add_tensor_variable_node_as_nnef_tensor(
+            g,
+            c_new_tv,
+            name_to_tensor,
+            prevent_variable=True,
+        )
+        NOperation(
+            graph=g,
+            type="add",
+            inputs=(f_c, i_g),
+            outputs=c_new_ref,
+            attribs={},
+        )
+
+        tanh_c = emit(
+            "tanh", (c_new_ref,), {}, "tanh_c_new", [batch_dim, hidden]
+        )
+        h_new_ref = helper.add_tensor_variable_node_as_nnef_tensor(
+            g,
+            h_new_tv,
+            name_to_tensor,
+            prevent_variable=True,
+        )
+        NOperation(
+            graph=g,
+            type="mul",
+            inputs=(o_t, tanh_c),
+            outputs=h_new_ref,
+            attribs={},
+        )
+        return []

--- a/torch_to_nnef/torch_graph/__init__.py
+++ b/torch_to_nnef/torch_graph/__init__.py
@@ -30,6 +30,7 @@ from torch_to_nnef.torch_graph.ir_graph import (
 )
 from torch_to_nnef.torch_graph.ir_module_tracer import TorchModuleTracer
 from torch_to_nnef.torch_graph.ir_op import TorchOp
+from torch_to_nnef.torch_graph.jit_passes import strip_assertion_ifs
 from torch_to_nnef.torch_graph.torch_const import MAP_TO_NOP
 
 __all__ = [
@@ -42,4 +43,5 @@ __all__ = [
     "MAP_TO_NOP",
     "module_tracer_into_ir_graph",
     "TorchModuleIRGraph",
+    "strip_assertion_ifs",
 ]

--- a/torch_to_nnef/torch_graph/ir_helpers.py
+++ b/torch_to_nnef/torch_graph/ir_helpers.py
@@ -254,14 +254,34 @@ def _find_data_node(data_nodes: ReactiveNamedItemDict, name: str):
 
 
 def _parse_getattr_tensor(node: torch._C.Node, module, data_nodes):
-    data_state = _unfold_graph_getattr_by_node(module, node)[1].data
-    data_nodes.append(
-        TensorVariable(
-            name=node.output().debugName(),
-            shape=list(data_state.shape),
-            dtype=data_state.dtype,
-            data=data_state,
+    """Resolve a `prim::GetAttr` node into a Data entry.
+
+    Inlined JIT graphs (see `torch._C._jit_pass_inline`) surface attribute
+    accesses for both tensors (parameters/buffers) and Python scalars
+    (e.g. an int field like `context_size_samples` registered on the module).
+    Tensors become a TensorVariable; bool/int/float/str/None attrs become a
+    PythonConstant. Anything else is rejected.
+    """
+    name = node.output().debugName()
+    attr = _unfold_graph_getattr_by_node(module, node)[1]
+    if isinstance(attr, torch.Tensor):
+        data_nodes.append(
+            TensorVariable(
+                name=name,
+                shape=list(attr.shape),
+                dtype=attr.dtype,
+                data=attr,
+            )
         )
+        return
+    # Order matters: bool subclasses int in Python, but isinstance against the
+    # tuple still returns True so the PythonConstant carries the original value.
+    if attr is None or isinstance(attr, (bool, int, float, str)):
+        data_nodes.append(PythonConstant(name=name, data=attr))
+        return
+    raise T2NErrorNotImplemented(
+        f"prim::GetAttr resolves to unsupported type "
+        f"{type(attr).__name__} for {name}"
     )
 
 
@@ -307,6 +327,12 @@ def _parse_constant(node: torch._C.Node, data_nodes) -> T.Optional[Data]:
         # Device will not be useful info for us but we pass it to avoid
         # dereferencing it from full graph
         pass
+    elif dtype.startswith("List["):
+        # Inlined/frozen JIT graphs may carry list constants
+        # (e.g. dilation=[1] baked into aten::conv1d) that would otherwise
+        # come from a prim::ListConstruct.
+        ivalue = node.output().toIValue()
+        data = list(ivalue) if ivalue is not None else []
     else:
         raise T2NErrorNotImplemented(dtype)
     data_nodes.append(PythonConstant(name=name, data=data))

--- a/torch_to_nnef/torch_graph/ir_op.py
+++ b/torch_to_nnef/torch_graph/ir_op.py
@@ -613,6 +613,13 @@ class TorchOp:
         """Trace output and try to find type shape and constant realisation."""
         if self.kind == CALL_KIND:
             return False
+        # nn.LSTMCell carries an `(input, hx)` Python signature where `hx` is
+        # a tuple. The IR flattens that to `(input, h, c)` (and reorders
+        # them positionally), so calling `op_ref(*self.args)` to infer
+        # shapes raises a TypeError. The LSTMCellExtractor sets shapes on
+        # its outputs explicitly so this fallback is unnecessary anyway.
+        if self.kind == "wired_custom::LSTMCell":
+            return False
 
         if not all(_.tracable for _ in self.inputs):
             return False

--- a/torch_to_nnef/torch_graph/jit_passes.py
+++ b/torch_to_nnef/torch_graph/jit_passes.py
@@ -1,0 +1,103 @@
+"""Reusable JIT-graph passes for hardening JIT-only models against t2n parsing.
+
+These helpers are useful when the source model arrives as a `torch.jit.JIT`
+artifact (e.g. Silero-VAD's `silero_vad.jit`) whose Python source isn't on
+the import path. After `torch._C._jit_pass_inline` flattens the graph,
+PyTorch's compiled-in dim/shape assertions (notably inside `nn.LSTMCell`
+and STFT helpers) leave behind `prim::If` nodes whose only effect on one
+branch is to raise an exception. Those branches feed scalar-typed
+arithmetic that t2n's tensor-oriented parser cannot represent, so we drop
+them.
+"""
+
+from __future__ import annotations
+
+import typing as T
+
+import torch
+
+ASSERTION_BLOCK_KINDS: T.Tuple[str, ...] = (
+    "prim::Constant",
+    "prim::ListConstruct",
+    "prim::TupleConstruct",
+    "prim::RaiseException",
+    "aten::format",
+    "aten::__getitem__",
+    "aten::__contains__",
+    "aten::__not__",
+    "aten::dim",
+    "aten::eq",
+    "aten::ne",
+    "aten::Int",
+    "aten::str",
+    "aten::add",
+    "aten::mul",
+    "prim::dtype",
+    "prim::device",
+)
+
+
+def _walk_nodes(graph_or_block):
+    """Yield nodes recursively, descending into prim::If / prim::Loop blocks."""
+    for node in graph_or_block.nodes():
+        yield node
+        for blk in node.blocks():
+            yield from _walk_nodes(blk)
+
+
+def _block_only_raises(block) -> bool:
+    """Return True iff the block is purely an assertion / RaiseException.
+
+    A no-op-with-exception block consists only of side-effect-free constant /
+    ad-hoc ops preparing the exception, ending in a RaiseException.
+
+    Intentionally conservative: any unrecognized op disqualifies the block
+    so we never strip a branch that may have observable side effects on
+    the rest of the graph.
+    """
+    nodes = list(block.nodes())
+    if not nodes:
+        return False
+    if nodes[-1].kind() != "prim::RaiseException":
+        return False
+    return all(n.kind() in ASSERTION_BLOCK_KINDS for n in nodes)
+
+
+def strip_assertion_ifs(graph: "torch._C.Graph") -> int:
+    """Drop `prim::If` nodes whose one branch is purely a `RaiseException`.
+
+    Replace uses of the If's outputs with the non-raising block's outputs,
+    then destroy the If. Walks nested blocks (assertion ifs are often
+    inside other prim::If branches). Returns the count of stripped nodes.
+    """
+    changed = True
+    total = 0
+    while changed:
+        changed = False
+        for node in list(_walk_nodes(graph)):
+            if node.kind() != "prim::If":
+                continue
+            blocks = list(node.blocks())
+            if len(blocks) != 2:
+                continue
+            true_blk, false_blk = blocks
+            if _block_only_raises(true_blk):
+                keep = false_blk
+            elif _block_only_raises(false_blk):
+                keep = true_blk
+            else:
+                continue
+            keep_outs = list(keep.returnNode().inputs())
+            node_outs = list(node.outputs())
+            if len(keep_outs) != len(node_outs):
+                continue
+            for old, new in zip(node_outs, keep_outs, strict=True):
+                old.replaceAllUsesWith(new)
+            for n in list(keep.nodes()):
+                n.moveBefore(node)
+            node.destroy()
+            changed = True
+            total += 1
+            # Iterators over a parent block may now be invalidated; restart.
+            break
+    return total


### PR DESCRIPTION
## Summary

Foundation for the JIT-only model support stack. Surfaces a few minimal IR fixes that come up immediately when t2n's recursive parser meets a JIT artifact whose Python source isn't on the import path:

- `_parse_constant`: handle `List[int|float|bool]` baked into frozen JIT graphs.
- `_parse_getattr_tensor`: accept non-Tensor module attributes (int/float/bool/str/None) as `PythonConstant`.
- `LSTMCellExtractor` (new): module-level extractor for `nn.LSTMCell`. Replaced by the fragment-based path in #83. Kept here as the seed.
- `strip_assertion_ifs` (new, `torch_graph.jit_passes`): drop `prim::If` whose one branch is a pure `RaiseException`, walking nested blocks. Picks up PyTorch's compiled-in dim-check assertions inside `nn.LSTMCell`.

A demo example using a Python re-implementation of Silero-VAD was originally bundled here. It's removed: the reimpl path defeats the purpose of the JIT-only support work. A real demo exporting from the actual JIT artifact will land at the end of the stack once the chain (Phases 1 -> 7) is complete.

This is the bottom of the stack. The phases that follow (#79 selective inline, #81 reach-analysis size folds, #82 scalar SSA outputs, #83 lstm_cell fragment, #84 standalone constant folds + JIT-only docs, #85 canonical aten/RNN orchestration) build on these IR fixes.