### PR TITLE
feat(torch_graph,op): IR + parser bug fixes for JIT-only models

### DIFF
--- a/tests/test_aten_parser_fixes.py
+++ b/tests/test_aten_parser_fixes.py
@@ -1,0 +1,85 @@
+"""Regression tests for aten-handler bugs surfaced by JIT-only export.
+
+Each test scripts a tiny module that hits a specific parser code path,
+exports through the full t2n pipeline with `check_io=False` (skip tract
+verification, we only need IR construction to succeed), and asserts the
+export call returns without raising.
+
+The originals were all latent bugs reachable by Silero-VAD; here we
+isolate each one to a minimal repro so a regression breaks the test
+without depending on `silero-vad` being installed.
+"""
+
+import tempfile
+from pathlib import Path
+
+import torch
+import torch.nn.functional as F
+from torch import nn
+
+from torch_to_nnef.export import export_model_to_nnef
+from torch_to_nnef.inference_target import TractNNEF
+
+
+def _export(model, args, **kwargs):
+    with tempfile.TemporaryDirectory() as tmpdir:
+        out = Path(tmpdir) / "model.nnef.tgz"
+        export_model_to_nnef(
+            model=model,
+            args=args,
+            file_path_export=out,
+            inference_target=TractNNEF(
+                version=TractNNEF.latest_version(), check_io=False
+            ),
+            **kwargs,
+        )
+
+
+class _SliceWithNoneBounds(nn.Module):
+    """`t[:]` lowers to `aten::slice(t, dim, None, None, 1)`."""
+
+    def forward(self, x):
+        return x[:] + 1.0
+
+
+def test_slice_with_none_bounds_exports():
+    m = torch.jit.script(_SliceWithNoneBounds().eval())
+    _export(m, (torch.randn(2, 3),))
+
+
+class _DivOfTwoIntAttrs(nn.Module):
+    """`int / int` constants surface a Python-scalar `.data` in the parser."""
+
+    def __init__(self):
+        super().__init__()
+        # frozen graphs bake int attrs as `prim::Constant`; the divider
+        # then folds at parser time and exercises the scalar-result path.
+        self.numer = 256
+        self.denom = 2
+
+    def forward(self, x):
+        ratio = float(self.numer / self.denom)
+        return x * ratio
+
+
+def test_div_of_two_scalars_exports():
+    m = torch.jit.freeze(torch.jit.script(_DivOfTwoIntAttrs().eval()))
+    _export(m, (torch.randn(2, 3),))
+
+
+class _Conv1dWithListPadding(nn.Module):
+    """`F.conv1d(..., padding=0)` with a literal int yields list padding."""
+
+    def __init__(self):
+        super().__init__()
+        self.weight = nn.Parameter(torch.randn(4, 3, 3))
+        self.bias = nn.Parameter(torch.zeros(4))
+
+    def forward(self, x):
+        return F.conv1d(x, self.weight, self.bias, stride=1, padding=0)
+
+
+def test_conv1d_with_list_padding_exports():
+    """The handler is registered for aten::conv1d which has int-list padding."""
+    m = torch.jit.script(_Conv1dWithListPadding().eval())
+    _export(m, (torch.randn(1, 3, 16),))

