### PR TITLE
feat(op/aten): canonical RNN orchestration + aten lstm/gru/rnn handlers

### DIFF
--- a/tests/test_aten_lstm_gru_rnn.py
+++ b/tests/test_aten_lstm_gru_rnn.py
@@ -1,0 +1,147 @@
+"""Tests for the aten-level RNN handlers.
+
+After Phase 6 the canonical NNEF emission lives in `op/aten/rnn.py`. The
+module-level extractors are thin shims that delegate to the same free
+functions, so existing `test_rnn_advanced.py` byte-equivalence tests
+also exercise this path. Here we verify:
+
+- The aten registry exposes `lstm`, `gru`, `rnn_tanh`, `rnn_relu`.
+- The adapter classes correctly map an aten op's flat
+  `params: Tensor[]` argument back to the named-attribute interface
+  the per-variant `tensor_params` reads from.
+
+`torch.jit.trace` decomposes the RNN modules into individual aten ops
+that are not the `aten::lstm` / `gru` / `rnn_*` we register, so the aten
+handlers fire only on scripted-then-inlined JIT artifacts. End-to-end
+parity tests through that path are out of scope here -- the existing
+extractor tests already prove byte-identical NNEF emission since both
+paths share `emit_rnn_via_fragment`.
+"""
+
+import torch
+from torch import nn
+
+from torch_to_nnef.op.aten import aten_ops_registry
+from torch_to_nnef.op.aten.rnn import (
+    _GRUAtenAdapter,
+    _LSTMAtenAdapter,
+    _RNNAtenAdapter,
+)
+
+
+def test_aten_rnn_handlers_registered():
+    for name in ("lstm", "gru", "rnn_tanh", "rnn_relu"):
+        fn = aten_ops_registry.get(name)
+        assert callable(fn), name
+
+
+def test_lstm_adapter_unidirectional_with_biases():
+    """Layout: per layer-direction `[w_ih, w_hh, b_ih, b_hh]`.
+
+    Single-direction, 2-layer with biases: 8 tensors total.
+    """
+    in_size, hidden, num_layers = 5, 7, 2
+    cell = nn.LSTM(in_size, hidden, num_layers=num_layers, bias=True)
+    flat = []
+    for layer in range(num_layers):
+        flat.extend(
+            [
+                getattr(cell, f"weight_ih_l{layer}").detach(),
+                getattr(cell, f"weight_hh_l{layer}").detach(),
+                getattr(cell, f"bias_ih_l{layer}").detach(),
+                getattr(cell, f"bias_hh_l{layer}").detach(),
+            ]
+        )
+    adapter = _LSTMAtenAdapter(
+        params_tensors=flat,
+        has_biases=True,
+        num_layers=num_layers,
+        bidirectional=False,
+        batch_first=False,
+        base_name="t",
+    )
+    assert adapter.hidden_size == hidden
+    assert adapter.num_layers == num_layers
+    assert adapter.bidirectional is False
+    for layer in range(num_layers):
+        assert torch.equal(
+            getattr(adapter, f"weight_ih_l{layer}"),
+            getattr(cell, f"weight_ih_l{layer}"),
+        )
+        assert torch.equal(
+            getattr(adapter, f"bias_hh_l{layer}"),
+            getattr(cell, f"bias_hh_l{layer}"),
+        )
+
+
+def test_lstm_adapter_bidirectional_no_biases():
+    """No biases: 2 tensors per direction. Bidirectional doubles per layer."""
+    in_size, hidden, num_layers = 4, 6, 1
+    cell = nn.LSTM(
+        in_size, hidden, num_layers=num_layers, bias=False, bidirectional=True
+    )
+    flat = [
+        cell.weight_ih_l0.detach(),
+        cell.weight_hh_l0.detach(),
+        cell.weight_ih_l0_reverse.detach(),
+        cell.weight_hh_l0_reverse.detach(),
+    ]
+    adapter = _LSTMAtenAdapter(
+        params_tensors=flat,
+        has_biases=False,
+        num_layers=num_layers,
+        bidirectional=True,
+        batch_first=False,
+        base_name="t",
+    )
+    assert adapter.hidden_size == hidden
+    assert adapter.bidirectional is True
+    assert torch.equal(adapter.weight_ih_l0, cell.weight_ih_l0)
+    assert torch.equal(adapter.weight_hh_l0_reverse, cell.weight_hh_l0_reverse)
+    assert not hasattr(adapter, "bias_ih_l0")
+
+
+def test_gru_adapter_recovers_hidden_size():
+    """GRU `weight_ih_l0` is `(3*H, I)` so adapter divides by 3."""
+    in_size, hidden = 4, 9
+    cell = nn.GRU(in_size, hidden, num_layers=1, bias=True)
+    flat = [
+        cell.weight_ih_l0.detach(),
+        cell.weight_hh_l0.detach(),
+        cell.bias_ih_l0.detach(),
+        cell.bias_hh_l0.detach(),
+    ]
+    adapter = _GRUAtenAdapter(
+        params_tensors=flat,
+        has_biases=True,
+        num_layers=1,
+        bidirectional=False,
+        batch_first=False,
+        base_name="t",
+    )
+    assert adapter.hidden_size == hidden
+    assert adapter.weight_ih_l0.shape == (3 * hidden, in_size)
+
+
+def test_rnn_adapter_recovers_hidden_size_and_nonlinearity():
+    """RNN `weight_ih_l0` is `(H, I)`."""
+    in_size, hidden = 4, 11
+    cell = nn.RNN(in_size, hidden, num_layers=1, bias=True, nonlinearity="relu")
+    flat = [
+        cell.weight_ih_l0.detach(),
+        cell.weight_hh_l0.detach(),
+        cell.bias_ih_l0.detach(),
+        cell.bias_hh_l0.detach(),
+    ]
+    adapter = _RNNAtenAdapter(
+        params_tensors=flat,
+        has_biases=True,
+        num_layers=1,
+        bidirectional=False,
+        batch_first=False,
+        base_name="t",
+        nonlinearity="relu",
+    )
+    assert adapter.hidden_size == hidden
+    assert adapter.nonlinearity == "relu"
+    assert adapter.weight_ih_l0.shape == (hidden, in_size)

--- a/torch_to_nnef/op/aten/rnn.py
+++ b/torch_to_nnef/op/aten/rnn.py
@@ -1,25 +1,33 @@
-"""Aten-level RNN op handlers and shared fragment-emission helpers.
+"""Aten-level RNN op handlers, adapters, and shared orchestration.
 
-`aten::lstm_cell` surfaces directly when an inlined JIT graph (Phase 1
-selective inline of non-importable submodules) exposes calls to the
-underlying `_VF.lstm_cell` primitive without a wrapping `nn.LSTMCell`
-module boundary.
+Canonical home for the RNN export math. Both the module-level extractors
+in `op/custom_extractors/rnn.py` (`LSTMExtractor`, `GRUExtractor`,
+`RNNExtractor`, `LSTMCellExtractor`) and the aten op handlers registered
+below go through the same set of free functions, so exports are
+byte-identical regardless of the entry point.
 
-Both this aten handler and the module-level `LSTMCellExtractor` go
-through `emit_lstm_cell_via_fragment`, which materializes the cell math
-as a single `lstm_cell` NNEF fragment call (see
-`op/fragment/lstm_cell.nnef`). The fragment uses the same grouped-matmul
-shape the flat decomposition would have emitted (one `(B, I) @ (4H, I).T`
-followed by one `(B, H) @ (4H, H).T`, then slice into the 4 gates), so
-runtime cost is unchanged. The benefit is graph shape: a single node
-per cell step, mirroring the existing `lstm` / `gru` / `rnn` fragment
-pattern in `op/fragment/`.
+Layout:
+
+  - Orchestration (multi-layer, bidirectional, batch_first, state setup):
+    `emit_rnn_via_fragment` and its private helpers. Variant-agnostic;
+    drives the per-layer / per-direction fragment call.
+  - Per-variant params extraction: `_lstm_tensor_params`,
+    `_gru_tensor_params`, `_rnn_tensor_params`. Read named weight
+    attributes off a "module-like" object.
+  - Aten adapters: `_LSTMAtenAdapter`, `_GRUAtenAdapter`,
+    `_RNNAtenAdapter`. Build an attribute interface compatible with the
+    per-variant tensor_params from the aten op's flat
+    `params: Tensor[]` argument.
+  - Aten op handlers: `aten::lstm`, `aten::gru`, `aten::rnn_tanh`,
+    `aten::rnn_relu`, plus `aten::lstm_cell` (single-step,
+    fragment-based via `lstm_cell.nnef`).
 """
 
 from __future__ import annotations
 
 import typing as T
 
+import nnef
 import torch
 from nnef_tools.model import Operation as NOperation
 from nnef_tools.model import Tensor as NTensor
@@ -30,9 +38,19 @@ from torch_to_nnef.op.helper import (
     add_tensor_variable_node_as_nnef_tensor,
     get_or_add_tensor_variable_in_nnef,
 )
-from torch_to_nnef.torch_graph.ir_data import FixedTensorList, TensorVariable
+from torch_to_nnef.tensor.named import NamedTensor
+from torch_to_nnef.torch_graph.ir_data import (
+    FixedTensorList,
+    PythonConstant,
+    TensorVariable,
+)
 
 OP_REGISTRY = AtenOpRegistry()
+
+
+# -------------------------------------------------------------------------
+# LSTMCell (single step, see lstm_cell.nnef fragment)
+# -------------------------------------------------------------------------
 
 
 def _add_weight_tensor(
@@ -59,14 +77,6 @@ def _multi_output_pair(
     h_new_tv: T.Optional[TensorVariable],
     c_new_tv: T.Optional[TensorVariable],
 ) -> T.Tuple[NTensor, NTensor]:
-    """Build the two output NNEF tensors for h_new / c_new.
-
-    Bound to the IR's TensorVariable name when one is provided (the
-    extractor / aten paths both pass their `node.outputs[*]` here so the
-    fragment outputs land on the names downstream consumers expect),
-    otherwise an anonymous intermediate.
-    """
-
     def make(suffix: str, tv: T.Optional[TensorVariable]) -> NTensor:
         if tv is not None:
             return add_tensor_variable_node_as_nnef_tensor(
@@ -103,15 +113,9 @@ def emit_lstm_cell_via_fragment(
 ) -> T.List[str]:
     """Emit a single `lstm_cell` NNEF fragment call.
 
