### PR TITLE
examples: Pocket-TTS flow_net export (TTS, PR A of 3)

### DIFF
--- a/examples/tts/pocket_tts/flow_net.py
+++ b/examples/tts/pocket_tts/flow_net.py
@@ -1,0 +1,108 @@
+"""Export Pocket-TTS' flow_net (``SimpleMLPAdaLN``) via torch-to-nnef.
+
+The flow_net is the small AdaLN-modulated MLP that turns one Gaussian noise
+sample into a denoised audio latent, conditioned on the FlowLM transformer's
+output. It is called ``lsd_decode_steps`` times (default 4) per generated
+audio frame -- the Rust runtime will invoke this graph once per inner step
+of the LSD decode loop, so it ships as its own NNEF artifact.
+
+Forward signature (matches ``SimpleMLPAdaLN.forward``):
+
+    flow_net(c, s, t, x) -> flow_dir
+
+- c : (B, cond_channels)  conditioning from FlowLM (transformer_out).
+- s : (B, 1)              start time of this LSD step (scalar in [0, 1]).
+- t : (B, 1)              target time of this LSD step.
+- x : (B, ldim)           current latent (Gaussian noise on the first step,
+                          partially denoised on subsequent steps).
+- flow_dir : (B, ldim)    flow direction; the runtime adds ``flow_dir / K`` to
+                          ``x`` between steps.
+
+Run:
+    # Mini, fast (random weights, ~13k params, no HF download):
+    python flow_net.py --mini --skip-io-check
+    # Mini with check_io against tract:
+    python flow_net.py --mini
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import torch
+from pocket_tts.modules.mlp import SimpleMLPAdaLN
+
+from torch_to_nnef import TractNNEF, export_model_to_nnef
+
+
+def build_mini_flow_net() -> SimpleMLPAdaLN:
+    """Tiny SimpleMLPAdaLN mirroring Pocket-TTS' real flow config.
+
+    Real Pocket-TTS: ``model_channels=512``, ``num_res_blocks=8``,
+    ``cond_channels=512``, ``ldim=64``. Here we shrink every dim while keeping
+    the AdaLN-modulated residual structure identical.
+    """
+    return SimpleMLPAdaLN(
+        in_channels=8,
+        model_channels=16,
+        out_channels=8,
+        cond_channels=24,
+        num_res_blocks=2,
+        num_time_conds=2,
+    ).eval()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--out", type=Path, default=Path("./pocket_tts_flow_net.nnef.tgz")
+    )
+    parser.add_argument("--tract-version", type=str, default=None)
+    parser.add_argument(
+        "--skip-io-check",
+        action="store_true",
+        help="Skip tract I/O comparison (only validates the graph emit).",
+    )
+    parser.add_argument(
+        "--mini",
+        action="store_true",
+        default=True,
+        help="Tiny random-weights config (default; only mode supported "
+        "today). Real flow_net export will load Pocket-TTS' published weights.",
+    )
+    args = parser.parse_args()
+
+    torch.manual_seed(0)
+    model = build_mini_flow_net()
+    print(f"flow_net params: {sum(p.numel() for p in model.parameters())}")
+
+    batch = 1
+    cond_dim = model.cond_embed.in_features
+    ldim = model.in_channels
+    cond = torch.randn(batch, cond_dim, dtype=torch.float32)
+    t_start = torch.zeros(batch, 1, dtype=torch.float32)
+    t_end = torch.full((batch, 1), 0.25, dtype=torch.float32)
+    x = torch.randn(batch, ldim, dtype=torch.float32)
+
+    with torch.no_grad():
+        flow_dir = model(cond, t_start, t_end, x)
+    print(f"PyTorch flow_dir shape: {tuple(flow_dir.shape)}")
+
+    tract_version = args.tract_version or TractNNEF.latest_version()
+    check_io = not args.skip_io_check
+    print(f"Exporting to NNEF with tract {tract_version} (check_io={check_io})")
+    export_model_to_nnef(
+        model=model,
+        args=(cond, t_start, t_end, x),
+        file_path_export=args.out,
+        inference_target=TractNNEF(version=tract_version, check_io=check_io),
+        input_names=["cond", "t_start", "t_end", "x"],
+        output_names=["flow_dir"],
+        debug_bundle_path=Path("./debug_pocket_tts_flow_net.tgz"),
+    )
+    print(f"Exported to {args.out.absolute()}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_model_zoo.py
+++ b/tests/test_model_zoo.py
@@ -518,6 +518,42 @@ except ImportError:
     print("missing diffusers to test Sana mini transformer")
 
 
+# Mini Pocket-TTS flow_net: the AdaLN-modulated MLP that runs once per LSD
+# decode step inside the FlowLM autoregressive loop. Pure feedforward, no
+# streaming state -- exercises RMSNorm with default ``var(correction=1)``,
+# AdaLN modulation, sinusoidal time embedding, and the cond+time merge.
+try:
+    from pocket_tts.modules.mlp import SimpleMLPAdaLN
+
+    class MiniPocketTTSFlowNet(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.flow_net = SimpleMLPAdaLN(
+                in_channels=8,
+                model_channels=16,
+                out_channels=8,
+                cond_channels=24,
+                num_res_blocks=2,
+                num_time_conds=2,
+            ).eval()
+
+        def forward(self, cond, t_start, t_end, x):
+            return self.flow_net(cond, t_start, t_end, x)
+
+    test_suite.add(
+        (
+            torch.randn(1, 24),
+            torch.zeros(1, 1),
+            torch.full((1, 1), 0.25),
+            torch.randn(1, 8),
+        ),
+        MiniPocketTTSFlowNet(),
+        test_name="mini_pocket_tts_flow_net",
+    )
+except ImportError:
+    print("missing pocket_tts to test Pocket-TTS flow_net")
+
+
 @pytest.mark.parametrize(
     "id,test_input,model,inference_target",
     test_suite.test_samples,

--- a/torch_to_nnef/op/aten/math.py
+++ b/torch_to_nnef/op/aten/math.py
@@ -609,16 +609,52 @@ def var(node, op_helper, **kwargs):
     else:
         raise T2NErrorNotImplemented(len(node.inputs))
     input_tensor = op_helper.get_or_add_tensor_variable_in_nnef(inode)
-    axes = dnode.data or list(range(input_tensor.rank))
-    if cornode.data != 0:
+    raw_axes = dnode.data or list(range(input_tensor.rank))
+    axes = [a if a >= 0 else input_tensor.rank + a for a in raw_axes]
+    correction = cornode.data
+    if correction not in (0, 1):
         raise T2NErrorNotImplemented(
-            "only variance without correction translated"
+            f"variance correction={correction} not supported"
         )
-    op_helper.add_single_output_op_from_nnef_tensors(
+    if correction == 0:
+        op_helper.add_single_output_op_from_nnef_tensors(
+            node,
+            "var",
+            inputs=input_tensor,
+            attrs={"axes": axes},
+        )
+        return ["var"]
+    # NNEF ``var`` is population variance (denominator N); PyTorch's default
+    # ``var(correction=1)`` is sample variance (denominator N - 1). Compute
+    # population variance, then rescale by N / (N - 1). Static axes only.
+    n = 1
+    for axis in axes:
+        dim = input_tensor.shape[axis]
+        if not isinstance(dim, int):
+            raise T2NErrorNotImplemented(
+                f"variance correction=1 needs static axes; got {dim}"
+            )
+        n *= dim
+    if n <= 1:
+        raise T2NErrorNotImplemented(
+            f"variance correction=1 ill-defined for N={n}"
+        )
+    pop_var = op_helper.add_single_output_op_from_nnef_tensors(
         node,
         "var",
         inputs=input_tensor,
         attrs={"axes": axes},
+        output_tensor_name_suffix="population",
+    )
+    scale_const = PythonConstant(
+        name=f"{node.outputs[0].name}_var_correction",
+        data=torch.tensor(float(n) / float(n - 1), dtype=torch.float32),
+    )
+    scale_tensor = op_helper.get_or_add_tensor_variable_in_nnef(scale_const)
+    op_helper.add_single_output_op_from_nnef_tensors(
+        node,
+        "mul",
+        inputs=[pop_var, scale_tensor],
     )
     return ["var"]
 


### PR DESCRIPTION
First slice of the Pocket-TTS export plan. This PR exports the AdaLN-modulated MLP that runs once per LSD decode step inside the FlowLM autoregressive loop -- the simplest piece, exercises RMSNorm + AdaLN + sinusoidal time embedding before the bigger FlowLM graph in the next PR.

## Contents

- ` examples/tts/pocket_tts/flow_net.py`: tiny ` SimpleMLPAdaLN` random-weights config; ` --mini` runs end-to-end through tract with ` check_io=True`.
- ` tests/test_model_zoo.py`: ` mini_pocket_tts_flow_net` test gated on ` pocket_tts` import.
- ` torch_to_nnef/op/aten/math.py`: ` aten::var` previously rejected ` correction=1` (PyTorch's default unbiased variance). Pocket-TTS' ` RMSNorm` uses it. Now emits NNEF ` var` (population) followed by ` mul` by ` N / (N - 1)` when the reduced axes are statically known. Also normalizes negative ` axes` so ` x.var(dim=-1)` doesn't reach tract as ` axes=[-1]`.