--- a/tests/test_jit_scalar_outputs.py
+++ b/tests/test_jit_scalar_outputs.py
@@ -1,0 +1,84 @@
+"""Tests for scalar-typed op outputs in the t2n IR.
+
+`TensorVariable.parse` was extended to accept `IntType` (already supported),
+`FloatType`, and `BoolType` SSA values: inlined / constfolded JIT graphs
+surface these as op outputs (e.g. `aten::Int`, `aten::Bool`, `aten::div(int,
+int) -> float`) and t2n's parser must not refuse them.
+"""
+
+import torch
+from torch import nn
+
+from torch_to_nnef.torch_graph.ir_data import TensorVariable
+
+
+def _walk(g):
+    for n in g.nodes():
+        yield n
+        for blk in n.blocks():
+            yield from _walk(blk)
+
+
+class _IntDiv(nn.Module):
+    def forward(self, x):
+        # `len(x) / 2` produces a `FloatType` SSA value via aten::div.
+        return x + (len(x) / 2.0)
+
+
+def test_float_scalar_output_parses():
+    m = torch.jit.script(_IntDiv())
+    div_outputs = [
+        out
+        for n in _walk(m.graph)
+        if n.kind() == "aten::div"
+        for out in n.outputs()
+        if out.type().annotation_str == "float"
+    ]
+    assert div_outputs, "test setup expected an aten::div with float output"
+
+    parsed = TensorVariable.parse(div_outputs[0])
+    assert parsed.dtype == torch.float32
+    assert parsed.shape == [1]
+
+
+class _BoolCast(nn.Module):
+    def forward(self, x, k: int):
+        return x + (1.0 if bool(k) else 0.0)
+
+
+def test_bool_scalar_output_parses():
+    m = torch.jit.script(_BoolCast())
+    bool_outputs = [
+        out
+        for n in _walk(m.graph)
+        if n.kind() == "aten::Bool"
+        for out in n.outputs()
+        if out.type().annotation_str == "bool"
+    ]
+    assert bool_outputs, "test setup expected an aten::Bool with bool output"
+
+    parsed = TensorVariable.parse(bool_outputs[0])
+    assert parsed.dtype == torch.bool
+    assert parsed.shape == [1]
+
+
+def test_int_scalar_output_still_parses():
+    """Sanity: the IntType path that already worked must still pass."""
+
+    class _LenQ(nn.Module):
+        def forward(self, x):
+            return x[: len(x)]
+
+    m = torch.jit.script(_LenQ())
+    len_outputs = [
+        out
+        for n in _walk(m.graph)
+        if n.kind() == "aten::len"
+        for out in n.outputs()
+        if out.type().annotation_str == "int"
+    ]
+    assert len_outputs
+
+    parsed = TensorVariable.parse(len_outputs[0])
+    assert parsed.dtype == torch.int64
+    assert parsed.shape == [1]

--- a/torch_to_nnef/op/aten/math.py
+++ b/torch_to_nnef/op/aten/math.py
@@ -22,6 +22,19 @@ LOGGER = logging.getLogger(__name__)
 OP_REGISTRY = AtenOpRegistry()
 
 
+def _div_constant_result(numerator, divisor, output_dtype) -> torch.Tensor:
+    """Return `numerator / divisor` as a tensor of `output_dtype`.
+
+    Both inputs may be Python scalars (after frozen-graph constant
+    folding); their division returns a Python scalar that has no `.to`,
+    so wrap before casting.
+    """
+    result = numerator / divisor
+    if not isinstance(result, torch.Tensor):
+        return torch.tensor(result, dtype=output_dtype)
+    return result.to(output_dtype)
+
+
 @OP_REGISTRY.register()
 def div(node, op_helper, inference_target, torch_graph, **kwargs):
     """Map PyTorch: 'aten:div' to NNEF."""
@@ -32,7 +45,9 @@ def div(node, op_helper, inference_target, torch_graph, **kwargs):
 
     if input_node.data is not None and divisor_node.data is not None:
         node.outputs[0].set_data(
-            (input_node.data / divisor_node.data).to(node.outputs[0].dtype)
+            _div_constant_result(
+                input_node.data, divisor_node.data, node.outputs[0].dtype
+            )
         )
         return []
 

--- a/torch_to_nnef/op/aten/matmul.py
+++ b/torch_to_nnef/op/aten/matmul.py
@@ -56,8 +56,11 @@ def _convolution_mode(
     padding = padding_node.data
     groups = groups_node.data
 
-    assert isinstance(padding, str), padding
-    if padding == "valid":
+    if isinstance(padding, (list, tuple)):
+        # `aten::conv1d/conv2d/conv3d` already carry an int-list padding,
+        # so no normalization is needed.
+        pass
+    elif padding == "valid":
         padding = [0] * len(stride)
     elif padding == "same":
         # ref: https://pytorch.org/docs/stable/generated/torch.nn.Conv2d.html

--- a/torch_to_nnef/op/aten/selector.py
+++ b/torch_to_nnef/op/aten/selector.py
@@ -44,6 +44,30 @@ def _nnef_cast(op_helper, node, tensor, to_tract_dtype: str, suffix: str = ""):
     )
 
 