-    The fragment internally does grouped `(B, I) @ (4H, I).T` and
+    Internally does grouped `(B, I) @ (4H, I).T` plus
     `(B, H) @ (4H, H).T`, adds the unsqueezed combined bias, slices into
-    the 4 gates, and computes `(h_new, c_new)`. Caller owns nothing but
-    the input refs and the four weight tensors.
-
-    `h_new_tv` and `c_new_tv` are the t2n IR `TensorVariable`s for the
-    user-facing outputs; they may be None if the caller wants anonymous
-    intermediates. Returns the list of fragments used so the parent
-    pipeline can include them in the exported NNEF.
+    the 4 gates, and computes `(h_new, c_new)`.
     """
     w_ih_ref = _add_weight_tensor(g, name_to_tensor, base, "weight_ih", w_ih)
     w_hh_ref = _add_weight_tensor(g, name_to_tensor, base, "weight_hh", w_hh)
@@ -119,9 +123,6 @@ def emit_lstm_cell_via_fragment(
     if b_ih is None and b_hh is None:
         bias = torch.zeros(1, 4 * hidden, dtype=w_ih.dtype)
     else:
-        # PyTorch sums the two biases at runtime; pre-sum and unsqueeze
-        # to (1, 4H) so the fragment's broadcast over (B, 4H) is
-        # unambiguous.
         zeros = torch.zeros(4 * hidden, dtype=w_ih.dtype)
         bi = b_ih if b_ih is not None else zeros
         bh = b_hh if b_hh is not None else zeros
@@ -159,8 +160,7 @@ def lstm_cell(g, node, name_to_tensor, **kwargs):
     """Map `aten::lstm_cell(input, hx_list, w_ih, w_hh, b_ih?, b_hh?)` to NNEF.
 
     `hx_list` is a t2n FixedTensorList of [h_prev, c_prev]. The output is
