### PR TITLE
feat: Silero-VAD JIT demo + fold_data_dependent_ifs pass

### DIFF
--- a/examples/silero_vad/export.py
+++ b/examples/silero_vad/export.py
@@ -1,0 +1,60 @@
+"""Export Silero-VAD's `silero_vad.jit` straight to NNEF.
+
+Demonstrates the JIT-only model export chain end-to-end on a real-world
+model: Silero loads as a `torch.jit.ScriptModule` whose Python source is
+not on the import path, so the standard tracer cannot reach it. The
+chain below specializes the JIT graph for the example inputs and hands
+the result to `export_model_to_nnef`.
+"""
+
+from pathlib import Path
+
+import torch
+from silero_vad import load_silero_vad
+
+from torch_to_nnef import TractNNEF, export_model_to_nnef
+from torch_to_nnef.torch_graph import (
+    fold_constant_ifs,
+    fold_constant_scalar_arithmetic,
+    fold_data_dependent_ifs,
+    fold_tuple_index_through_tuple_construct,
+    inline_unresolvable_submodules,
+    replace_size_calls_with_constants,
+    strip_assertion_ifs,
+    strip_prim_data,
+)
+
+raw_model = load_silero_vad()._model.eval()
+x = torch.randn(1, 576, dtype=torch.float32) * 0.1
+state = torch.zeros(2, 1, 128, dtype=torch.float32)
+
+# `torch.jit.freeze` resolves CallMethod/CallFunction/GetAttr in one go.
+model = torch.jit.freeze(raw_model)
+torch._C._jit_pass_dce(model.graph)
+
+# JIT-only specialization chain. Each pass is a no-op on already-clean
+# graphs, so the order is safe to apply unconditionally.
+inline_unresolvable_submodules(model.graph, model)
+torch._C._jit_pass_dce(model.graph)
+replace_size_calls_with_constants(model.graph, [model, x, state])
+fold_constant_scalar_arithmetic(model.graph)
+fold_constant_ifs(model.graph)
+fold_tuple_index_through_tuple_construct(model.graph)
+strip_prim_data(model.graph)
+strip_assertion_ifs(model.graph)
+fold_data_dependent_ifs(model.graph, [model, x, state])
+torch._C._jit_pass_dce(model.graph)
+
+out_path = Path("silero_vad.nnef.tgz")
+export_model_to_nnef(
+    model=model,
+    args=(x, state),
+    file_path_export=out_path,
+    inference_target=TractNNEF(
+        version=TractNNEF.latest_version(),
+        check_io=True,
+    ),
+    input_names=["x", "state"],
+    output_names=["prob", "new_state"],
+)
+print(f"exported {out_path.absolute()}")

--- a/examples/silero_vad/requirements.txt
+++ b/examples/silero_vad/requirements.txt
@@ -1,0 +1,4 @@
+-e ../../
+silero-vad
+torch==2.11.0
+torchaudio==2.9.1

