### PR TITLE
feat(torch_graph): fold prim::TupleIndex through prim::TupleConstruct

### DIFF
--- a/tests/test_jit_tuple_index.py
+++ b/tests/test_jit_tuple_index.py
@@ -1,0 +1,128 @@
+"""Tests for `fold_tuple_index_through_tuple_construct`.
+
+PyTorch's scripter constant-folds `pair[0]` directly when the
+`prim::TupleConstruct` is in the same scope as the consumption, so the
+test models route the tuple build through a separate scripted method
+that gets inlined via `_jit_pass_inline`. After inlining the pattern
+becomes `prim::TupleConstruct -> prim::TupleIndex`, which the pass
+under test rewrites.
+"""
+
+import torch
+from torch import nn
+
+from torch_to_nnef.torch_graph import (
+    fold_tuple_index_through_tuple_construct,
+)
+
+
+def _walk(g):
+    for n in g.nodes():
+        yield n
+        for blk in n.blocks():
+            yield from _walk(blk)
+
+
+def _node_count(g, kind):
+    return sum(1 for n in _walk(g) if n.kind() == kind)
+
+
+class _PairBuilderTwoIndex(nn.Module):
+    def helper(self, x, y):
+        return (x, y)
+
+    def forward(self, x, y):
+        pair = self.helper(x, y)
+        return pair[0] + pair[1]
+
+
+def _scripted_inlined(cls):
+    m = torch.jit.script(cls())
+    torch._C._jit_pass_inline(m.graph)
+    return m
+
+
+def test_fold_collapses_tupleindex_into_construct_input():
+    m = _scripted_inlined(_PairBuilderTwoIndex)
+    assert _node_count(m.graph, "prim::TupleIndex") == 2
+    assert _node_count(m.graph, "prim::TupleConstruct") == 1
+
+    folded = fold_tuple_index_through_tuple_construct(m.graph)
+    torch._C._jit_pass_dce(m.graph)
+
+    assert folded == 2
+    assert _node_count(m.graph, "prim::TupleIndex") == 0
+    # The TupleConstruct DCEs once its only consumers (the TupleIndex
+    # nodes) are gone.
+    assert _node_count(m.graph, "prim::TupleConstruct") == 0
+
+
+def test_fold_preserves_output():
+    """Bitwise parity: rewriting the graph must not change behavior."""
+    ref = _PairBuilderTwoIndex().eval()
+    x = torch.randn(2, 3)
+    y = torch.randn(2, 3)
+    expected = ref(x, y)
+
+    m = _scripted_inlined(_PairBuilderTwoIndex)
+    fold_tuple_index_through_tuple_construct(m.graph)
+    torch._C._jit_pass_dce(m.graph)
+
+    got = m(x, y)
+    assert torch.allclose(got, expected)
+
+
+class _RuntimeIndex(nn.Module):
+    def helper(self, x, y):
+        return (x, y)
+
+    def forward(self, x, y, idx: int):
+        # The index is a runtime parameter, not a `prim::Constant`, so
+        # the pass must leave the TupleIndex alone.
+        pair = self.helper(x, y)
+        return pair[idx]
+
+
+def test_pass_leaves_runtime_index_alone():
+    m = _scripted_inlined(_RuntimeIndex)
+    folded = fold_tuple_index_through_tuple_construct(m.graph)
+    assert folded == 0
+    assert _node_count(m.graph, "prim::TupleIndex") == 1
+
+
+class _NestedTupleConsumer(nn.Module):
+    """Tuple indexing inside `prim::If` exercises the recursive walker.
+
+    Each branch consumes the tuple by a different constant index so the
+    pass has work to do inside both blocks.
+    """
+
+    def helper(self, x, y):
+        return (x, y)
+
+    def forward(self, x, y, take_first: bool):
+        pair = self.helper(x, y)
+        if take_first:  # noqa: SIM108 -- explicit if/else exercises prim::If
+            out = pair[0]
+        else:
+            out = pair[1]
+        return out + 1.0
+
+
+def test_fold_walks_into_nested_blocks():
+    m = _scripted_inlined(_NestedTupleConsumer)
+    assert _node_count(m.graph, "prim::TupleIndex") == 2
+    folded = fold_tuple_index_through_tuple_construct(m.graph)
+    torch._C._jit_pass_dce(m.graph)
+    assert folded == 2
+    assert _node_count(m.graph, "prim::TupleIndex") == 0
+
+
+def test_pass_is_safe_when_no_tuple_index_present():
+    class _Plain(nn.Module):
+        def forward(self, x):
+            return x + 1.0
+
+    m = torch.jit.script(_Plain())
+    folded = fold_tuple_index_through_tuple_construct(m.graph)
+    assert folded == 0

