### PR TITLE
feat(torch_graph): standalone constant folds and prim::data strip; jit-only docs

### DIFF
--- a/docs/tutos/12_jit_only_models.md
+++ b/docs/tutos/12_jit_only_models.md
@@ -1,0 +1,141 @@
+# Exporting JIT-only models
+
+Some PyTorch models ship as a TorchScript artifact (a single `.jit` /
+`.pt` file produced by `torch.jit.save`) without their training-time
+Python source on the import path. Examples include `silero-vad` and
+`funasr/fsmn-vad`: the JIT carries qualified type names like
+`__torch__.vad.model.vad_annotator.SileroVadBlock`, but importing
+`vad.model.vad_annotator` raises `ModuleNotFoundError` on a normal
+install.
+
+`torch_to_nnef`'s recursive parser identifies the class behind every
+`prim::CallMethod` via `importlib.import_module(qualname.module_path)`.
+When that import fails, the parser cannot recurse, so vanilla
+`export_model_to_nnef(jit_module, ...)` blows up before reaching the op
+handlers.
+
+The `torch_to_nnef.torch_graph` module ships a chain of opt-in passes
+that reshape the JIT graph in place so that, after the chain, every
+`prim::CallMethod` left in the graph targets an importable class
+(`torch.nn.*`) and every other unsupported construct collapses into ops
+that the standard parser handles.
+
+## The chain
+
+```python
+import torch
+from torch_to_nnef import TractNNEF, export_model_to_nnef
+from torch_to_nnef.torch_graph import (
+    fold_constant_ifs,
+    fold_constant_scalar_arithmetic,
+    inline_unresolvable_submodules,
+    replace_size_calls_with_constants,
+    strip_assertion_ifs,
+    strip_prim_data,
+)
+
+inner = torch.jit.load("model.jit").eval()
+example_inputs = (x, state)  # tensors with concrete shapes
+
+# Phase 1: inline only the JIT submodules whose source class is not
+# importable; keep torch.nn.* boundaries so existing module-level
+# extractors (LSTM, GRU, RNN) still fire.
+inline_unresolvable_submodules(inner.graph, inner)
+torch._C._jit_pass_dce(inner.graph)
+
+# Phase 2: fold aten::dim/size/len/numel against the example inputs'
+# shapes via complete_shape_analysis. Once size queries collapse,
+# scalar arithmetic and prim::If conditions can fold too.
+replace_size_calls_with_constants(inner.graph, [inner, *example_inputs])
+
+# Standalone constant-fold replacement for `_jit_pass_constant_propagation`.
+# Walks aten::eq/ne/lt/le/gt/ge, aten::__not__, aten::__contains__,
+# aten::Bool/Int/Float when their operands are `prim::Constant`. We
+# avoid the upstream pass because it has been observed to trip an
+# internal `setInsertPoint` assertion on graphs that mix Phase 1
+# inlined submodules and Phase 2 size-fold constants.
+fold_constant_scalar_arithmetic(inner.graph)
+
+# Drop prim::If whose condition is now a constant boolean: keep the
+# chosen branch's body, destroy the other.
+fold_constant_ifs(inner.graph)
+
+# `prim::data` is `.data` access on a tensor (autograd detach). It is a
+# no-op in inference; the parser doesn't handle it, so we elide.
+strip_prim_data(inner.graph)
+
+# Drop any remaining prim::If whose one branch is purely a
+# RaiseException (PyTorch's compiled-in dim-check assertions).
+strip_assertion_ifs(inner.graph)
+
+torch._C._jit_pass_dce(inner.graph)
+
+# Standard t2n export from this point on.
+export_model_to_nnef(
+    model=inner,
+    args=example_inputs,
+    file_path_export="model.nnef.tgz",
+    inference_target=TractNNEF(version=TractNNEF.latest_version()),
+    input_names=["x", "state"],
+    output_names=["prob", "new_state"],
+)
+```
+
+## Why each pass exists
+
+- **`inline_unresolvable_submodules`**: Without it, recursion into
+  non-importable JIT submodules raises `ModuleNotFoundError`. Inlining
+  exposes their bodies in the parent graph; importable submodules
+  (`torch.nn.*`) remain as `prim::CallMethod` so existing module
+  extractors continue to handle them.
+- **`replace_size_calls_with_constants`**: After Phase 1, the graph
+  often contains `prim::If` nodes gated on runtime size queries (e.g.
+  `if input.dim() == 2:`). Folding the size queries to constants is the
+  precondition for collapsing those branches.
+- **`fold_constant_scalar_arithmetic`** + **`fold_constant_ifs`**:
+  Together they simulate `_jit_pass_constant_propagation` on the
+  bool/int arithmetic that gates the surviving `prim::If` nodes. Used
+  instead of the upstream pass because of the assertion crash noted
+  above.
+- **`strip_prim_data`**: Replaces `prim::data(t)` with `t`; the parser
+  doesn't have a handler for that op kind.
+- **`strip_assertion_ifs`**: Drops `prim::If` whose one branch is purely
+  a `RaiseException`. Picks up assertions that depend on values that
+  remain symbolic at trace time.
+
+## Module-level extractor preservation
+
+The chain leaves importable `torch.nn.*` calls intact. That matters for:
+
+- `nn.LSTM` / `nn.GRU` / `nn.RNN`: handled by the dedicated extractors
+  in `op/custom_extractors/rnn.py` (NNEF custom fragments).
+- `nn.LSTMCell`: decomposed to primitive NNEF ops by the
+  `LSTMCellExtractor`. The decomposition body lives in
+  `op/aten/rnn.py::emit_lstm_cell_decomposition` and is also wired to
+  the `aten::lstm_cell` aten handler, so an inlined JIT graph that
+  exposes the underlying `_VF.lstm_cell` directly produces the same
+  NNEF ops as the module-level path.
+
+## Limitations and known gaps
+
+The chain handles the common patterns in real-world JIT artifacts
+(Silero-VAD, FunASR), but production JITs sometimes use IR constructs
+that are not yet covered here:
+
+- `prim::TupleIndex(state, k)`: indexing a tuple by a constant k. Today
+  the parser does not have a handler. Workaround: avoid tuple-typed
+  state at the model boundary, or pre-process the JIT graph to replace
+  `TupleIndex` with `aten::select` on the underlying tensor.
+- Other `prim::*` constructs that survive Phase 1 inlining (rare). If
+  your model trips one, please open an issue with a minimal repro.
+
+## Pytest gotcha
+
+PyTorch's JIT type cache leaks between scripted modules in the same
+process. After compiling several small `nn.Module`s in a pytest run and
+then inlining a non-importable submodule into a JIT artifact,
+`_jit_pass_constant_propagation` and `_jit_pass_peephole` can trip an
+internal `setInsertPoint` assertion. The standalone fold passes
+(`fold_constant_scalar_arithmetic`, `fold_constant_ifs`) sidestep this,
+which is one reason they exist as user-callable helpers rather than as
+a transparent wrapper around the upstream pass.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -129,6 +129,7 @@ nav:
     - '9. Tensors only export': "tutos/9_peft.md"
     - '10. Nemo ASR export & eval': "tutos/10_nemo.md"
     - '11. Shapes remodeler': "tutos/11_remodeler.md"