--- a/tests/test_jit_data_dependent_ifs.py
+++ b/tests/test_jit_data_dependent_ifs.py
@@ -1,0 +1,108 @@
+"""Tests for `fold_data_dependent_ifs`.
+
+PyTorch's JIT shape analysis does not propagate shapes through
+`prim::If` nodes that produce tensors. That leaves runtime dim/shape
+checks (e.g. `nn.LSTMCell`'s `if input.dim() == 1: input.unsqueeze(0)`)
+in the graph after the standard size-fold + constant-If passes have
+run. `fold_data_dependent_ifs` evaluates each remaining If's condition
+by re-executing the graph with the user's example inputs, then inlines
+the chosen branch; bitwise output equivalence is verified below.
+"""
+
+import torch
+from torch import nn
+
+from torch_to_nnef.torch_graph import fold_data_dependent_ifs
+
+
+def _walk(g):
+    for n in g.nodes():
+        yield n
+        for blk in n.blocks():
+            yield from _walk(blk)
+
+
+def _node_count(g, kind):
+    return sum(1 for n in _walk(g) if n.kind() == kind)
+
+
+class _DimDependentBranch(nn.Module):
+    """`x.dim() == 1` branch that JIT shape-analysis cannot fold.
+
+    The condition is data-dependent in the sense that it relies on a
+    runtime tensor property; `replace_size_calls_with_constants` only
+    folds dim/size queries that flow purely into control flow, and this
+    one feeds an `aten::unsqueeze` (tensor production), so it survives.
+    """
+
+    def forward(self, x):
+        if x.dim() == 1:
+            x = x.unsqueeze(0)
+        return x + 1.0
+
+
+def test_fold_picks_branch_consistent_with_example():
+    m = torch.jit.script(_DimDependentBranch())
+    torch._C._jit_pass_inline(m.graph)
+    x = torch.randn(2, 3)  # 2D input -> the False branch is correct
+    assert _node_count(m.graph, "prim::If") == 1
+
+    folded = fold_data_dependent_ifs(m.graph, [m, x])
+    torch._C._jit_pass_dce(m.graph)
+
+    assert folded == 1
+    assert _node_count(m.graph, "prim::If") == 0
+
+
+def test_fold_preserves_output():
+    """Bitwise parity: rewriting the graph must not change behavior."""
+    ref = _DimDependentBranch().eval()
+    x = torch.randn(2, 3)
+    expected = ref(x)
+
+    m = torch.jit.script(_DimDependentBranch())
+    torch._C._jit_pass_inline(m.graph)
+    fold_data_dependent_ifs(m.graph, [m, x])
+    torch._C._jit_pass_dce(m.graph)
+
+    got = m(x)
+    assert torch.allclose(got, expected)
+
+
+class _NestedDimIfs(nn.Module):
+    """Nested data-dependent Ifs exercise the fixed-point loop.
+
+    After the outer If is folded, the inner one surfaces to the top
+    level and a second iteration picks it up.
+    """
+
+    def forward(self, x):
+        if x.dim() == 1:
+            x = x.unsqueeze(0)
+        if x.dim() == 2:
+            return x + 1.0
+        return x - 1.0
+
+
+def test_fold_handles_nested_ifs_via_fixed_point():
+    m = torch.jit.script(_NestedDimIfs())
+    torch._C._jit_pass_inline(m.graph)
+    x = torch.randn(4, 5)
+    assert _node_count(m.graph, "prim::If") == 2
+
+    folded = fold_data_dependent_ifs(m.graph, [m, x])
+    torch._C._jit_pass_dce(m.graph)
+
+    assert folded == 2
+    assert _node_count(m.graph, "prim::If") == 0
+
+
+def test_fold_is_safe_when_no_if_present():
+    class _Plain(nn.Module):
+        def forward(self, x):
+            return x + 1.0
+
+    m = torch.jit.script(_Plain())
+    x = torch.randn(3)
+    folded = fold_data_dependent_ifs(m.graph, [m, x])
+    assert folded == 0

--- a/torch_to_nnef/op/aten/math.py
+++ b/torch_to_nnef/op/aten/math.py
@@ -31,9 +31,12 @@ def div(node, op_helper, inference_target, torch_graph, **kwargs):
     rounding_mode = None
 
     if input_node.data is not None and divisor_node.data is not None:
-        node.outputs[0].set_data(
-            (input_node.data / divisor_node.data).to(node.outputs[0].dtype)
-        )
+        result = input_node.data / divisor_node.data
+        if not isinstance(result, torch.Tensor):
+            result = torch.tensor(result, dtype=node.outputs[0].dtype)
+        else:
+            result = result.to(node.outputs[0].dtype)
+        node.outputs[0].set_data(result)
         return []
 
     if remap_if_neutral_op(torch_graph, node, divisor_node, input_node):

