### PR TITLE
feat(torch_graph): accept FloatType and BoolType scalar SSA outputs in IR

### DIFF
--- a/tests/test_jit_scalar_outputs.py
+++ b/tests/test_jit_scalar_outputs.py
@@ -1,0 +1,84 @@
+"""Tests for scalar-typed op outputs in the t2n IR.
+
+`TensorVariable.parse` was extended to accept `IntType` (already supported),
+`FloatType`, and `BoolType` SSA values: inlined / constfolded JIT graphs
+surface these as op outputs (e.g. `aten::Int`, `aten::Bool`, `aten::div(int,
+int) -> float`) and t2n's parser must not refuse them.
+"""
+
+import torch
+from torch import nn
+
+from torch_to_nnef.torch_graph.ir_data import TensorVariable
+
+
+def _walk(g):
+    for n in g.nodes():
+        yield n
+        for blk in n.blocks():
+            yield from _walk(blk)
+
+
+class _IntDiv(nn.Module):
+    def forward(self, x):
+        # `len(x) / 2` produces a `FloatType` SSA value via aten::div.
+        return x + (len(x) / 2.0)
+
+
+def test_float_scalar_output_parses():
+    m = torch.jit.script(_IntDiv())
+    div_outputs = [
+        out
+        for n in _walk(m.graph)
+        if n.kind() == "aten::div"
+        for out in n.outputs()
+        if out.type().annotation_str == "float"
+    ]
+    assert div_outputs, "test setup expected an aten::div with float output"
+
+    parsed = TensorVariable.parse(div_outputs[0])
+    assert parsed.dtype == torch.float32
+    assert parsed.shape == [1]
+
+
+class _BoolCast(nn.Module):
+    def forward(self, x, k: int):
+        return x + (1.0 if bool(k) else 0.0)
+
+
+def test_bool_scalar_output_parses():
+    m = torch.jit.script(_BoolCast())
+    bool_outputs = [
+        out
+        for n in _walk(m.graph)
+        if n.kind() == "aten::Bool"
+        for out in n.outputs()
+        if out.type().annotation_str == "bool"
+    ]
+    assert bool_outputs, "test setup expected an aten::Bool with bool output"
+
+    parsed = TensorVariable.parse(bool_outputs[0])
+    assert parsed.dtype == torch.bool
+    assert parsed.shape == [1]
+
+
+def test_int_scalar_output_still_parses():
+    """Sanity: the IntType path that already worked must still pass."""
+
+    class _LenQ(nn.Module):
+        def forward(self, x):
+            return x[: len(x)]
+
+    m = torch.jit.script(_LenQ())
+    len_outputs = [
+        out
+        for n in _walk(m.graph)
+        if n.kind() == "aten::len"
+        for out in n.outputs()
+        if out.type().annotation_str == "int"
+    ]
+    assert len_outputs
+
+    parsed = TensorVariable.parse(len_outputs[0])
+    assert parsed.dtype == torch.int64
+    assert parsed.shape == [1]

--- a/torch_to_nnef/torch_graph/ir_data.py
+++ b/torch_to_nnef/torch_graph/ir_data.py
@@ -30,8 +30,10 @@ from torch_to_nnef.exceptions import (
 )
 from torch_to_nnef.torch_graph.torch_const import (
     ATEN_SCALARIMPLICIT,
+    BOOLTYPE_KIND,
     CONSTANT_KIND,
     DICTTYPE_KIND,
+    FLOATTYPE_KIND,
     INTTYPE_KIND,
     NUMBERTYPE_KIND,
     TUPLETYPE_KIND,
@@ -279,11 +281,24 @@ class TensorVariable(Data):
             )
         return data.to(self.dtype)
 
+    SCALAR_TYPE_KIND_TO_DTYPE = {
+        INTTYPE_KIND: torch.int64,
+        FLOATTYPE_KIND: torch.float32,
+        BOOLTYPE_KIND: torch.bool,
+    }
+
     @classmethod
     def parse(cls, node_c_value: torch._C.Value) -> "TensorVariable":
         node_type = node_c_value.type()
-        if node_type.kind() == INTTYPE_KIND:
-            dtype = torch.int64
+        scalar_dtype = cls.SCALAR_TYPE_KIND_TO_DTYPE.get(node_type.kind())
+        if scalar_dtype is not None:
+            # Python-typed scalar SSA value (int, float, bool). Inlined or
+            # constfolded JIT graphs surface these for ops like `aten::Int`,
+            # `aten::Bool`, `aten::div(int,int) -> float` that survived
+            # specialization. Represent as a 1-element tensor of the right
+            # dtype, mirroring how INT scalars were already handled.
+            dtype = scalar_dtype
+            shape = [1]
         else:
             if node_type.kind() == NUMBERTYPE_KIND:
                 parent_node = node_c_value.node()
@@ -293,11 +308,10 @@ class TensorVariable(Data):
                     raise T2NErrorNotImplemented()
             stype = node_type.scalarType()
             dtype = str_to_torch_dtype(stype) if stype else None
+            shape = node_type.sizes()
         return cls(
             name=node_c_value.debugName(),
-            shape=[1]
-            if node_type.kind() == INTTYPE_KIND
-            else node_type.sizes(),
+            shape=shape,
             dtype=dtype,
             data=node_c_value.toIValue(),
             quant=None,

--- a/torch_to_nnef/torch_graph/torch_const.py
+++ b/torch_to_nnef/torch_graph/torch_const.py
@@ -59,6 +59,8 @@ TUPLETYPE_KIND = "TupleType"
 LISTTYPE_KIND = "ListType"
 NONETYPE_KIND = "NoneType"
 INTTYPE_KIND = "IntType"
+FLOATTYPE_KIND = "FloatType"
+BOOLTYPE_KIND = "BoolType"
 NUMBERTYPE_KIND = "NumberType"  # This type represents a Python number
 DICTTYPE_KIND = "DictType"
 # Subtype hierarchy for Number Types (NumberType as the base type):


### PR DESCRIPTION
## Summary

Phase 3 of the JIT-only model support plan, stacked on #81.

`TensorVariable.parse` accepted `IntType` SSA values as 1-element int64 tensors but raised on `FloatType` and `BoolType`. After Phases 1 and 2, inlined / constfolded JIT graphs surface ops like `aten::Int`, `aten::Bool`, `aten::div(int,int) -> float` whose outputs hit this path. Treat them symmetrically: 1-element tensors of the right dtype, with the SSA value's `toIValue()` (statically known constant) carried through if available.

Adds `FLOATTYPE_KIND` and `BOOLTYPE_KIND` constants in `torch_graph/torch_const.py` plus a `SCALAR_TYPE_KIND_TO_DTYPE` lookup that drops the previous `if/elif` chain. Tests verify each scalar SSA type rounds through `parse` with the correct dtype and shape.