+def _resolve_slice_bound(bound_node, input_node, dim: int, default):
+    """Resolve a slice begin/end into either a concrete int or an Identifier.
+
+    Returns `(value, has_concrete_value)`. `has_concrete_value` is False
+    when the bound is a runtime Identifier or a negative concrete value
+    (the latter requires deferred resolution against `dim_size`).
+
+    A `prim::Constant[NoneType]` bound (`t[:n]` or `t[m:]`) maps to the
+    `default` argument: 0 for begin, INT64_MAX for end.
+    """
+    if isinstance(bound_node, PythonConstant) and bound_node.data is None:
+        return default, True
+    if bound_node.data is None:
+        return nnef.Identifier(bound_node.export_name), False
+    if bound_node.data >= 0:
+        return (
+            pick_index_in_axis(
+                input_node, dim, bound_node.data, check_is_positive=False
+            ),
+            True,
+        )
+    return bound_node.data, False
+
+
 @OP_REGISTRY.register(torch_op_ids=["slice"])
 def slice_(
     node,
@@ -69,31 +93,14 @@ def slice_(
     # we assert for now all node except first are all constant
     dim = axis_node.data
 
-    has_concrete_values = True
     # we use this since by default pytorch generate max int64 value for end
-    if begin_node.data is not None:
-        if begin_node.data >= 0:
-            begin = pick_index_in_axis(
-                input_node, dim, begin_node.data, check_is_positive=False
-            )
-        else:
-            begin = begin_node.data
-            has_concrete_values = False
-    else:
-        has_concrete_values = False
-        begin = nnef.Identifier(begin_node.export_name)
-
-    if end_node.data is not None:
-        if end_node.data >= 0:
-            end = pick_index_in_axis(
-                input_node, dim, end_node.data, check_is_positive=False
-            )
-        else:
-            has_concrete_values = False
-            end = end_node.data
-    else:
-        has_concrete_values = False
-        end = nnef.Identifier(end_node.export_name)
+    begin, begin_concrete = _resolve_slice_bound(
+        begin_node, input_node, dim, default=0
+    )
+    end, end_concrete = _resolve_slice_bound(
+        end_node, input_node, dim, default=np.iinfo(np.int64).max
+    )
+    has_concrete_values = begin_concrete and end_concrete
 
     fixed_dims_and_higher_end_slice = (
         isinstance(end, int)

--- a/torch_to_nnef/torch_graph/ir_data.py
+++ b/torch_to_nnef/torch_graph/ir_data.py
@@ -30,8 +30,10 @@ from torch_to_nnef.exceptions import (
 )
 from torch_to_nnef.torch_graph.torch_const import (
     ATEN_SCALARIMPLICIT,
+    BOOLTYPE_KIND,
     CONSTANT_KIND,
     DICTTYPE_KIND,
+    FLOATTYPE_KIND,
     INTTYPE_KIND,
     NUMBERTYPE_KIND,
     TUPLETYPE_KIND,
@@ -279,11 +281,24 @@ class TensorVariable(Data):
             )
         return data.to(self.dtype)
 
+    SCALAR_TYPE_KIND_TO_DTYPE = {
+        INTTYPE_KIND: torch.int64,
+        FLOATTYPE_KIND: torch.float32,
+        BOOLTYPE_KIND: torch.bool,
+    }
+
     @classmethod
     def parse(cls, node_c_value: torch._C.Value) -> "TensorVariable":
         node_type = node_c_value.type()
-        if node_type.kind() == INTTYPE_KIND:
-            dtype = torch.int64
+        scalar_dtype = cls.SCALAR_TYPE_KIND_TO_DTYPE.get(node_type.kind())
+        if scalar_dtype is not None:
+            # Python-typed scalar SSA value (int, float, bool). Inlined or
+            # constfolded JIT graphs surface these for ops like `aten::Int`,
+            # `aten::Bool`, `aten::div(int,int) -> float` that survived
+            # specialization. Represent as a 1-element tensor of the right
+            # dtype, mirroring how INT scalars were already handled.
+            dtype = scalar_dtype
+            shape = [1]
         else:
             if node_type.kind() == NUMBERTYPE_KIND:
                 parent_node = node_c_value.node()
@@ -293,11 +308,10 @@ class TensorVariable(Data):
                     raise T2NErrorNotImplemented()
             stype = node_type.scalarType()
             dtype = str_to_torch_dtype(stype) if stype else None
+            shape = node_type.sizes()
         return cls(
             name=node_c_value.debugName(),
-            shape=[1]
-            if node_type.kind() == INTTYPE_KIND
-            else node_type.sizes(),
+            shape=shape,
             dtype=dtype,
             data=node_c_value.toIValue(),
             quant=None,

--- a/torch_to_nnef/torch_graph/ir_helpers.py
+++ b/torch_to_nnef/torch_graph/ir_helpers.py
@@ -254,14 +254,34 @@ def _find_data_node(data_nodes: ReactiveNamedItemDict, name: str):
 
 
 def _parse_getattr_tensor(node: torch._C.Node, module, data_nodes):
-    data_state = _unfold_graph_getattr_by_node(module, node)[1].data
-    data_nodes.append(
-        TensorVariable(
-            name=node.output().debugName(),
-            shape=list(data_state.shape),
-            dtype=data_state.dtype,
-            data=data_state,
+    """Resolve a `prim::GetAttr` node into a Data entry.
+
+    Inlined JIT graphs (see `torch._C._jit_pass_inline`) surface attribute
+    accesses for both tensors (parameters/buffers) and Python scalars
+    (e.g. an int field like `context_size_samples` registered on the module).
+    Tensors become a TensorVariable; bool/int/float/str/None attrs become a
+    PythonConstant. Anything else is rejected.
+    """
+    name = node.output().debugName()
+    attr = _unfold_graph_getattr_by_node(module, node)[1]
+    if isinstance(attr, torch.Tensor):
+        data_nodes.append(
+            TensorVariable(
+                name=name,
+                shape=list(attr.shape),
+                dtype=attr.dtype,
+                data=attr,
+            )
         )
+        return
+    # Order matters: bool subclasses int in Python, but isinstance against the
+    # tuple still returns True so the PythonConstant carries the original value.
+    if attr is None or isinstance(attr, (bool, int, float, str)):
+        data_nodes.append(PythonConstant(name=name, data=attr))
+        return
+    raise T2NErrorNotImplemented(
+        f"prim::GetAttr resolves to unsupported type "
+        f"{type(attr).__name__} for {name}"
     )
 
 
@@ -307,6 +327,12 @@ def _parse_constant(node: torch._C.Node, data_nodes) -> T.Optional[Data]:
         # Device will not be useful info for us but we pass it to avoid
         # dereferencing it from full graph
         pass
+    elif dtype.startswith("List["):
+        # Inlined/frozen JIT graphs may carry list constants
+        # (e.g. dilation=[1] baked into aten::conv1d) that would otherwise
+        # come from a prim::ListConstruct.
+        ivalue = node.output().toIValue()
+        data = list(ivalue) if ivalue is not None else []
     else:
         raise T2NErrorNotImplemented(dtype)
     data_nodes.append(PythonConstant(name=name, data=data))
@@ -527,7 +553,7 @@ def _rerouted_parsing(
                     raise T2NErrorNotImplemented(o_type.kind())
 
                 dtype = str_to_torch_dtype(stype) if stype else None
-                dnode.name = o_node_c_value.debugName()
+                dnode.name = cleanup_data_name(o_node_c_value.debugName())
                 dnode.shape = shape
                 dnode.dtype = dtype
                 dnode.set_data(o_node_c_value.toIValue())

--- a/torch_to_nnef/torch_graph/ir_op.py
+++ b/torch_to_nnef/torch_graph/ir_op.py
@@ -87,6 +87,7 @@ from torch_to_nnef.torch_graph.torch_const import (
     NUMTOTENSOR_KIND,
     TUPLETYPE_KIND,
     WIRED_CUSTOM_LSTM,
+    WIRED_CUSTOM_LSTM_CELL,
 )
 from torch_to_nnef.utils import ReactiveNamedItemDict
 
@@ -612,6 +613,13 @@ class TorchOp:
     def realise_output_type_and_size(self, approx: bool = True) -> bool:
         """Trace output and try to find type shape and constant realisation."""
         if self.kind == CALL_KIND:
+            return False
+        # nn.LSTMCell carries an `(input, hx)` Python signature where `hx` is
+        # a tuple. The IR flattens that to `(input, h, c)` (and reorders
+        # them positionally), so calling `op_ref(*self.args)` to infer
+        # shapes raises a TypeError. The LSTMCellExtractor sets shapes on
+        # its outputs explicitly so this fallback is unnecessary anyway.
+        if self.kind == WIRED_CUSTOM_LSTM_CELL:
             return False
 
         if not all(_.tracable for _ in self.inputs):

--- a/torch_to_nnef/torch_graph/torch_const.py
+++ b/torch_to_nnef/torch_graph/torch_const.py
@@ -59,6 +59,8 @@ TUPLETYPE_KIND = "TupleType"
 LISTTYPE_KIND = "ListType"
 NONETYPE_KIND = "NoneType"
 INTTYPE_KIND = "IntType"
+FLOATTYPE_KIND = "FloatType"
+BOOLTYPE_KIND = "BoolType"
 NUMBERTYPE_KIND = "NumberType"  # This type represents a Python number
 DICTTYPE_KIND = "DictType"
 # Subtype hierarchy for Number Types (NumberType as the base type):
@@ -71,6 +73,7 @@ MODULE_PATH_QUANTIZED = "TORCH_INTERNAL_QUANTIZED"
 SPECIAL_ATEN_REMAP_PYTORCH = {"__and__": "bitwise_and", "__or__": "bitwise_or"}
 
 WIRED_CUSTOM_LSTM = "wired_custom::LSTM"
+WIRED_CUSTOM_LSTM_CELL = "wired_custom::LSTMCell"
 
 MAP_TO_NOP = [
     NUMTOTENSOR_KIND,


### PR DESCRIPTION
Bottom of a 5-PR stack: small IR and parser fixes that surface immediately on any JIT-only model whose Python source isn't on the import path.

## IR fixes

- `_parse_constant`: handle `List[int|float|bool]` baked into frozen JIT graphs.
- `_parse_getattr_tensor`: accept non-Tensor module attributes (int/float/bool/str/None) as `PythonConstant`.
- `TensorVariable.parse`: accept `FloatType` and `BoolType` SSA values as 1-element tensors via a new `SCALAR_TYPE_KIND_TO_DTYPE` lookup; previously only `IntType` was wrapped.
- `prim::TupleUnpack` handler: route the renamed output name through `cleanup_data_name` so SSA names containing dots (e.g. `h0.1`) match the lookup convention used elsewhere in the IR. Without this, lookups normalize dots to underscores but storage left them raw, breaking the round-trip.

## Parser bug fixes

Each is pre-existing latent, surfaced while exporting Silero-VAD:

- `slice_`: recognize `prim::Constant[NoneType]` for begin/end. Python's `t[:]` lowers to `aten::slice(t, dim, None, None)`; the handler treated None as a dynamic Identifier instead of substituting defaults (begin=0, end=INT64_MAX).
- `div`: wrap scalar division result in a 0-d tensor before `.to(dtype)`. Both-Python-scalar division returns a float without `.to`.
- `_convolution_mode`: skip the str-mode branch when padding is a list. The handler is registered for both `_convolution_mode` (str padding) and `aten::conv1d/2d/3d` (int-list padding); the str-only assertion would fire on any short-form conv.

## Tests

`tests/test_jit_scalar_outputs.py` covers Float/Bool/Int SSA round-trips through `TensorVariable.parse`. The three aten-handler fixes (slice/div/conv) are exercised end-to-end via the Silero demo in #92; no targeted unit test in this PR.

## Stack

Part of a 5-PR stack: **#88 (this PR)** -> #89 (selective inline) -> #90 (graph hardening passes) -> #91 (aten lstm_cell + canonical RNN) -> #92 (`harden_jit_for_export` helper + Silero demo).