+    - '12. Exporting JIT-only models': "tutos/12_jit_only_models.md"
   - 'Export API': export_api.md
   - 'Internals API': reference/
   - Contributing:

--- a/tests/test_jit_constant_folds.py
+++ b/tests/test_jit_constant_folds.py
@@ -1,0 +1,106 @@
+"""Tests for the standalone JIT constant-fold passes.
+
+`fold_constant_scalar_arithmetic`, `fold_constant_ifs`, and
+`strip_prim_data` are written so the JIT-only export chain can avoid
+`torch._C._jit_pass_constant_propagation`, which has been observed to
+trip an internal `setInsertPoint` assertion when applied to a graph that
+mixes Phase 1 inlined submodules and Phase 2 size-fold constants.
+"""
+
+import torch
+from torch import nn
+
+from torch_to_nnef.torch_graph import (
+    fold_constant_ifs,
+    fold_constant_scalar_arithmetic,
+    replace_size_calls_with_constants,
+    strip_prim_data,
+)
+
+
+def _walk(g):
+    for n in g.nodes():
+        yield n
+        for blk in n.blocks():
+            yield from _walk(blk)
+
+
+def _node_count(g, kind):
+    return sum(1 for n in _walk(g) if n.kind() == kind)
+
+
+class _DimEqIf(nn.Module):
+    def forward(self, x):
+        if x.dim() == 2:
+            return x + 1.0
+        return x * 2.0
+
+
+def test_fold_constant_ifs_picks_true_branch():
+    m = torch.jit.script(_DimEqIf())
+    x = torch.randn(3, 4)
+
+    # Phase 2 folds dim() to constant; our scalar arithmetic fold then
+    # collapses `aten::eq(prim_const_2, prim_const_2)` to `True`.
+    replace_size_calls_with_constants(m.graph, [m, x])
+    fold_constant_scalar_arithmetic(m.graph)
+
+    folded_ifs = fold_constant_ifs(m.graph)
+    torch._C._jit_pass_dce(m.graph)
+
+    assert folded_ifs == 1
+    assert _node_count(m.graph, "prim::If") == 0
+
+
+class _BoolNot(nn.Module):
+    def forward(self, x, k: int):
+        return x + (1.0 if not bool(k) else 0.0)
+
+
+def test_fold_scalar_arithmetic_no_crash_on_runtime_inputs():
+    """Smoke: the pass walks cleanly on a graph with no constant folds.
+
+    The graph has `aten::Bool` and `aten::__not__` on a runtime int
+    input so nothing should fold; just check no crash.
+    """
+    m = torch.jit.script(_BoolNot())
+    folded = fold_constant_scalar_arithmetic(m.graph)
+    assert folded >= 0
+
+
+class _DataAccess(nn.Module):
+    def forward(self, x):
+        # `x.data` produces a `prim::data` node in the JIT IR.
+        return x.data + 1.0
+
+
+def test_strip_prim_data():
+    m = torch.jit.script(_DataAccess())
+    assert _node_count(m.graph, "prim::data") == 1
+    n_stripped = strip_prim_data(m.graph)
+    torch._C._jit_pass_dce(m.graph)
+    assert n_stripped == 1
+    assert _node_count(m.graph, "prim::data") == 0
+
+
+def test_fold_chain_on_simple_dim_check():
+    """End-to-end mini chain on a dim-check module.
+
+    Order: fold sizes, fold scalar arithmetic, fold constant ifs, dce.
+    Result must be a graph with no `prim::If` and an output that
+    matches the unmodified module on a 2D input.
+    """
+    m = torch.jit.script(_DimEqIf())
+    m_ref = torch.jit.script(_DimEqIf())
+    x = torch.randn(3, 4)
+
+    replace_size_calls_with_constants(m.graph, [m, x])
+    fold_constant_scalar_arithmetic(m.graph)
+    fold_constant_ifs(m.graph)
+    torch._C._jit_pass_dce(m.graph)
+
+    assert _node_count(m.graph, "prim::If") == 0
+    with torch.no_grad():
+        ref = m_ref(x)
+        new = m(x)
+    assert torch.allclose(ref, new)