--- a/torch_to_nnef/op/aten/matmul.py
+++ b/torch_to_nnef/op/aten/matmul.py
@@ -56,8 +56,11 @@ def _convolution_mode(
     padding = padding_node.data
     groups = groups_node.data
 
-    assert isinstance(padding, str), padding
-    if padding == "valid":
+    if isinstance(padding, (list, tuple)):
+        # `aten::conv1d/conv2d/conv3d` already carry an int-list padding,
+        # so no normalization is needed.
+        pass
+    elif padding == "valid":
         padding = [0] * len(stride)
     elif padding == "same":
         # ref: https://pytorch.org/docs/stable/generated/torch.nn.Conv2d.html

--- a/torch_to_nnef/op/aten/selector.py
+++ b/torch_to_nnef/op/aten/selector.py
@@ -71,7 +71,16 @@ def slice_(
 
     has_concrete_values = True
     # we use this since by default pytorch generate max int64 value for end
-    if begin_node.data is not None:
+    begin_is_default_none = (
+        isinstance(begin_node, PythonConstant) and begin_node.data is None
+    )
+    end_is_default_none = (
+        isinstance(end_node, PythonConstant) and end_node.data is None
+    )
+    if begin_is_default_none:
+        # `t[None:n]` -> begin defaults to 0
+        begin = 0
+    elif begin_node.data is not None:
         if begin_node.data >= 0:
             begin = pick_index_in_axis(
                 input_node, dim, begin_node.data, check_is_positive=False
@@ -83,7 +92,10 @@ def slice_(
         has_concrete_values = False
         begin = nnef.Identifier(begin_node.export_name)
 
-    if end_node.data is not None:
+    if end_is_default_none:
+        # `t[:None]` -> end defaults to int64 max
+        end = np.iinfo(np.int64).max
+    elif end_node.data is not None:
         if end_node.data >= 0:
             end = pick_index_in_axis(
                 input_node, dim, end_node.data, check_is_positive=False

--- a/torch_to_nnef/torch_graph/__init__.py
+++ b/torch_to_nnef/torch_graph/__init__.py
@@ -34,6 +34,7 @@ from torch_to_nnef.torch_graph.jit_inline import inline_unresolvable_submodules
 from torch_to_nnef.torch_graph.jit_passes import (
     fold_constant_ifs,
     fold_constant_scalar_arithmetic,
+    fold_data_dependent_ifs,
     fold_tuple_index_through_tuple_construct,
     replace_size_calls_with_constants,
     strip_assertion_ifs,
@@ -53,6 +54,7 @@ __all__ = [
     "TorchModuleIRGraph",
     "fold_constant_ifs",
     "fold_constant_scalar_arithmetic",
+    "fold_data_dependent_ifs",
     "fold_tuple_index_through_tuple_construct",
     "inline_unresolvable_submodules",
     "replace_size_calls_with_constants",

--- a/torch_to_nnef/torch_graph/ir_helpers.py
+++ b/torch_to_nnef/torch_graph/ir_helpers.py
@@ -553,7 +553,7 @@ def _rerouted_parsing(
                     raise T2NErrorNotImplemented(o_type.kind())
 
                 dtype = str_to_torch_dtype(stype) if stype else None
-                dnode.name = o_node_c_value.debugName()
+                dnode.name = cleanup_data_name(o_node_c_value.debugName())
                 dnode.shape = shape
                 dnode.dtype = dtype
                 dnode.set_data(o_node_c_value.toIValue())

--- a/torch_to_nnef/torch_graph/jit_passes.py
+++ b/torch_to_nnef/torch_graph/jit_passes.py
@@ -564,3 +564,85 @@ def strip_assertion_ifs(graph: "torch._C.Graph") -> int:
             # Iterators over a parent block may now be invalidated; restart.
             break
     return total
+
+
+def _eval_value_by_example(
+    graph: "torch._C.Graph",
+    value: "torch._C.Value",
+    example_inputs: T.Sequence[T.Any],
+) -> T.Any:
+    """Run the graph with the given example inputs, returning `value`.
+
+    Temporarily swaps the graph's outputs for `value`, executes via
+    `torch._C._jit_interpret_graph`, and restores the original outputs.
+    The mutation/restore happens under try/finally so the graph is left
+    in its original state even on interpreter failure.
+    """
+    orig_outputs = list(graph.outputs())
+    n_outs = len(orig_outputs)
+    for _ in range(n_outs):
+        graph.eraseOutput(0)
+    graph.registerOutput(value)
+    try:
+        return torch._C._jit_interpret_graph(graph, tuple(example_inputs))
+    finally:
+        graph.eraseOutput(0)
+        for o in orig_outputs:
+            graph.registerOutput(o)
+
+
+def fold_data_dependent_ifs(
+    graph: "torch._C.Graph",
+    example_inputs: T.Sequence[T.Any],
+) -> int:
+    """Fold `prim::If` nodes whose condition is data-dependent on the input.
+
+    PyTorch's JIT shape-analysis passes do not propagate shapes through
+    `prim::If` nodes that produce tensors, leaving runtime dim/shape
+    checks (e.g. `nn.LSTMCell`'s `if input.dim() == 1: ...`) unresolved
+    by `replace_size_calls_with_constants` + `fold_constant_ifs`. To
+    specialize the graph for the user's example inputs, we evaluate
+    each remaining `prim::If`'s condition by running the graph itself
+    with the example, observing the chosen branch, and inlining it.
+
+    Only top-level Ifs are folded each pass; nested Ifs surface to the
+    top once their parent is removed, so a fixed-point loop catches
+    them too.
+
+    Returns the number of Ifs folded.
+    """
+    top_block = graph.return_node().owningBlock()
+    total = 0
+    for _ in range(20):
+        candidates = [
+            n
+            for n in graph.nodes()
+            if n.kind() == "prim::If" and n.owningBlock() == top_block
+        ]
+        folded = 0
+        for if_node in candidates:
+            cond_v = next(if_node.inputs())
+            try:
+                cond_val = _eval_value_by_example(graph, cond_v, example_inputs)
+            except Exception:  # noqa: BLE001 -- interpreter may fail; skip
+                continue
+            if not isinstance(cond_val, bool):
+                continue
+            blocks = list(if_node.blocks())
+            if len(blocks) != 2:
+                continue
+            chosen = blocks[0 if cond_val else 1]
+            keep_outs = list(chosen.returnNode().inputs())
+            node_outs = list(if_node.outputs())
+            if len(keep_outs) != len(node_outs):
+                continue
+            for old, new in zip(node_outs, keep_outs, strict=True):
+                old.replaceAllUsesWith(new)
+            for n in list(chosen.nodes()):
+                n.moveBefore(if_node)
+            if_node.destroy()
+            folded += 1
+        if folded == 0:
+            break
+        total += folded
+    return total


### PR DESCRIPTION
Closes the JIT-only export chain on a real-world model. `torch.jit.freeze` + the existing passes leave behind `nn.LSTMCell`'s runtime dim check because PyTorch's JIT shape analysis does not propagate through tensor-producing `prim::If` nodes. New `fold_data_dependent_ifs` evaluates each remaining If's condition by re-executing the graph with the user's example via `torch._C._jit_interpret_graph` and inlines the chosen branch.

Four pre-existing parser bugs surfaced by Silero are fixed alongside:
- TupleUnpack name normalization: `h0.1` was stored raw but lookups normalize dots to underscores.
- Slice handler `prim::Constant[None]` defaults: Python's `t[:]` lowers to `aten::slice(t, dim, None, None)`.
- Div handler scalar-result casting: both-Python-scalar division returns a float, which has no `.to`.
- Conv handler `aten::conv1d/2d/3d` list padding: the `_convolution_mode` handler is registered for both str-mode and regular convs but asserted str padding.

`examples/silero_vad/` exports `silero_vad.jit` straight to NNEF; the result loads in tract and matches outputs under `check_io=True`.