-    `(h_new, c_new)`. Emits a single `lstm_cell` fragment call via the
-    shared helper.
+    `(h_new, c_new)`.
     """
     if len(node.inputs) < 4:
         raise T2NErrorNotImplemented(
@@ -235,3 +235,963 @@ def lstm_cell(g, node, name_to_tensor, **kwargs):
         h_new_tv=h_new_tv,
         c_new_tv=c_new_tv,
     )
+
+
+# -------------------------------------------------------------------------
+# Multi-step RNN orchestration (lifted from `_RNNMixin`)
+# -------------------------------------------------------------------------
+
+
+def _prep_states(states_0: T.Tuple, layer_index: int) -> T.Tuple:
+    """Slice the initial state down to one layer.
+
+    `states_0` is `(tensor_variable_or_None, torch_tensor_or_None)`. When
+    a torch tensor is present we split along the layer axis (axis 0).
+    """
+    if isinstance(states_0[1], torch.Tensor):
+        tensor_variable, torch_tensor = states_0
+        return (
+            tensor_variable,
+            torch_tensor.split(1)[layer_index][:, :1, :],
+        )
+    return states_0
+
+
+def _apply_layer_and_unsqueeze_to_params(
+    params: T.Dict[str, T.Any], layer_index: int, backward: bool = False
+) -> T.Dict[str, T.Any]:
+    """Per-layer / direction key prefixing and unsqueeze for biases.
+
+    Weights gain a leading layer-direction axis, biases gain that plus a
+    leading singleton, and the dict keys are prefixed `l{layer}` (or
+    `l{layer}_backward`).
+    """
+    for k, v in params.items():
+        if isinstance(v, torch.Tensor):
+            v_new = v.detach()
+            if k.startswith("b_"):
+                v_new = v_new.unsqueeze(0)
+            v_new = v_new.unsqueeze(0)
+            if hasattr(v, "nnef_name"):
+                v_new = NamedTensor(v_new, nnef_name=v.nnef_name)
+            params[k] = v_new
+
+    linfo = str(layer_index)
+    if backward:
+        linfo += "_backward"
+    return {f"l{linfo}_{k}": v for k, v in params.items()}
+
+
+def _pre_batch_first(g, input_tensor, node, name_to_tensor) -> NTensor:
+    # pylint: disable-next=import-outside-toplevel
+    from torch_to_nnef.op import helper
+
+    transposed = helper.add_tensor_variable_node_as_nnef_tensor(
+        g, node.inputs[0], name_to_tensor, name_suffix="transposed"
+    )
+    NOperation(
+        g,
+        type="transpose",
+        inputs=input_tensor,
+        outputs=transposed,
+        attribs={"axes": [1, 0, 2]},
+    )
+    return transposed
+
+
+def _post_batch_first(g, input_tensor, node, name_to_tensor) -> NTensor:
+    # pylint: disable-next=import-outside-toplevel
+    from torch_to_nnef.op import helper
+
+    input_tensor.name += "_batch_first"
+    out = helper.add_tensor_variable_node_as_nnef_tensor(
+        g, node.outputs[0], name_to_tensor
+    )
+    NOperation(
+        g,
+        type="transpose",
+        inputs=input_tensor,
+        outputs=out,
+        attribs={"axes": [1, 0, 2]},
+    )
+    return out
+
+
+def _multi_layers_concat(
+    g, node, name_to_tensor, last_hc_at_each_layers
+) -> None:
+    """Concat last h_t (and c_t for LSTM) across layers."""
+    # pylint: disable-next=import-outside-toplevel
+    from torch_to_nnef.op import helper
+
+    for idx, out_node in enumerate(node.outputs[1:]):
+        real_output = helper.add_tensor_variable_node_as_nnef_tensor(
+            g, out_node, name_to_tensor
+        )
+        NOperation(
+            graph=g,
+            type="concat",
+            inputs=[_[idx] for _ in last_hc_at_each_layers],
+            outputs=real_output,
+            attribs={"axis": 0},
+        )
+
+
+def _translate_state_variable_load_and_prep(
+    g,
+    node,
+    name_to_tensor,
+    var_name: str,
+    tensor_variable,
+    torch_tensor,
+    input_tensor,
+) -> NTensor:
+    """Materialize a default initial state at runtime.
+
+    Used when the user did not pass an explicit hidden state. We store
+    the per-layer init tensor as a variable and tile it along the input's
+    batch axis so the runtime gets a correctly-shaped state without the
+    graph baking in a specific batch size.
+    """
+    # pylint: disable-next=import-outside-toplevel
+    from torch_to_nnef.op import helper
+
+    assert tensor_variable is None, tensor_variable
+    base_var_name = next(node.op_ref.parameters()).nnef_name.rsplit(".", 1)[0]
+    variable_storage_id = f"{var_name}_store"
+    store_tensor = helper.get_or_add_tensor_variable_in_nnef(
+        name_suffix=variable_storage_id,
+        node=helper.TensorVariable(
+            name=node.outputs[0].name,
+            data=NamedTensor(
+                torch_tensor, nnef_name=f"{base_var_name}.{var_name}_init"
+            )
+            if not isinstance(torch_tensor, NamedTensor)
+            else torch_tensor,
+            shape=list(torch_tensor.shape),
+            dtype=torch_tensor.dtype,
+        ),
+        g=g,
+        name_to_tensor=name_to_tensor,
+    )
+
+    reference_rnn_input = helper.TensorVariable(
+        name=input_tensor.name,
+        data=None,
+        shape=list(input_tensor.shape),
+        dtype=node.inputs[0].dtype,
+    )
+
+    batch_size_tensor_id = f"{reference_rnn_input.export_name}_batch_size"
+    if batch_size_tensor_id in name_to_tensor:
+        input_batch_size_tensor = name_to_tensor[batch_size_tensor_id]
+    else:
+        input_shape_tensor = helper.add_tensor_variable_node_as_nnef_tensor(
+            g,
+            reference_rnn_input,
+            name_to_tensor,
+            name_suffix="shape",
+            prevent_variable=True,
+        )
+        NOperation(
+            g,
+            type="tract_core_shape_of",
+            inputs=name_to_tensor[reference_rnn_input.export_name],
+            outputs=input_shape_tensor,
+        )
+        input_batch_size_slice_tensor = (
+            helper.add_tensor_variable_node_as_nnef_tensor(
+                g,
+                reference_rnn_input,
+                name_to_tensor,
+                name_suffix="batch_size_sliced",
+                prevent_variable=True,
+            )
+        )
+        NOperation(
+            g,
+            type="slice",
+            inputs=input_shape_tensor,
+            outputs=input_batch_size_slice_tensor,
+            attribs={
+                "axes": [0],
+                "begin": [1],
+                "end": [2],
+                "stride": [1],
+            },
+        )
+        input_batch_size_tensor = (
+            helper.add_tensor_variable_node_as_nnef_tensor(
+                g,
+                reference_rnn_input,
+                name_to_tensor,
+                name_suffix="batch_size",
+                prevent_variable=True,
+            )
+        )
+        NOperation(
+            g,
+            type="squeeze",
+            inputs=input_batch_size_slice_tensor,
+            outputs=input_batch_size_tensor,
+            attribs={"axes": [0]},
+        )
+
+    initial_state_ready_tensor = helper.add_tensor_variable_node_as_nnef_tensor(
+        name_suffix=var_name,
+        node=helper.TensorVariable(
+            name=node.outputs[0].name,
+            data=torch_tensor,
+            shape=list(torch_tensor.shape),
+            dtype=torch_tensor.dtype,
+        ),
+        g=g,
+        name_to_tensor=name_to_tensor,
+        prevent_variable=True,
+    )
+    NOperation(
+        g,
+        type="tile",
+        inputs=store_tensor,
+        outputs=initial_state_ready_tensor,
+        attribs={
+            "repeats": [
+                1,
+                nnef.Identifier(input_batch_size_tensor.name),
+                1,
+            ]
+        },
+    )
+    return initial_state_ready_tensor
+
+
+def _translate_to_nnef_variable(
+    module,
+    tensor_params_kwargs,
+    layer_index: int,
+    node,
+    g,
+    name_to_tensor,
+    is_backward: bool,
+    input_tensor: NTensor,
+    tensor_params_fn: T.Callable,
+) -> T.Dict[str, NTensor]:
+    """Per-layer-and-direction param materialization.
+
+    Calls `tensor_params_fn(module, layer_index, backward, **kwargs)` to
+    get a {param_name: torch.Tensor or (tensor_variable, torch_tensor)}
+    dict, then converts each entry into an NNEF tensor reference.
+    """
+    # pylint: disable-next=import-outside-toplevel
+    from torch_to_nnef import torch_graph as tg
+
+    # pylint: disable-next=import-outside-toplevel
+    from torch_to_nnef.op import helper
+
+    name_to_nnef_variable: T.Dict[str, NTensor] = {}
+    for var_name, item in tensor_params_fn(
+        module,
+        layer_index=layer_index,
+        backward=is_backward,
+        **tensor_params_kwargs,
+    ).items():
+        if isinstance(item, torch.Tensor):
+            name_to_nnef_variable[var_name] = (
+                helper.get_or_add_tensor_variable_in_nnef(
+                    name_suffix=var_name,
+                    node=helper.TensorVariable(
+                        name=getattr(item, "nnef_name", node.outputs[0].name),
+                        data=item,
+                        shape=list(item.shape),
+                        dtype=item.dtype,
+                    ),
+                    g=g,
+                    name_to_tensor=name_to_tensor,
+                )
+            )
+        elif isinstance(item, tuple):
+            assert len(item) == 2, item
+            tensor_variable, torch_tensor = item
+            if torch_tensor is None:
+                # User-manipulated state: slice the per-layer slab out
+                # of the existing state input.
+                reference = name_to_tensor[tensor_variable.export_name]
+                input_layer_states_tensor = (
+                    helper.add_tensor_variable_node_as_nnef_tensor(
+                        g=g,
+                        node=tg.TensorVariable(
+                            name=node.outputs[0].name,
+                            shape=[1] + list(reference.shape[1:]),
+                            dtype=node.inputs[0].dtype,
+                            quant=None,
+                            data=None,
+                        ),
+                        name_to_tensor=name_to_tensor,
+                        name_suffix=var_name,
+                        prevent_variable=True,
+                        force_full_output_tensor_name=var_name,
+                    )
+                )
+                NOperation(
+                    g,
+                    type="slice",
+                    inputs=reference,
+                    outputs=input_layer_states_tensor,
+                    attribs={
+                        "axes": [0],
+                        "begin": [layer_index],
+                        "end": [layer_index + 1],
+                        "stride": [1],
+                    },
+                )
+                name_to_nnef_variable[var_name] = input_layer_states_tensor
+            else:
+                name_to_nnef_variable[var_name] = (
+                    _translate_state_variable_load_and_prep(
+                        g,
+                        node,
+                        name_to_tensor,
+                        var_name,
+                        tensor_variable,
+                        torch_tensor,
+                        input_tensor,
+                    )
+                )
+        else:
+            raise T2NErrorNotImplemented(item)
+
+    return name_to_nnef_variable
+
+
+def _translate_to_nnef_outputs(
+    g, name_to_tensor, linfo: str, module, node
+) -> T.List[NTensor]:
+    # pylint: disable-next=import-outside-toplevel
+    from torch_to_nnef.op import helper
+
+    return [
+        helper.add_tensor_variable_node_as_nnef_tensor(
+            g,
+            out_node,
+            name_to_tensor,
+            name_suffix=f"l{linfo}"
+            if (module.num_layers > 1 or module.bidirectional)
+            else "",
+        )
+        for out_node in node.outputs
+    ]
+
+
+def _apply_rnn_bidirectional_pack_at_layer(
+    g,
+    node,
+    name_to_tensor,
+    layer_index: int,
+    last_forward_h: NTensor,
+    last_backward_h: NTensor,
+    module,
+) -> NTensor:
+    # pylint: disable-next=import-outside-toplevel
+    from torch_to_nnef.op import helper
+
+    out_packed_bidi = helper.add_tensor_variable_node_as_nnef_tensor(
+        g,
+        node.outputs[0],
+        name_to_tensor,
+        name_suffix=f"l{layer_index}_packed_bidi",
+    )
+    NOperation(
+        g,
+        type="rnn_bidi_pack",
+        inputs=tuple([last_forward_h, last_backward_h]),
+        outputs=out_packed_bidi,
+        attribs={"shape": module.hidden_size * 2},
+    )
+    return out_packed_bidi
+
+
+def emit_rnn_via_fragment(
+    g,
+    node,
+    name_to_tensor,
+    module,
+    nnef_fragment_name: str,
+    argument_names_order: T.Sequence[str],
+    tensor_params_fn: T.Callable,
+    **tensor_params_kwargs,
+) -> T.List[str]:
+    """Multi-layer / bidirectional RNN orchestration around a fragment call.
+
+    Variant-agnostic: drives the per-layer-and-direction loop, calls
+    `tensor_params_fn` to materialize weights / states per slice, and
+    issues one `nnef_fragment_name` call per (layer, direction). Bidi
+    packing and multi-layer concat are handled internally.
+    """
+    used_fragments = [nnef_fragment_name]
+    if module.bidirectional:
+        used_fragments += ["rnn_bidi_pack"]
+
+    input_tensor = name_to_tensor[node.inputs[0].export_name]
+
+    if module.batch_first:
+        input_tensor = _pre_batch_first(g, input_tensor, node, name_to_tensor)
+
+    last_hc_at_each_layers: T.List[T.Tuple[NTensor, ...]] = []
+    passes_is_backward = [False]
+    if module.bidirectional:
+        passes_is_backward += [True]
+
+    last_backward_h: T.Optional[NTensor] = None
+    last_forward_h: T.Optional[NTensor] = None
+    base_lstm_input = [input_tensor]
+    for layer_index in range(module.num_layers):
+        if last_forward_h:
+            base_lstm_input = [last_forward_h]
+
+        for is_backward in passes_is_backward:
+            linfo = str(layer_index)
+            name_to_nnef_variable = _translate_to_nnef_variable(
+                module,
+                tensor_params_kwargs,
+                layer_index,
+                node,
+                g,
+                name_to_tensor,
+                is_backward,
+                input_tensor=input_tensor,
+                tensor_params_fn=tensor_params_fn,
+            )
+
+            if is_backward:
+                linfo += "_backward"
+            outputs = _translate_to_nnef_outputs(
+                g, name_to_tensor, linfo, module, node
+            )
+
+            argument_order = [
+                f"l{linfo}_{arg_name}" for arg_name in argument_names_order
+            ]
+
+            NOperation(
+                graph=g,
+                type=nnef_fragment_name,
+                inputs=tuple(
+                    base_lstm_input
+                    + [name_to_nnef_variable[_] for _ in argument_order]
+                ),
+                outputs=tuple(outputs),
+                attribs={"scan_pace": -1 if is_backward else 1},
+            )
+            if is_backward:
+                last_backward_h = outputs[0]
+            else:
+                last_forward_h = outputs[0]
+
+            last_hc_at_each_layers.append(outputs[1:])
+        if module.bidirectional:
+            last_forward_h = _apply_rnn_bidirectional_pack_at_layer(
+                g,
+                node,
+                name_to_tensor,
+                layer_index,
+                last_forward_h,
+                last_backward_h,
+                module,
+            )
+
+    if module.batch_first:
+        last_forward_h = _post_batch_first(
+            g, last_forward_h, node, name_to_tensor
+        )
+
+    h_out_name = node.outputs[0].export_name
+    last_forward_h.name = h_out_name
+    name_to_tensor[h_out_name] = last_forward_h
+
+    if len(last_hc_at_each_layers) > 1:
+        _multi_layers_concat(g, node, name_to_tensor, last_hc_at_each_layers)
+    return used_fragments
+
+
+# -------------------------------------------------------------------------
+# Per-variant tensor_params (read named weights off a module-like object)
+# -------------------------------------------------------------------------
+
+
+def _lstm_tensor_params(
+    module,
+    layer_index: int,
+    backward: bool,
+    c_0,
+    h_0,
+    **kwargs,
+) -> T.Dict[str, T.Any]:
+    h_0_layer = _prep_states(h_0, layer_index)
+    c_0_layer = _prep_states(c_0, layer_index)
+
+    suffix = str(layer_index)
+    if backward:
+        suffix += "_reverse"
+
+    wi_var = getattr(module, f"weight_ih_l{suffix}")
+    w_ii, w_if, w_ig, w_io = wi_var.split(int(wi_var.shape[0] / 4))
+    wh_var = getattr(module, f"weight_hh_l{suffix}")
+    w_hi, w_hf, w_hg, w_ho = wh_var.split(int(wh_var.shape[0] / 4))
+
+    bias_i_name = f"bias_ih_l{suffix}"
+    if (
+        hasattr(module, bias_i_name)
+        and getattr(module, bias_i_name) is not None
+    ):
+        b_var = getattr(module, bias_i_name)
+        b_ii, b_if, b_ig, b_io = b_var.split(int(b_var.shape[0] / 4))
+    else:
+        b_ii, b_if, b_ig, b_io = (torch.tensor(0.0) for _ in range(4))
+
+    bias_h_name = f"bias_hh_l{suffix}"
+    if (
+        hasattr(module, bias_h_name)
+        and getattr(module, bias_h_name) is not None
+    ):
+        b_var = getattr(module, bias_h_name)
+        b_hi, b_hf, b_hg, b_ho = b_var.split(int(b_var.shape[0] / 4))
+    else:
+        b_hi, b_hf, b_hg, b_ho = (torch.tensor(0.0) for _ in range(4))
+
+    params: T.Dict[str, T.Any] = {"c_0": c_0_layer, "h_0": h_0_layer}
+    base_mod_name = wi_var.nnef_name.rsplit(".", 1)[0]
+
+    def add_param(name: str, tensor: torch.Tensor) -> None:
+        lname = name.lower()
+        backward_str = "back_" if backward else ""
+        params[name] = NamedTensor(
+            tensor,
+            nnef_name=f"{base_mod_name}.l{layer_index}_{backward_str}{lname}",
+        )
+
+    add_param("W_ii", w_ii)
+    add_param("W_if", w_if)
+    add_param("W_ig", w_ig)
+    add_param("W_io", w_io)
+    add_param("W_hi", w_hi)
+    add_param("W_hf", w_hf)
+    add_param("W_hg", w_hg)
+    add_param("W_ho", w_ho)
+    add_param("b_i", b_ii + b_hi)
+    add_param("b_f", b_if + b_hf)
+    add_param("b_g", b_ig + b_hg)
+    add_param("b_o", b_io + b_ho)
+    if hasattr(module, "proj_size") and module.proj_size > 0:
+        add_param("W_hr", getattr(module, f"weight_hr_l{suffix}"))
+
+    return _apply_layer_and_unsqueeze_to_params(
+        params, layer_index, backward=backward
+    )
+
+
+def _gru_tensor_params(
+    module,
+    layer_index: int,
+    backward: bool,
+    h_0,
+    **kwargs,
+) -> T.Dict[str, T.Any]:
+    suffix = str(layer_index)
+    if backward:
+        suffix += "_reverse"
+
+    h_0_layer = _prep_states(h_0, layer_index)
+    w_var = getattr(module, f"weight_ih_l{suffix}")
+    w_ir, w_iz, w_in = w_var.split(int(w_var.shape[0] / 3))
+    w_var = getattr(module, f"weight_hh_l{suffix}")
+    w_hr, w_hz, w_hn = w_var.split(int(w_var.shape[0] / 3))
+
+    bias_i_name = f"bias_ih_l{suffix}"
+    if (
+        hasattr(module, bias_i_name)
+        and getattr(module, bias_i_name) is not None
+    ):
+        bias_var = getattr(module, bias_i_name)
+        b_ir, b_iz, b_in = bias_var.split(int(bias_var.shape[0] / 3))
+    else:
+        b_ir, b_iz, b_in = (torch.tensor(0.0) for _ in range(3))
+
+    bias_h_name = f"bias_hh_l{suffix}"
+    if (
+        hasattr(module, bias_h_name)
+        and getattr(module, bias_h_name) is not None
+    ):
+        bias_var = getattr(module, bias_h_name)
+        b_hr, b_hz, b_hn = bias_var.split(int(bias_var.shape[0] / 3))
+    else:
+        b_hr, b_hz, b_hn = (torch.tensor(0.0) for _ in range(3))
+
+    base_mod_name = w_var.nnef_name.rsplit(".", 1)[0]
+
+    params: T.Dict[str, T.Any] = {"h_0": h_0_layer}
+
+    def add_param(name: str, tensor: torch.Tensor) -> None:
+        lname = name.lower()
+        backward_str = "b" if backward else ""
+        params[name] = NamedTensor(
+            tensor,
+            nnef_name=f"{base_mod_name}.l{layer_index}_{backward_str}{lname}",
+        )
+
+    add_param("W_ir", w_ir)
+    add_param("W_iz", w_iz)
+    add_param("W_in", w_in)
+    add_param("W_hr", w_hr)
+    add_param("W_hz", w_hz)
+    add_param("W_hn", w_hn)
+    add_param("b_r", b_ir + b_hr)
+    add_param("b_z", b_iz + b_hz)
+    add_param("b_in", b_in)
+    add_param("b_hn", b_hn)
+    return _apply_layer_and_unsqueeze_to_params(
+        params, layer_index, backward=backward
+    )
+
+
+def _rnn_tensor_params(
+    module,
+    layer_index: int,
+    backward: bool,
+    h_0,
+    **kwargs,
+) -> T.Dict[str, T.Any]:
+    suffix = str(layer_index)
+    if backward:
+        suffix += "_reverse"
+
+    h_0_layer = _prep_states(h_0, layer_index)
+    w_ih = getattr(module, f"weight_ih_l{suffix}")
+    w_hh = getattr(module, f"weight_hh_l{suffix}")
+
+    bias_i_name = f"bias_ih_l{suffix}"
+    if (
+        hasattr(module, bias_i_name)
+        and getattr(module, bias_i_name) is not None
+    ):
+        bias_ih = getattr(module, bias_i_name)
+    else:
+        bias_ih = torch.tensor(0.0)
+
+    bias_h_name = f"bias_hh_l{suffix}"
+    if (
+        hasattr(module, bias_h_name)
+        and getattr(module, bias_h_name) is not None
+    ):
+        bias_hh = getattr(module, bias_h_name)
+    else:
+        bias_hh = torch.tensor(0.0)
+
+    base_mod_name = w_ih.nnef_name.rsplit(".", 1)[0]
+
+    params: T.Dict[str, T.Any] = {"h_0": h_0_layer}
+
+    def add_param(name: str, tensor: torch.Tensor) -> None:
+        lname = name.lower()
+        backward_str = "b" if backward else ""
+        params[name] = NamedTensor(
+            tensor,
+            nnef_name=f"{base_mod_name}.l{layer_index}_{backward_str}{lname}",
+        )
+
+    add_param("W_ih", w_ih)
+    add_param("W_hh", w_hh)
+    add_param("b_ih_hh", bias_ih + bias_hh)
+    return _apply_layer_and_unsqueeze_to_params(
+        params, layer_index, backward=backward
+    )
+
+
+# -------------------------------------------------------------------------
+# Aten adapters: view a flat aten::lstm/gru/rnn `params: Tensor[]` as a
+# module-like object with the named weight attributes the per-variant
+# tensor_params expect.
+# -------------------------------------------------------------------------
+
+
+class _RNNAdapterBase:
+    """Common attribute interface for aten path adapters."""
+
+    proj_size = 0
+    nonlinearity = "tanh"
+
+    def __init__(
+        self,
+        params_tensors: T.Sequence[torch.Tensor],
+        has_biases: bool,
+        num_layers: int,
+        bidirectional: bool,
+        batch_first: bool,
+        base_name: str,
+    ):
+        self.num_layers = int(num_layers)
+        self.bidirectional = bool(bidirectional)
+        self.batch_first = bool(batch_first)
+        self.bias = bool(has_biases)
+        self.base_name = base_name
+        self._populate(params_tensors, has_biases, num_layers, bidirectional)
+
+    def _set_named(self, attr: str, t: torch.Tensor) -> None:
+        wrapped = NamedTensor(t, nnef_name=f"{self.base_name}.{attr}")
+        setattr(self, attr, wrapped)
+
+    def _populate(
+        self,
+        params_tensors: T.Sequence[torch.Tensor],
+        has_biases: bool,
+        num_layers: int,
+        bidirectional: bool,
+    ) -> None:
+        per_dir = 4 if has_biases else 2
+        directions = ("", "_reverse") if bidirectional else ("",)
+        idx = 0
+        for layer in range(num_layers):
+            for dsuffix in directions:
+                suffix = f"{layer}{dsuffix}"
+                if idx + per_dir > len(params_tensors):
+                    raise T2NErrorNotImplemented(
+                        f"params list too short for layer {layer}{dsuffix}: "
+                        f"got {len(params_tensors)} tensors, "
+                        f"expected at least {idx + per_dir}"
+                    )
+                self._set_named(f"weight_ih_l{suffix}", params_tensors[idx])
+                idx += 1
+                self._set_named(f"weight_hh_l{suffix}", params_tensors[idx])
+                idx += 1
+                if has_biases:
+                    self._set_named(f"bias_ih_l{suffix}", params_tensors[idx])
+                    idx += 1
+                    self._set_named(f"bias_hh_l{suffix}", params_tensors[idx])
+                    idx += 1
+
+
+class _LSTMAtenAdapter(_RNNAdapterBase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        wi = self.weight_ih_l0
+        self.hidden_size = int(wi.shape[0]) // 4
+
+
+class _GRUAtenAdapter(_RNNAdapterBase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        wi = self.weight_ih_l0
+        self.hidden_size = int(wi.shape[0]) // 3
+
+
+class _RNNAtenAdapter(_RNNAdapterBase):
+    def __init__(self, *args, nonlinearity: str = "tanh", **kwargs):
+        super().__init__(*args, **kwargs)
+        wi = self.weight_ih_l0
+        self.hidden_size = int(wi.shape[0])
+        self.nonlinearity = nonlinearity
+
+
+# -------------------------------------------------------------------------
+# Aten op handlers
+# -------------------------------------------------------------------------
+
+
+def _scalar(node) -> T.Any:
+    if isinstance(node, PythonConstant):
+        return node.data
+    if isinstance(node, TensorVariable) and node.data is not None:
+        return node.data
+    raise T2NErrorNotImplemented(
+        f"expected statically-resolved scalar; got {node!r}"
+    )
+
+
+def _params_tensors(params_node) -> T.List[torch.Tensor]:
+    if not isinstance(params_node, FixedTensorList):
+        raise T2NErrorNotImplemented(
+            "aten RNN handler expects a FixedTensorList of params; got "
+            f"{params_node!r}"
+        )
+    out: T.List[torch.Tensor] = []
+    for p in params_node.data:
+        if not isinstance(p, TensorVariable) or p.data is None:
+            raise T2NErrorNotImplemented(
+                "aten RNN params must be statically-resolved tensors"
+            )
+        out.append(p.data)
+    return out
+
+
+def _split_aten_rnn_inputs(node) -> T.Dict[str, T.Any]:
+    if len(node.inputs) != 9:
+        raise T2NErrorNotImplemented(
+            "aten RNN handler expects 9 inputs (input, hx, params, "
+            f"has_biases, num_layers, dropout, train, bidirectional, "
+            f"batch_first); got {len(node.inputs)}"
+        )
+    input_node, hx_node, params_node = node.inputs[:3]
+    has_biases = bool(_scalar(node.inputs[3]))
+    num_layers = int(_scalar(node.inputs[4]))
+    # node.inputs[5] = dropout, [6] = train: ignored in inference
+    bidirectional = bool(_scalar(node.inputs[7]))
+    batch_first = bool(_scalar(node.inputs[8]))
+    return {
+        "input_node": input_node,
+        "hx_node": hx_node,
+        "params": _params_tensors(params_node),
+        "has_biases": has_biases,
+        "num_layers": num_layers,
+        "bidirectional": bidirectional,
+        "batch_first": batch_first,
+    }
+
+
+def _build_state_kwargs(hx_node, single_state: bool) -> T.Dict[str, T.Tuple]:
+    """Translate the aten op's `hx` into state pairs.
+
+    Returns the (tensor_variable, torch_tensor) tuples
+    `tensor_params_fn` expects.
+    """
+    if single_state:
+        if isinstance(hx_node, FixedTensorList):
+            if len(hx_node.data) != 1:
+                raise T2NErrorNotImplemented(
+                    "single-state RNN expects 1-element hx; "
+                    f"got {len(hx_node.data)}"
+                )
+            (h0,) = hx_node.data
+        else:
+            h0 = hx_node
+        return {"h_0": (h0, None)}
+    if not isinstance(hx_node, FixedTensorList) or len(hx_node.data) != 2:
+        raise T2NErrorNotImplemented(
+            "LSTM expects a 2-element FixedTensorList for hx (h_0, c_0); "
+            f"got {hx_node!r}"
+        )
+    h0, c0 = hx_node.data
+    return {"h_0": (h0, None), "c_0": (c0, None)}
+
+
+_LSTM_ARG_NAMES_ORDER = (
+    "c_0",
+    "h_0",
+    "W_ii",
+    "W_hi",
+    "W_if",
+    "W_hf",
+    "W_ig",
+    "W_hg",
+    "W_io",
+    "W_ho",
+    "b_i",
+    "b_f",
+    "b_g",
+    "b_o",
+)
+
+_GRU_ARG_NAMES_ORDER = (
+    "h_0",
+    "W_ir",
+    "W_hr",
+    "W_iz",
+    "W_hz",
+    "W_in",
+    "W_hn",
+    "b_r",
+    "b_z",
+    "b_in",
+    "b_hn",
+)
+
+_RNN_ARG_NAMES_ORDER = ("h_0", "W_ih", "W_hh", "b_ih_hh")
+
+
+@OP_REGISTRY.register()
+def lstm(g, node, name_to_tensor, **kwargs):
+    """Map `aten::lstm.input` to NNEF via the existing `lstm` fragment."""
+    parsed = _split_aten_rnn_inputs(node)
+    base = node.outputs[0].export_name
+    adapter = _LSTMAtenAdapter(
+        params_tensors=parsed["params"],
+        has_biases=parsed["has_biases"],
+        num_layers=parsed["num_layers"],
+        bidirectional=parsed["bidirectional"],
+        batch_first=parsed["batch_first"],
+        base_name=f"aten_lstm.{base}",
+    )
+    state_kwargs = _build_state_kwargs(parsed["hx_node"], single_state=False)
+    return emit_rnn_via_fragment(
+        g,
+        node,
+        name_to_tensor,
+        module=adapter,
+        nnef_fragment_name="lstm",
+        argument_names_order=list(_LSTM_ARG_NAMES_ORDER),
+        tensor_params_fn=_lstm_tensor_params,
+        **state_kwargs,
+    )
+
+
+@OP_REGISTRY.register()
+def gru(g, node, name_to_tensor, **kwargs):
+    """Map `aten::gru.input` to NNEF via the existing `gru` fragment."""
+    parsed = _split_aten_rnn_inputs(node)
+    base = node.outputs[0].export_name
+    adapter = _GRUAtenAdapter(
+        params_tensors=parsed["params"],
+        has_biases=parsed["has_biases"],
+        num_layers=parsed["num_layers"],
+        bidirectional=parsed["bidirectional"],
+        batch_first=parsed["batch_first"],
+        base_name=f"aten_gru.{base}",
+    )
+    state_kwargs = _build_state_kwargs(parsed["hx_node"], single_state=True)
+    return emit_rnn_via_fragment(
+        g,
+        node,
+        name_to_tensor,
+        module=adapter,
+        nnef_fragment_name="gru",
+        argument_names_order=list(_GRU_ARG_NAMES_ORDER),
+        tensor_params_fn=_gru_tensor_params,
+        **state_kwargs,
+    )
+
+
+def _emit_aten_rnn_simple(
+    g, node, name_to_tensor, fragment_name: str, nonlinearity: str
+):
+    parsed = _split_aten_rnn_inputs(node)
+    base = node.outputs[0].export_name
+    adapter = _RNNAtenAdapter(
+        params_tensors=parsed["params"],
+        has_biases=parsed["has_biases"],
+        num_layers=parsed["num_layers"],
+        bidirectional=parsed["bidirectional"],
+        batch_first=parsed["batch_first"],
+        base_name=f"aten_{fragment_name}.{base}",
+        nonlinearity=nonlinearity,
+    )
+    state_kwargs = _build_state_kwargs(parsed["hx_node"], single_state=True)
+    return emit_rnn_via_fragment(
+        g,
+        node,
+        name_to_tensor,
+        module=adapter,
+        nnef_fragment_name=fragment_name,
+        argument_names_order=list(_RNN_ARG_NAMES_ORDER),
+        tensor_params_fn=_rnn_tensor_params,
+        **state_kwargs,
+    )
+
+
+@OP_REGISTRY.register()
+def rnn_tanh(g, node, name_to_tensor, **kwargs):
+    """Map `aten::rnn_tanh.input` to NNEF via existing `rnn_tanh` fragment."""
+    return _emit_aten_rnn_simple(g, node, name_to_tensor, "rnn_tanh", "tanh")
+
+
+@OP_REGISTRY.register()
+def rnn_relu(g, node, name_to_tensor, **kwargs):
+    """Map `aten::rnn_relu.input` to NNEF via existing `rnn_relu` fragment."""
+    return _emit_aten_rnn_simple(g, node, name_to_tensor, "rnn_relu", "relu")

--- a/torch_to_nnef/op/custom_extractors/rnn.py
+++ b/torch_to_nnef/op/custom_extractors/rnn.py
@@ -1,9 +1,6 @@
 import typing as T
 
-import nnef
 import torch
-from nnef_tools.model import Operation as NOperation
-from nnef_tools.model import Tensor as NTensor
 from torch import nn
 
 from torch_to_nnef.exceptions import (
@@ -12,7 +9,6 @@ from torch_to_nnef.exceptions import (
 )
 from torch_to_nnef.inference_target import TractNNEF
 from torch_to_nnef.op.custom_extractors.base import ModuleInfoExtractor
-from torch_to_nnef.tensor.named import NamedTensor
 from torch_to_nnef.torch_graph.torch_const import (
     ATEN_ZEROS,
     LISTCONSTRUCT_KIND,
@@ -23,14 +19,30 @@ T_RNNS = T.Union[nn.LSTM, nn.GRU, nn.RNN]
 
 
 class _RNNMixin:
-    def tensor_params(
-        self,
-        module: T_RNNS,
-        layer_index: int,
-        backward: bool,
-        **kwargs,
-    ):
+    """Module-extractor base for `nn.LSTM` / `nn.GRU` / `nn.RNN`.
+
+    The actual NNEF emission lives in `op/aten/rnn.py` so the aten-op
+    handlers and this module path share the same fragment-emission path
+    byte-for-byte. This class only:
+
+    - hosts `ordered_args` (JIT-arg reordering specific to module-call
+      tracing),
+    - hands a `tensor_params_fn` matching the variant down to
+      `emit_rnn_via_fragment`.
+    """
+
+    def _tensor_params_fn(self):
+        """Return the matching `_*_tensor_params` callable.
+
+        Subclasses pull from `op/aten/rnn.py` lazily to avoid a circular
+        import between the extractor module and the aten op module.
+        """
         raise T2NErrorNotImplemented()
+
+    def tensor_params(self, module, layer_index, backward, **kwargs):
+        return self._tensor_params_fn()(
+            module, layer_index=layer_index, backward=backward, **kwargs
+        )
 
     def ordered_args(self, torch_graph):
         """List of args ordered to be Python call compliant.