--- a/torch_to_nnef/torch_graph/__init__.py
+++ b/torch_to_nnef/torch_graph/__init__.py
@@ -34,6 +34,7 @@ from torch_to_nnef.torch_graph.jit_inline import inline_unresolvable_submodules
 from torch_to_nnef.torch_graph.jit_passes import (
     fold_constant_ifs,
     fold_constant_scalar_arithmetic,
+    fold_tuple_index_through_tuple_construct,
     replace_size_calls_with_constants,
     strip_assertion_ifs,
     strip_prim_data,
@@ -52,6 +53,7 @@ __all__ = [
     "TorchModuleIRGraph",
     "fold_constant_ifs",
     "fold_constant_scalar_arithmetic",
+    "fold_tuple_index_through_tuple_construct",
     "inline_unresolvable_submodules",
     "replace_size_calls_with_constants",
     "strip_assertion_ifs",

--- a/torch_to_nnef/torch_graph/jit_passes.py
+++ b/torch_to_nnef/torch_graph/jit_passes.py
@@ -443,6 +443,50 @@ def strip_prim_data(graph: "torch._C.Graph") -> int:
     return folded
 
 
+def fold_tuple_index_through_tuple_construct(
+    graph: "torch._C.Graph",
+) -> int:
+    """Fold `prim::TupleIndex(tuple_const, k)` into the k-th tuple input.
+
+    JIT artifacts whose Python source builds a tuple at the call site
+    (e.g. `return (h, c)`) and consumes it later via positional indexing
+    (`pair[0]`, `pair[1]`) leave behind `prim::TupleConstruct ->
+    prim::TupleIndex` chains in the inlined graph. t2n's parser already
+    knows about `TupleConstruct` and `TupleUnpack`, but `TupleIndex` is
+    unsupported. When the index is a static `prim::Constant int` and the
+    tuple value is the direct output of a `TupleConstruct`, we rewire
+    `TupleIndex`'s output to the tuple's k-th input verbatim, leaving
+    the `TupleConstruct` itself in place (DCE removes it later if it
+    has no other consumers).
+
+    Returns the count of nodes folded.
+    """
+    folded = 0
+    for node in list(_walk_nodes(graph)):
+        if node.kind() != "prim::TupleIndex":
+            continue
+        inputs = list(node.inputs())
+        if len(inputs) != 2:
+            continue
+        tuple_node = inputs[0].node()
+        if tuple_node.kind() != "prim::TupleConstruct":
+            continue
+        idx_node = inputs[1].node()
+        if idx_node.kind() != "prim::Constant":
+            continue
+        try:
+            idx = int(idx_node["value"])
+        except (RuntimeError, TypeError):
+            continue
+        tuple_inputs = list(tuple_node.inputs())
+        if not 0 <= idx < len(tuple_inputs):
+            continue
+        node.output().replaceAllUsesWith(tuple_inputs[idx])
+        node.destroy()
+        folded += 1
+    return folded
+
+
 def fold_constant_ifs(graph: "torch._C.Graph") -> int:
     """Fold `prim::If` nodes whose condition is a `prim::Constant[bool]`.
 


### PR DESCRIPTION
## Summary

Phase 7 of the JIT-only model support plan, stacked on #85.

`fold_tuple_index_through_tuple_construct(graph)` rewrites `prim::TupleIndex(tuple_value, k)` into the k-th input of a direct `prim::TupleConstruct`, when `k` is a static `prim::Constant int`.

JIT artifacts whose Python source builds a tuple at the call site (`return (h, c)`) and consumes it later via positional indexing (`pair[0]`, `pair[1]`) leave behind `prim::TupleConstruct -> prim::TupleIndex` chains in the inlined graph. t2n's parser already knows about `TupleConstruct` and `TupleUnpack` but not `TupleIndex`; the fold removes the chain so the parser can proceed.

This was the last graph-level blocker on the Silero-VAD JIT export. The chain `inline_unresolvable_submodules -> dce -> replace_size_calls_with_constants -> fold_constant_scalar_arithmetic -> fold_constant_ifs -> fold_tuple_index_through_tuple_construct -> strip_prim_data -> strip_assertion_ifs -> dce` now leaves the inlined Silero graph in a shape t2n's parser can consume end-to-end.

Tests in `tests/test_jit_tuple_index.py` cover: basic fold + DCE roundtrip, output preservation (bitwise parity vs eager), runtime-index left alone, nested-block traversal, and the no-op-when-not-present case.