--- a/torch_to_nnef/torch_graph/__init__.py
+++ b/torch_to_nnef/torch_graph/__init__.py
@@ -32,8 +32,11 @@ from torch_to_nnef.torch_graph.ir_module_tracer import TorchModuleTracer
 from torch_to_nnef.torch_graph.ir_op import TorchOp
 from torch_to_nnef.torch_graph.jit_inline import inline_unresolvable_submodules
 from torch_to_nnef.torch_graph.jit_passes import (
+    fold_constant_ifs,
+    fold_constant_scalar_arithmetic,
     replace_size_calls_with_constants,
     strip_assertion_ifs,
+    strip_prim_data,
 )
 from torch_to_nnef.torch_graph.torch_const import MAP_TO_NOP
 
@@ -47,7 +50,10 @@ __all__ = [
     "MAP_TO_NOP",
     "module_tracer_into_ir_graph",
     "TorchModuleIRGraph",
+    "fold_constant_ifs",
+    "fold_constant_scalar_arithmetic",
     "inline_unresolvable_submodules",
     "replace_size_calls_with_constants",
     "strip_assertion_ifs",
+    "strip_prim_data",
 ]

--- a/torch_to_nnef/torch_graph/jit_passes.py
+++ b/torch_to_nnef/torch_graph/jit_passes.py
@@ -293,6 +293,195 @@ def replace_size_calls_with_constants(
     return folded
 
 
+_SCALAR_BINARY_FOLDERS: T.Mapping[str, T.Callable[[T.Any, T.Any], T.Any]] = {
+    "aten::eq": lambda a, b: a == b,
+    "aten::ne": lambda a, b: a != b,
+    "aten::lt": lambda a, b: a < b,
+    "aten::le": lambda a, b: a <= b,
+    "aten::gt": lambda a, b: a > b,
+    "aten::ge": lambda a, b: a >= b,
+}
+
+
+def _const_value(value):
+    """Resolve an SSA value to its compile-time Python constant.
+
+    Returns the Python value when `value` is the output of a
+    `prim::Constant`, otherwise the sentinel `_NOT_CONST`.
+    """
+    n = value.node()
+    if n.kind() != "prim::Constant":
+        return _NOT_CONST
+    out = n.output()
+    out_ty = out.type().kind()
+    if out_ty == "BoolType":
+        return bool(n["value"])
+    if out_ty == "IntType":
+        return int(n["value"])
+    if out_ty == "FloatType":
+        return float(n["value"])
+    if out_ty == "StringType":
+        return str(n["value"])
+    if out_ty == "NoneType":
+        return None
+    return _NOT_CONST
+
+
+_NOT_CONST = object()
+
+
+def _emit_python_constant(graph, value, before_node):
+    """Insert a `prim::Constant` carrying a Python scalar.
+
+    Supports bool, int, float; placed just before `before_node`.
+    """
+    n = graph.create("prim::Constant")
+    if isinstance(value, bool):
+        n.output().setType(torch._C.BoolType.get())
+        n.i_("value", int(value))
+    elif isinstance(value, int):
+        n.output().setType(torch._C.IntType.get())
+        n.i_("value", int(value))
+    elif isinstance(value, float):
+        n.output().setType(torch._C.FloatType.get())
+        n.f_("value", float(value))
+    else:
+        raise NotImplementedError(f"unsupported constant {type(value)}")
+    n.insertBefore(before_node)
+    return n.output()
+
+
+def fold_constant_scalar_arithmetic(graph: "torch._C.Graph") -> int:
+    """Fold scalar arithmetic on `prim::Constant` operands.
+
+    Walks `aten::eq/ne/lt/le/gt/ge`, `aten::__not__`,
+    `aten::__contains__`, and the unary `aten::Bool/Int/Float` casts.
+    Standalone replacement for `_jit_pass_constant_propagation`: used
+    in the JIT-only export chain to avoid a torch internal assertion
+    that fires when the upstream pass walks a graph mixing Phase 1
+    inlined submodules and Phase 2 size-fold constants.
+
+    Returns the number of nodes folded.
+    """
+    folded = 0
+    unary_casts = {
+        "aten::Bool": bool,
+        "aten::Int": int,
+        "aten::Float": float,
+    }
+    candidates = [
+        n
+        for n in _walk_nodes(graph)
+        if n.kind() in _SCALAR_BINARY_FOLDERS
+        or n.kind() in ("aten::__not__", "aten::__contains__")
+        or n.kind() in unary_casts
+    ]
+    for node in candidates:
+        kind = node.kind()
+        inputs = list(node.inputs())
+        new_val = None
+        if kind in _SCALAR_BINARY_FOLDERS and len(inputs) == 2:
+            a = _const_value(inputs[0])
+            b = _const_value(inputs[1])
+            if a is _NOT_CONST or b is _NOT_CONST:
+                continue
+            new_val = _emit_python_constant(
+                graph, _SCALAR_BINARY_FOLDERS[kind](a, b), node
+            )
+        elif kind in unary_casts and len(inputs) == 1:
+            a = _const_value(inputs[0])
+            if a is _NOT_CONST:
+                continue
+            new_val = _emit_python_constant(graph, unary_casts[kind](a), node)
+        elif kind == "aten::__not__" and len(inputs) == 1:
+            a = _const_value(inputs[0])
+            if a is _NOT_CONST:
+                continue
+            new_val = _emit_python_constant(graph, not a, node)
+        elif kind == "aten::__contains__" and len(inputs) == 2:
+            haystack_node = inputs[0].node()
+            needle = _const_value(inputs[1])
+            if needle is _NOT_CONST:
+                continue
+            if haystack_node.kind() != "prim::ListConstruct":
+                continue
+            elems = []
+            for el in haystack_node.inputs():
+                v = _const_value(el)
+                if v is _NOT_CONST:
+                    elems = None
+                    break
+                elems.append(v)
+            if elems is None:
+                continue
+            new_val = _emit_python_constant(graph, needle in elems, node)
+        if new_val is None:
+            continue
+        node.output().replaceAllUsesWith(new_val)
+        node.destroy()
+        folded += 1
+    return folded
+
+
+def strip_prim_data(graph: "torch._C.Graph") -> int:
+    """Replace `prim::data(t)` nodes with their input.
+
+    `prim::data` is the IR form of Tensor `.data` access (detaches from
+    autograd). In inference it is a no-op; t2n's parser doesn't have a
+    handler for it, so we elide it.
+    """
+    folded = 0
+    for node in list(_walk_nodes(graph)):
+        if node.kind() != "prim::data":
+            continue
+        inputs = list(node.inputs())
+        if len(inputs) != 1:
+            continue
+        node.output().replaceAllUsesWith(inputs[0])
+        node.destroy()
+        folded += 1
+    return folded
+
+
+def fold_constant_ifs(graph: "torch._C.Graph") -> int:
+    """Fold `prim::If` nodes whose condition is a `prim::Constant[bool]`.
+
+    Replaces the If with the chosen block's nodes. Returns the count
+    folded.
+    """
+    folded = 0
+    changed = True
+    while changed:
+        changed = False
+        for node in list(_walk_nodes(graph)):
+            if node.kind() != "prim::If":
+                continue
+            cond_node = next(node.inputs()).node()
+            if cond_node.kind() != "prim::Constant":
+                continue
+            try:
+                cond = bool(cond_node["value"])
+            except (RuntimeError, TypeError):
+                continue
+            blocks = list(node.blocks())
+            if len(blocks) != 2:
+                continue
+            keep = blocks[0] if cond else blocks[1]
+            keep_outs = list(keep.returnNode().inputs())
+            node_outs = list(node.outputs())
+            if len(keep_outs) != len(node_outs):
+                continue
+            for old, new in zip(node_outs, keep_outs, strict=True):
+                old.replaceAllUsesWith(new)
+            for n in list(keep.nodes()):
+                n.moveBefore(node)
+            node.destroy()
+            folded += 1
+            changed = True
+            break
+    return folded
+
+
 def strip_assertion_ifs(graph: "torch._C.Graph") -> int:
     """Drop `prim::If` nodes whose one branch is purely a `RaiseException`.
 


### PR DESCRIPTION
## Summary

Phase 5 of the JIT-only model support plan, stacked on #83.

Adds three small JIT-graph passes plus a tutorial:

- `fold_constant_scalar_arithmetic`: walks `aten::eq/ne/lt/le/gt/ge`, `aten::__not__`, `aten::__contains__`, and the `aten::Bool/Int/Float` casts; folds whichever have `prim::Constant` operands. Standalone replacement for `_jit_pass_constant_propagation`, which was observed to trip an internal `setInsertPoint` assertion when applied to graphs that mix Phase 1 inlined submodules and Phase 2 size-fold constants.
- `fold_constant_ifs`: drops `prim::If` whose condition is a constant boolean by inlining the chosen block's body. Pairs with the arithmetic fold.
- `strip_prim_data`: replaces `prim::data(t)` with `t`. The op is autograd-detach (no-op in inference), but t2n's parser does not have a handler for it.

`docs/tutos/12_jit_only_models.md` documents the full chain (`inline_unresolvable_submodules` -> `replace_size_calls_with_constants` -> `fold_constant_scalar_arithmetic` -> `fold_constant_ifs` -> `strip_prim_data` -> `strip_assertion_ifs`), why each pass is needed, the pytest type-cache gotcha, and currently-known gaps (e.g. `prim::TupleIndex`) for production JIT artifacts.

The chain runs end-to-end on Silero-VAD's JIT in a fresh process: all `prim::If` collapse, output stays bitwise-identical to the unmodified JIT. Full export still trips on `prim::TupleIndex` and similar IR constructs that are out of scope for these phases; documented as known gaps.