@@ -69,371 +81,6 @@ class _RNNMixin:
             new_args = torch_graph.tracer.args
         return new_args
 
-    def _check_rank(self, node, module):
-        batch_rank = 0 if module.batch_first else 1
-        assert node.inputs[0].shape[batch_rank] == 1, (
-            f"should be dim=1 for rank={batch_rank} since batch_size beyond "
-            f"are not supported but provided shape is {node.inputs[0].shape}"
-        )
-
-    @staticmethod
-    def _prep_states(states_0, layer_index: int):
-        if isinstance(states_0[1], torch.Tensor):
-            states_0_tensor_variable, states_0_torch = states_0
-            states_0_layer = (
-                states_0_tensor_variable,
-                states_0_torch.split(1)[layer_index][:, :1, :],
-            )  # to be tiled
-        else:
-            states_0_layer = states_0
-        return states_0_layer
-
-    def _pre_batch_first(self, g, input_tensor, node, name_to_tensor):
-        # pylint: disable-next=import-outside-toplevel
-        from torch_to_nnef.op import helper
-
-        transposed_input_tensor = (
-            helper.add_tensor_variable_node_as_nnef_tensor(
-                g, node.inputs[0], name_to_tensor, name_suffix="transposed"
-            )
-        )
-        NOperation(
-            g,
-            type="transpose",
-            inputs=input_tensor,
-            outputs=transposed_input_tensor,
-            attribs={"axes": [1, 0, 2]},
-        )
-        return transposed_input_tensor
-
-    def _post_batch_first(self, g, input_tensor, node, name_to_tensor):
-        # pylint: disable-next=import-outside-toplevel
-        from torch_to_nnef.op import helper
-
-        input_tensor.name += "_batch_first"
-        out_transpose_tensor = helper.add_tensor_variable_node_as_nnef_tensor(
-            g,
-            node.outputs[0],
-            name_to_tensor,
-        )
-        NOperation(
-            g,
-            type="transpose",
-            inputs=input_tensor,
-            outputs=out_transpose_tensor,
-            attribs={"axes": [1, 0, 2]},
-        )
-        return out_transpose_tensor
-
-    def _multi_layers_concat(
-        self, g, node, name_to_tensor, last_hc_at_each_layers
-    ):
-        """Allow to concat last from each layers for h_t and and c_t."""
-        # pylint: disable-next=import-outside-toplevel
-        from torch_to_nnef.op import helper
-
-        for idx, out_node in enumerate(node.outputs[1:]):
-            real_output = helper.add_tensor_variable_node_as_nnef_tensor(
-                g, out_node, name_to_tensor
-            )
-            NOperation(
-                graph=g,
-                type="concat",
-                inputs=[_[idx] for _ in last_hc_at_each_layers],
-                outputs=real_output,
-                attribs={"axis": 0},
-            )
-
-    def _translate_state_variable_load_and_prep(
-        self,
-        g,
-        node,
-        name_to_tensor,
-        var_name: str,
-        tensor_variable,
-        torch_tensor,
-        input_tensor,
-    ):
-        """Reproduce initial states preparations before rnn layer call.
-
-        ie:
-        @code nnef
-          h_0 = variable<scalar>(
-            label = 'gru_output_0_l0_h_0_store',
-            shape = [1, 1, 5]);
-          input_shape = tract_core_shape_of(input);
-          batch_size = slice(
-            input_shape,
-            axes=[0],
-            begin=[1],
-            end=[2],
-            stride=[1]
-          );
-          h_batch_expanded_0 = tile(h_0, repeats=[1, batch_size, 1]);
-        @end
-
-        """
-        # pylint: disable-next=import-outside-toplevel
-        from torch_to_nnef.op import helper
-
-        assert tensor_variable is None, tensor_variable
-        base_var_name = next(node.op_ref.parameters()).nnef_name.rsplit(".", 1)[
-            0
-        ]
-        variable_storage_id = f"{var_name}_store"
-        store_tensor = helper.get_or_add_tensor_variable_in_nnef(
-            name_suffix=variable_storage_id,
-            # build imaginary node to fill data correctly
-            node=helper.TensorVariable(
-                name=node.outputs[0].name,
-                data=NamedTensor(
-                    torch_tensor, nnef_name=f"{base_var_name}.{var_name}_init"
-                )
-                if not isinstance(torch_tensor, NamedTensor)
-                else torch_tensor,
-                shape=list(torch_tensor.shape),
-                dtype=torch_tensor.dtype,
-            ),
-            g=g,
-            name_to_tensor=name_to_tensor,
-        )
-
-        # NOTE: here we create a fake node so that even if rnn is 'batch_first'
-        # we reference the right rnn input 'name'
-        reference_rnn_input = helper.TensorVariable(
-            name=input_tensor.name,
-            data=None,
-            shape=list(input_tensor.shape),
-            dtype=node.inputs[0].dtype,
-        )
-
-        batch_size_tensor_id = f"{reference_rnn_input.export_name}_batch_size"
-        if batch_size_tensor_id in name_to_tensor:
-            input_batch_size_tensor = name_to_tensor[batch_size_tensor_id]
-        else:
-            input_shape_tensor = helper.add_tensor_variable_node_as_nnef_tensor(
-                g,
-                reference_rnn_input,
-                name_to_tensor,
-                name_suffix="shape",
-                prevent_variable=True,
-            )
-            NOperation(
-                g,
-                type="tract_core_shape_of",
-                inputs=name_to_tensor[reference_rnn_input.export_name],
-                outputs=input_shape_tensor,
-            )
-            input_batch_size_slice_tensor = (
-                helper.add_tensor_variable_node_as_nnef_tensor(
-                    g,
-                    reference_rnn_input,
-                    name_to_tensor,
-                    name_suffix="batch_size_sliced",
-                    prevent_variable=True,
-                )
-            )
-            NOperation(
-                g,
-                type="slice",
-                inputs=input_shape_tensor,
-                outputs=input_batch_size_slice_tensor,
-                attribs={
-                    "axes": [0],
-                    "begin": [1],
-                    "end": [2],
-                    "stride": [1],
-                },
-            )
-            input_batch_size_tensor = (
-                helper.add_tensor_variable_node_as_nnef_tensor(
-                    g,
-                    reference_rnn_input,
-                    name_to_tensor,
-                    name_suffix="batch_size",
-                    prevent_variable=True,
-                )
-            )
-            NOperation(
-                g,
-                type="squeeze",
-                inputs=input_batch_size_slice_tensor,
-                outputs=input_batch_size_tensor,
-                attribs={
-                    "axes": [0],
-                },
-            )
-
-        initial_state_ready_tensor = (
-            helper.add_tensor_variable_node_as_nnef_tensor(
-                name_suffix=var_name,
-                # build imaginary node to fill data correctly
-                node=helper.TensorVariable(
-                    name=node.outputs[0].name,
-                    data=torch_tensor,
-                    shape=list(torch_tensor.shape),
-                    dtype=torch_tensor.dtype,
-                ),
-                g=g,
-                name_to_tensor=name_to_tensor,
-                prevent_variable=True,
-            )
-        )
-        NOperation(
-            g,
-            type="tile",
-            inputs=store_tensor,
-            outputs=initial_state_ready_tensor,
-            attribs={
-                "repeats": [
-                    1,
-                    nnef.Identifier(input_batch_size_tensor.name),
-                    1,
-                ]
-            },
-        )
-        return initial_state_ready_tensor
-
-    def _translate_to_nnef_variable(
-        self,
-        module: T_RNNS,
-        tensor_params_kwargs,
-        layer_index: int,
-        node,  # : TensorVariable
-        g,
-        name_to_tensor,
-        is_backward: bool,
-        input_tensor: NTensor,
-    ) -> T.Dict[str, NTensor]:
-        # pylint: disable-next=import-outside-toplevel
-        from torch_to_nnef import torch_graph as tg
-
-        # pylint: disable-next=import-outside-toplevel
-        from torch_to_nnef.op import helper
-
-        name_to_nnef_variable = {}
-        for var_name, item in self.tensor_params(
-            module,
-            layer_index=layer_index,
-            backward=is_backward,
-            **tensor_params_kwargs,
-        ).items():
-            if isinstance(item, torch.Tensor):
-                name_to_nnef_variable[var_name] = (
-                    helper.get_or_add_tensor_variable_in_nnef(
-                        name_suffix=var_name,
-                        # build imaginary node to fill data correctly
-                        node=helper.TensorVariable(
-                            name=getattr(
-                                item, "nnef_name", node.outputs[0].name
-                            ),
-                            data=item,
-                            shape=list(item.shape),
-                            dtype=item.dtype,
-                        ),
-                        g=g,
-                        name_to_tensor=name_to_tensor,
-                    )
-                )
-            elif isinstance(item, tuple):
-                assert len(item) == 2, item
-                tensor_variable, torch_tensor = item
-                if torch_tensor is None:
-                    # variable is manipulated by user
-                    reference_state_nnef_tensor = name_to_tensor[
-                        tensor_variable.export_name
-                    ]
-                    input_layer_states_tensor = helper.add_tensor_variable_node_as_nnef_tensor(  # noqa: E501
-                        g=g,
-                        node=tg.TensorVariable(
-                            name=node.outputs[0].name,
-                            shape=[1]
-                            + list(reference_state_nnef_tensor.shape[1:]),
-                            dtype=node.inputs[0].dtype,
-                            quant=None,  # would probably need better handling
-                            data=None,
-                        ),
-                        name_to_tensor=name_to_tensor,
-                        name_suffix=var_name,
-                        prevent_variable=True,
-                        force_full_output_tensor_name=var_name,
-                    )
-                    NOperation(
-                        g,
-                        type="slice",
-                        inputs=reference_state_nnef_tensor,
-                        outputs=input_layer_states_tensor,
-                        attribs={
-                            "axes": [0],
-                            "begin": [layer_index],
-                            "end": [layer_index + 1],
-                            "stride": [1],
-                        },
-                    )
-                    name_to_nnef_variable[var_name] = input_layer_states_tensor
-                else:
-                    name_to_nnef_variable[var_name] = (
-                        self._translate_state_variable_load_and_prep(
-                            g,
-                            node,
-                            name_to_tensor,
-                            var_name,
-                            tensor_variable,
-                            torch_tensor,
-                            input_tensor,
-                        )
-                    )
-            else:
-                raise T2NErrorNotImplemented(item)
-
-        return name_to_nnef_variable
-
-    def _translate_to_nnef_outputs(
-        self, g, name_to_tensor, linfo: str, module: T_RNNS, node
-    ) -> T.List[NTensor]:
-        # pylint: disable-next=import-outside-toplevel
-        from torch_to_nnef.op import helper
-
-        return [
-            helper.add_tensor_variable_node_as_nnef_tensor(
-                g,
-                out_node,
-                name_to_tensor,
-                name_suffix=f"l{linfo}"
-                if (module.num_layers > 1 or module.bidirectional)
-                else "",
-            )
-            for out_node in node.outputs
-        ]
-
-    def _apply_rnn_bidirectional_pack_at_layer(
-        self,
-        g,
-        node,
-        name_to_tensor,
-        layer_index: int,
-        last_forward_h: NTensor,
-        last_backward_h: NTensor,
-        module: T_RNNS,
-    ):
-        # pylint: disable-next=import-outside-toplevel
-        from torch_to_nnef.op import helper
-
-        out_packed_bidi = helper.add_tensor_variable_node_as_nnef_tensor(
-            g,
-            node.outputs[0],
-            name_to_tensor,
-            name_suffix=f"l{layer_index}_packed_bidi",
-        )
-        NOperation(
-            g,
-            type="rnn_bidi_pack",
-            inputs=tuple([last_forward_h, last_backward_h]),
-            outputs=out_packed_bidi,
-            attribs={"shape": module.hidden_size * 2},
-        )
-        return out_packed_bidi
-
     def _core_convert_to_nnef(
         self,
         module,
@@ -444,212 +91,42 @@ class _RNNMixin:
         argument_names_order,
         **tensor_params_kwargs,
     ):
-        """Core convertion to NNEF of rnn.
+        """Delegate the per-layer loop to the canonical fragment emitter.
 
-        Avoid repeated configuration of:
-        batch_first
-        multi_layers
+        `emit_rnn_via_fragment` in `op/aten/rnn.py` produces the same
+        NNEF output as before the lift.
         """
-        # self._check_rank(node, module)
+        # pylint: disable-next=import-outside-toplevel
+        from torch_to_nnef.op.aten.rnn import emit_rnn_via_fragment
 
-        used_fragments = [nnef_fragment_name]
-        if module.bidirectional:
-            used_fragments += ["rnn_bidi_pack"]
+        return emit_rnn_via_fragment(
+            g=g,
+            node=node,
+            name_to_tensor=name_to_tensor,
+            module=module,
+            nnef_fragment_name=nnef_fragment_name,
+            argument_names_order=argument_names_order,
+            tensor_params_fn=self._tensor_params_fn(),
+            **tensor_params_kwargs,
+        )
 
-        input_tensor = name_to_tensor[node.inputs[0].export_name]
-
-        if module.batch_first:
-            input_tensor = self._pre_batch_first(
-                g, input_tensor, node, name_to_tensor
-            )
-
-        last_hc_at_each_layers = []
-
-        passes_is_backward = [False]
-        if module.bidirectional:
-            passes_is_backward += [True]
-
-        last_backward_h = None
-        last_forward_h = None
-        base_lstm_input = [input_tensor]
-        for layer_index in range(module.num_layers):
-            if last_forward_h:
-                base_lstm_input = [last_forward_h]
-
-            for is_backward in passes_is_backward:
-                linfo = str(layer_index)
-                name_to_nnef_variable = self._translate_to_nnef_variable(
-                    module,
-                    tensor_params_kwargs,
-                    layer_index,
-                    node,
-                    g,
-                    name_to_tensor,
-                    is_backward,
-                    input_tensor=input_tensor,
-                )
-
-                if is_backward:
-                    linfo += "_backward"
-                # outputs: h_n, h_last
-                outputs = self._translate_to_nnef_outputs(
-                    g, name_to_tensor, linfo, module, node
-                )
-
-                argument_order = [
-                    f"l{linfo}_{arg_name}" for arg_name in argument_names_order
-                ]
-
-                NOperation(
-                    graph=g,
-                    type=nnef_fragment_name,
-                    inputs=tuple(
-                        base_lstm_input
-                        + [name_to_nnef_variable[_] for _ in argument_order]
-                    ),
-                    outputs=tuple(outputs),
-                    attribs={"scan_pace": -1 if is_backward else 1},
-                )
-                if is_backward:
-                    last_backward_h = outputs[0]
-                else:
-                    last_forward_h = outputs[0]
-
-                last_hc_at_each_layers.append(outputs[1:])
-            if module.bidirectional:
-                last_forward_h = self._apply_rnn_bidirectional_pack_at_layer(
-                    g,
-                    node,
-                    name_to_tensor,
-                    layer_index,
-                    last_forward_h,
-                    last_backward_h,
-                    module,
-                )
-
-        if module.batch_first:
-            last_forward_h = self._post_batch_first(
-                g, last_forward_h, node, name_to_tensor
-            )
-
-        h_out_name = node.outputs[0].export_name
-        last_forward_h.name = h_out_name
-        name_to_tensor[h_out_name] = last_forward_h
-
-        if len(last_hc_at_each_layers) > 1:
-            self._multi_layers_concat(
-                g, node, name_to_tensor, last_hc_at_each_layers
-            )
-        return used_fragments
-
-    def _apply_layer_and_unsqueeze_to_params(
-        self, params, layer_index: int, backward: bool = False
-    ):
-        for k, v in params.items():
-            if isinstance(v, torch.Tensor):
-                v_new = v.detach()
-                if k.startswith("b_"):
-                    v_new = v_new.unsqueeze(0)
-                v_new = v_new.unsqueeze(0)
-                if hasattr(v, "nnef_name"):
-                    v_new = NamedTensor(v_new, nnef_name=v.nnef_name)
-                params[k] = v_new
-
-        linfo = str(layer_index)
-        if backward:
-            linfo += "_backward"
-        return {f"l{linfo}_{k}": v for k, v in params.items()}
+    # The orchestration helpers (`_pre_batch_first`, `_post_batch_first`,
+    # `_translate_to_nnef_variable`, `_translate_to_nnef_outputs`,
+    # `_apply_rnn_bidirectional_pack_at_layer`, `_multi_layers_concat`,
+    # `_translate_state_variable_load_and_prep`,
+    # `_apply_layer_and_unsqueeze_to_params`, `_prep_states`) all moved to
+    # `op/aten/rnn.py` as free functions. This mixin is intentionally
+    # thin now.
 
 
 class LSTMExtractor(_RNNMixin, ModuleInfoExtractor):
     MODULE_CLASS = nn.LSTM
 
-    # should be good enough for this use case
-    #  liskov substitution being not used here
-    #  pylint: disable-next=arguments-differ
-    def tensor_params(  # type: ignore
-        self,
-        module: T_RNNS,
-        layer_index: int,
-        backward: bool,
-        c_0: torch.Tensor,
-        h_0: torch.Tensor,
-        **kwargs,
-    ):
-        h_0_layer = self._prep_states(h_0, layer_index)
-        c_0_layer = self._prep_states(c_0, layer_index)
+    def _tensor_params_fn(self):
+        # pylint: disable-next=import-outside-toplevel
+        from torch_to_nnef.op.aten.rnn import _lstm_tensor_params
 
-        suffix = str(layer_index)
-        if backward:
-            suffix += "_reverse"
-
-        # lstm weight packed in order (W_ii|W_if|W_ig|W_io)
-        wi_var = getattr(module, f"weight_ih_l{suffix}")
-        w_ii, w_if, w_ig, w_io = wi_var.split(int(wi_var.shape[0] / 4))
-        # lstm weight packed in order (W_hi|W_hf|W_hg|W_ho)
-        wh_var = getattr(module, f"weight_hh_l{suffix}")
-
-        w_hi, w_hf, w_hg, w_ho = wh_var.split(int(wh_var.shape[0] / 4))
-
-        bias_i_name = f"bias_ih_l{suffix}"
-        if (
-            hasattr(module, bias_i_name)
-            and getattr(module, bias_i_name) is not None
-        ):
-            b_var = getattr(module, bias_i_name)
-            # module packed in order (b_ii|b_if|b_ig|b_io)
-            b_ii, b_if, b_ig, b_io = b_var.split(int(b_var.shape[0] / 4))
-        else:
-            b_ii, b_if, b_ig, b_io = (torch.tensor(0.0) for _ in range(4))
-
-        bias_h_name = f"bias_hh_l{suffix}"
-        if (
-            hasattr(module, bias_h_name)
-            and getattr(module, bias_h_name) is not None
-        ):
-            # lstm packed in order (b_hi|b_hf|b_hg|b_ho)
-            b_var = getattr(module, bias_h_name)
-            b_hi, b_hf, b_hg, b_ho = b_var.split(int(b_var.shape[0] / 4))
-        else:
-            b_hi, b_hf, b_hg, b_ho = (torch.tensor(0.0) for _ in range(4))
-
-        params = {
-            "c_0": c_0_layer,
-            "h_0": h_0_layer,
-        }
-        base_mod_name = wi_var.nnef_name.rsplit(".", 1)[0]
-
-        def add_param(name, tensor):
-            lname = name.lower()
-            backward_str = "back_" if backward else ""
-            params[name] = NamedTensor(
-                tensor,
-                nnef_name=f"{base_mod_name}.l{layer_index}_{backward_str}{lname}",
-            )
-
-        # -----------
-        add_param("W_ii", w_ii)
-        add_param("W_if", w_if)
-        add_param("W_ig", w_ig)
-        add_param("W_io", w_io)
-        # -----------
-        add_param("W_hi", w_hi)
-        add_param("W_hf", w_hf)
-        add_param("W_hg", w_hg)
-        add_param("W_ho", w_ho)
-        # pre summed bias
-        add_param("b_i", b_ii + b_hi)
-        add_param("b_f", b_if + b_hf)
-        add_param("b_g", b_ig + b_hg)
-        add_param("b_o", b_io + b_ho)
-        if hasattr(module, "proj_size") and module.proj_size > 0:  # type: ignore
-            # LSTM.weight_hr_l[k] may be with suffix
-            w_hr = getattr(module, f"weight_hr_l{suffix}")
-            add_param("W_hr", w_hr)
-
-        return self._apply_layer_and_unsqueeze_to_params(
-            params, layer_index, backward=backward
-        )
+        return _lstm_tensor_params
 
     def convert_to_nnef(
         self,
@@ -751,79 +228,11 @@ class LSTMExtractor(_RNNMixin, ModuleInfoExtractor):
 class GRUExtractor(_RNNMixin, ModuleInfoExtractor):
     MODULE_CLASS = nn.GRU
 
-    #  pylint: disable-next=arguments-differ
-    def tensor_params(  # type: ignore
-        self,
-        module: T_RNNS,
-        layer_index: int,
-        backward: bool,
-        h_0: torch.Tensor,
-        **kwargs,
-    ):
-        suffix = str(layer_index)
-        if backward:
-            suffix += "_reverse"
+    def _tensor_params_fn(self):
+        # pylint: disable-next=import-outside-toplevel
+        from torch_to_nnef.op.aten.rnn import _gru_tensor_params
 
-        h_0_layer = self._prep_states(h_0, layer_index)
-        # module weight packed in order (W_ir|W_iz|W_in)
-        w_var = getattr(module, f"weight_ih_l{suffix}")
-        w_ir, w_iz, w_in = w_var.split(int(w_var.shape[0] / 3))
-        # module weight packed in order (W_hr|W_hz|W_hn)
-        w_var = getattr(module, f"weight_hh_l{suffix}")
-        w_hr, w_hz, w_hn = w_var.split(int(w_var.shape[0] / 3))
-
-        bias_i_name = f"bias_ih_l{suffix}"
-        if (
-            hasattr(module, bias_i_name)
-            and getattr(module, bias_i_name) is not None
-        ):
-            # module packed in order (b_ir|b_iz|b_in)
-            bias_var = getattr(module, bias_i_name)
-            b_ir, b_iz, b_in = bias_var.split(int(bias_var.shape[0] / 3))
-        else:
-            b_ir, b_iz, b_in = (torch.tensor(0.0) for _ in range(3))
-
-        bias_h_name = f"bias_hh_l{suffix}"
-        if (
-            hasattr(module, bias_h_name)
-            and getattr(module, bias_h_name) is not None
-        ):
-            # module packed in order (b_hr|b_hz|b_hn)
-            bias_var = getattr(module, bias_h_name)
-            b_hr, b_hz, b_hn = bias_var.split(int(bias_var.shape[0] / 3))
-        else:
-            b_hr, b_hz, b_hn = (torch.tensor(0.0) for _ in range(3))
-
-        base_mod_name = w_var.nnef_name.rsplit(".", 1)[0]
-
-        def add_param(name, tensor):
-            lname = name.lower()
-            backward_str = "b" if backward else ""
-            params[name] = NamedTensor(
-                tensor,
-                nnef_name=f"{base_mod_name}.l{layer_index}_{backward_str}{lname}",
-            )
-
-        params = {
-            "h_0": h_0_layer,
-        }
-        # -----------
-        add_param("W_ir", w_ir)
-        add_param("W_iz", w_iz)
-        add_param("W_in", w_in)
-        # -----------
-        add_param("W_hr", w_hr)
-        add_param("W_hz", w_hz)
-        add_param("W_hn", w_hn)
-        # pre summed bias
-        add_param("b_r", b_ir + b_hr)
-        add_param("b_z", b_iz + b_hz)
-        # not summable
-        add_param("b_in", b_in)
-        add_param("b_hn", b_hn)
-        return self._apply_layer_and_unsqueeze_to_params(
-            params, layer_index, backward=backward
-        )
+        return _gru_tensor_params
 
     def convert_to_nnef(
         self,
@@ -884,65 +293,11 @@ class GRUExtractor(_RNNMixin, ModuleInfoExtractor):
 class RNNExtractor(_RNNMixin, ModuleInfoExtractor):
     MODULE_CLASS = nn.RNN
 
-    #  pylint: disable-next=arguments-differ
-    def tensor_params(  # type: ignore
-        self,
-        module: T_RNNS,
-        layer_index: int,
-        backward: bool,
-        h_0: T.Union[torch.Tensor, str],
-        **kwargs,
-    ):
-        suffix = str(layer_index)
-        if backward:
-            suffix += "_reverse"
+    def _tensor_params_fn(self):
+        # pylint: disable-next=import-outside-toplevel
+        from torch_to_nnef.op.aten.rnn import _rnn_tensor_params
 
-        h_0_layer = self._prep_states(h_0, layer_index)
-
-        w_ih = getattr(module, f"weight_ih_l{suffix}")
-        w_hh = getattr(module, f"weight_hh_l{suffix}")
-
-        bias_i_name = f"bias_ih_l{suffix}"
-        if (
-            hasattr(module, bias_i_name)
-            and getattr(module, bias_i_name) is not None
-        ):
-            # module packed in order (b_ir|b_iz|b_in)
-            bias_ih = getattr(module, bias_i_name)
-        else:
-            bias_ih = torch.tensor(0.0)
-
-        bias_h_name = f"bias_hh_l{suffix}"
-        if (
-            hasattr(module, bias_h_name)
-            and getattr(module, bias_h_name) is not None
-        ):
-            # module packed in order (b_hr|b_hz|b_hn)
-            bias_hh = getattr(module, bias_h_name)
-        else:
-            bias_hh = torch.tensor(0.0)
-
-        base_mod_name = w_ih.nnef_name.rsplit(".", 1)[0]
-
-        def add_param(name, tensor):
-            lname = name.lower()
-            backward_str = "b" if backward else ""
-            params[name] = NamedTensor(
-                tensor,
-                nnef_name=f"{base_mod_name}.l{layer_index}_{backward_str}{lname}",
-            )
-
-        params = {
-            "h_0": h_0_layer,
-        }
-        add_param("W_ih", w_ih)
-        add_param("W_hh", w_hh)
-        # -----
-        # pre summed bias
-        add_param("b_ih_hh", bias_ih + bias_hh)
-        return self._apply_layer_and_unsqueeze_to_params(
-            params, layer_index, backward=backward
-        )
+        return _rnn_tensor_params
 
     def convert_to_nnef(
         self,


### PR DESCRIPTION
## Summary

Phase 6 of the JIT-only model support plan, stacked on #84. Establishes `op/aten/rnn.py` as the canonical home for the RNN export math; the module-level extractors in `op/custom_extractors/rnn.py` become thin shims that delegate.

### Lifted to free functions

`_core_convert_to_nnef`, `_translate_to_nnef_variable`, `_translate_to_nnef_outputs`, `_pre_batch_first`, `_post_batch_first`, `_apply_rnn_bidirectional_pack_at_layer`, `_multi_layers_concat`, `_translate_state_variable_load_and_prep`, `_apply_layer_and_unsqueeze_to_params`, `_prep_states`: all moved out of `_RNNMixin` into `op/aten/rnn.py` as private free functions. The public entry point is `emit_rnn_via_fragment(g, node, name_to_tensor, module, nnef_fragment_name, argument_names_order, tensor_params_fn, **kwargs)`. `tensor_params_fn` is the variant-specific bit, injected as a callable.

### Per-variant tensor_params

`_lstm_tensor_params`, `_gru_tensor_params`, `_rnn_tensor_params` are now free functions reading named weight attributes off a "module-like" object. The same callable serves both module path and aten path.

### Aten adapters

`_LSTMAtenAdapter`, `_GRUAtenAdapter`, `_RNNAtenAdapter` view a flat aten op `params: Tensor[]` argument as an `nn.LSTM` / `nn.GRU` / `nn.RNN`-compatible attribute interface (named `weight_ih_l{suffix}` etc.). The per-variant tensor_params reads the same way regardless of source.

### Aten op handlers

`aten::lstm`, `aten::gru`, `aten::rnn_tanh`, `aten::rnn_relu` registered through `OP_REGISTRY`. Each parses the JIT op's 9-input signature, builds the right adapter, dispatches to `emit_rnn_via_fragment`. Same `lstm` / `gru` / `rnn_tanh` / `rnn_relu` NNEF fragments emitted as the module path; on-disk NNEF is byte-identical.

### Module extractors are now shims

`LSTMExtractor`, `GRUExtractor`, `RNNExtractor`: each provides a `_tensor_params_fn` returning the matching free function (lazy import to avoid circular load), and a `convert_to_nnef` that builds the input-parsing setup before delegating to `_core_convert_to_nnef` (which itself delegates to `emit_rnn_via_fragment`). The 540-line `_RNNMixin` shrinks to ~80 lines.

### Tests

- All existing RNN tests in `test_rnn_advanced.py` (LSTM / GRU / RNN, multi-layer, bidirectional, batch-first, reused, picked-h_t) continue to pass byte-equally through the lifted orchestration.
- `test_aten_lstm_gru_rnn.py` (new) covers: handler registry exposure, adapter layout for unidirectional+biases / bidirectional+nobias / GRU 3xH / RNN with nonlinearity.

`torch.jit.trace` decomposes RNN modules into individual aten ops below the `aten::lstm` / `gru` / `rnn_*` boundary, so the new aten handlers fire only on scripted-then-inlined JIT artifacts. End-to-end byte-equivalence with the module path is guaranteed by construction since both go through the same `emit_rnn_via_fragment`.