### PR TITLE
feat(torch_graph): selective inline of unresolvable JIT submodules

### DIFF
--- a/tests/test_jit_inline.py
+++ b/tests/test_jit_inline.py
@@ -1,0 +1,169 @@
+"""Tests for `torch_to_nnef.torch_graph.inline_unresolvable_submodules`.
+
+Covers:
+- Importable submodules are preserved (no inlining when not needed).
+- Non-importable submodules are inlined; output stays bitwise-equal.
+- The pass is idempotent on a fully-resolved graph.
+- The Silero-VAD JIT integration test (gated on silero_vad availability)
+  confirms only the `vad.*` calls are inlined while every `torch.nn.*`
+  call is preserved as a `prim::CallMethod` for downstream extractors.
+"""
+
+import importlib
+from collections import Counter
+
+import pytest
+import torch
+from torch import nn
+
+from torch_to_nnef.torch_graph import inline_unresolvable_submodules
+
+
+def _walk_nodes(graph_or_block):
+    for node in graph_or_block.nodes():
+        yield node
+        for blk in node.blocks():
+            yield from _walk_nodes(blk)
+
+
+def _callmethod_counts(graph) -> Counter:
+    counts = Counter()
+    for n in _walk_nodes(graph):
+        if n.kind() != "prim::CallMethod":
+            continue
+        ty = next(n.inputs()).type()
+        try:
+            counts[ty.qualified_name()] += 1
+        except (RuntimeError, AttributeError):
+            counts["<unknown>"] += 1
+    return counts
+
+
+class _PureTorchSubmod(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.lin = nn.Linear(4, 4)
+
+    def forward(self, x):
+        return torch.relu(self.lin(x))
+
+
+class _PureTorchOuter(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.inner = _PureTorchSubmod()
+
+    def forward(self, x):
+        return self.inner(x) + 1.0
+
+
+def test_inline_is_noop_when_all_classes_resolvable():
+    """No-op path: every CallMethod target lives in an importable module.
+
+    The graph should be untouched; count stays the same.
+    """
+    m = torch.jit.script(_PureTorchOuter().eval())
+    before = _callmethod_counts(m.graph)
+    assert before, "test setup expected at least one CallMethod"
+
+    inlined = inline_unresolvable_submodules(m.graph, m)
+    after = _callmethod_counts(m.graph)
+
+    assert inlined == 0
+    assert before == after
+
+
+def test_inline_drops_non_importable_targets_and_preserves_torchnn(
+    monkeypatch,
+):
+    """Inline path under a forced ModuleNotFoundError on the inner class.
+
+    Patches `importlib.import_module` so the test-local outer's qualname
+    raises. Afterwards every surviving CallMethod must target an
+    importable `torch.nn.*` class, and outputs must match.
+    """
+    m = torch.jit.script(_PureTorchOuter().eval())
+
+    # Find the qualname host module for our test-local class and patch
+    # importlib.import_module to raise on that exact path. Real torch.nn.*
+    # imports must still succeed.
+    inner_call = next(
+        n for n in _walk_nodes(m.graph) if n.kind() == "prim::CallMethod"
+    )
+    inner_qname = next(inner_call.inputs()).type().qualified_name()
+    parts = [
+        p
+        for p in inner_qname[len("__torch__.") :].split(".")
+        if "___torch_mangle_" not in p
+    ]
+    inner_mod_path = ".".join(parts[:-1])
+
+    real_import = importlib.import_module
+
+    def fake_import_module(name, *args, **kwargs):
+        if name == inner_mod_path:
+            raise ModuleNotFoundError(f"forced for test: {name}")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(
+        "torch_to_nnef.torch_graph.jit_inline.importlib.import_module",
+        fake_import_module,
+    )
+
+    ref_x = torch.randn(2, 4)
+    with torch.no_grad():
+        ref_y = m(ref_x)
+    inlined = inline_unresolvable_submodules(m.graph, m)
+    torch._C._jit_pass_dce(m.graph)
+    with torch.no_grad():
+        new_y = m(ref_x)
+
+    assert inlined >= 1
+    after = _callmethod_counts(m.graph)
+    for qn in after:
+        assert qn.startswith("__torch__.torch.nn."), (
+            f"non-torch.nn.* CallMethod survived inline: {qn}"
+        )
+    assert torch.allclose(ref_y, new_y)
+
+
+def test_inline_is_idempotent():
+    m = torch.jit.script(_PureTorchOuter().eval())
+    n1 = inline_unresolvable_submodules(m.graph, m)
+    n2 = inline_unresolvable_submodules(m.graph, m)
+    assert (n1, n2) == (0, 0)
+
+
+@pytest.mark.skipif(
+    importlib.util.find_spec("silero_vad") is None,
+    reason="silero_vad not installed",
+)
+def test_inline_silero_vad_jit_real_world():
+    """End-to-end on the upstream silero-vad JIT.
+
+    Only `vad.*` modules should be inlined; every `torch.nn.*` call must
+    survive; outputs must be bitwise-identical to the unmodified JIT.
+    """
+    from silero_vad import load_silero_vad
+
+    full = load_silero_vad()
+    inner = full._model.eval()
+    x = torch.randn(1, 576) * 0.1
+    state = torch.zeros(2, 1, 128)
+    with torch.no_grad():
+        ref_out, ref_state = inner(x, state)
+
+    inlined = inline_unresolvable_submodules(inner.graph, inner)
+    torch._C._jit_pass_dce(inner.graph)
+    after = _callmethod_counts(inner.graph)
+
+    assert inlined > 0
+    for qn in after:
+        assert qn.startswith("__torch__.torch.nn."), (
+            f"non-torch.nn.* CallMethod target survived: {qn}"
+        )
+
+    with torch.no_grad():
+        new_out, new_state = inner(x, state)
+    assert torch.allclose(ref_out, new_out)
+    assert torch.allclose(ref_state, new_state)

--- a/torch_to_nnef/torch_graph/__init__.py
+++ b/torch_to_nnef/torch_graph/__init__.py
@@ -30,6 +30,7 @@ from torch_to_nnef.torch_graph.ir_graph import (
 )
 from torch_to_nnef.torch_graph.ir_module_tracer import TorchModuleTracer
 from torch_to_nnef.torch_graph.ir_op import TorchOp
+from torch_to_nnef.torch_graph.jit_inline import inline_unresolvable_submodules
 from torch_to_nnef.torch_graph.torch_const import MAP_TO_NOP
 
 __all__ = [
@@ -42,4 +43,5 @@ __all__ = [
     "MAP_TO_NOP",
     "module_tracer_into_ir_graph",
     "TorchModuleIRGraph",
+    "inline_unresolvable_submodules",
 ]

--- a/torch_to_nnef/torch_graph/ir_helpers.py
+++ b/torch_to_nnef/torch_graph/ir_helpers.py
@@ -25,6 +25,7 @@ from torch_to_nnef.torch_graph.ir_data import (
     cleanup_data_name,
 )
 from torch_to_nnef.torch_graph.ir_module_tracer import TorchModuleTracer
+from torch_to_nnef.torch_graph.jit_utils import parse_jit_qualname
 from torch_to_nnef.torch_graph.torch_const import (
     ATEN_ARANGE,
     ATEN_CONTIGUOUS_KIND,
@@ -605,14 +606,7 @@ def _extract_op_infos_call_kind(module, traced_module, node, inputs):
         # input of the PyTorch IR 'graph'
         # in this case finding the Python object reference based on
         # PyTorch IR python API is hard.
-        ref_cls_path = ".".join(
-            [
-                _
-                for _ in qualname.replace("__torch__.", "").split(".")
-                if "___torch_mangle_" not in _
-            ]
-        )
-        ref_mod_path, ref_cls_name = ref_cls_path.rsplit(".", 1)
+        ref_mod_path, ref_cls_name = parse_jit_qualname(qualname)
         ref_cls = getattr(importlib.import_module(ref_mod_path), ref_cls_name)
         module_getter_ref, op_ref = next(
             (name, mod)

--- a/torch_to_nnef/torch_graph/jit_inline.py
+++ b/torch_to_nnef/torch_graph/jit_inline.py
@@ -1,0 +1,142 @@
+"""Selective inlining of unresolvable JIT submodule calls.
+
+`torch_to_nnef`'s recursive parser identifies the class behind a
+`prim::CallMethod` via `importlib.import_module(qualname.module_path)` and
+`isinstance(submod, ref_cls)`. JIT artifacts shipped without their training
+source (e.g. Silero-VAD's `silero_vad.jit`) carry qualified names like
+`__torch__.vad.model.vad_annotator.SileroVadBlock` that fail to import.
+
+`inline_unresolvable_submodules(graph, model)` walks the JIT graph and
+inlines exactly those calls in place, leaving importable `torch.nn.*`
+calls intact so existing module-level extractors (LSTM, GRU, RNN, ...)
+still fire.
+
+Companion to `strip_assertion_ifs` in this package: a typical JIT-only
+preprocessing chain is `inline_unresolvable_submodules -> _jit_pass_dce
+-> strip_assertion_ifs`.
+"""
+
+from __future__ import annotations
+
+import importlib
+import typing as T
+
+import torch
+from torch import nn
+
+from torch_to_nnef.torch_graph.jit_utils import parse_jit_qualname, walk_nodes
+from torch_to_nnef.torch_graph.torch_const import CALL_KIND, GETATTR_KIND
+
+
+def _is_resolvable_qualname(qualname: str) -> bool:
+    mod_path, _ = parse_jit_qualname(qualname)
+    if not mod_path:
+        # Not a `__torch__.*` class qualname; treat as resolvable
+        # (nothing to do).
+        return True
+    try:
+        importlib.import_module(mod_path)
+    except (ImportError, ModuleNotFoundError):
+        return False
+    return True
+
+
+def _resolve_call_target(
+    node: "torch._C.Node", root_model: nn.Module
+) -> T.Tuple[nn.Module, "torch._C.Graph"]:
+    """Resolve a CallMethod node to its target submodule and method graph.
+
+    Walks the GetAttr chain from the CallMethod's first input back to the
+    root `self` parameter, traverses the model accordingly, and returns
+    `(submodule, method_graph)`.
+    """
+    method_name = node.s("name")
+    first_in = next(node.inputs())
+
+    sequence: T.List[str] = []
+    cur = first_in.node()
+    while cur.kind() == GETATTR_KIND:
+        sequence.append(cur.s("name"))
+        cur = next(cur.inputs()).node()
+    # `cur` should now be the graph param node for `self`. We don't
+    # validate it here because the caller already checked the qualname.
+    sequence = sequence[::-1]
+
+    submodule: nn.Module = root_model
+    for attr in sequence:
+        submodule = getattr(submodule, attr)
+
+    method = getattr(submodule, method_name)
+    if not hasattr(method, "graph"):
+        raise RuntimeError(
+            f"Cannot inline {method_name} on {type(submodule).__name__}: "
+            "method has no .graph attribute"
+        )
+    return submodule, method.graph
+
+
+def _find_inlineable_callmethod(
+    graph: "torch._C.Graph",
+) -> T.Optional["torch._C.Node"]:
+    for node in walk_nodes(graph):
+        if node.kind() != CALL_KIND:
+            continue
+        first_in = next(node.inputs())
+        ty = first_in.type()
+        try:
+            qualname = ty.qualified_name()
+        except (RuntimeError, AttributeError):
+            continue
+        if _is_resolvable_qualname(qualname):
+            continue
+        return node
+    return None
+
+
+def _inline_one_callmethod(
+    graph: "torch._C.Graph",
+    node: "torch._C.Node",
+    root_model: nn.Module,
+) -> None:
+    _, sub_graph = _resolve_call_target(node, root_model)
+
+    # `Graph.insertGraph(sub_graph, vals)` clones sub_graph's body at the
+    # current insert point, substituting sub_graph's inputs with `vals`.
+    # sub_graph's first input is the submodule's `self`; node's first
+    # input is the value referencing that submodule in the parent graph
+    # (a GetAttr chain) -- the substitution correctly rewires nested
+    # GetAttrs through the parent's path.
+    graph.setInsertPoint(node)
+    new_outputs = graph.insertGraph(sub_graph, list(node.inputs()))
+
+    for old_out, new_out in zip(node.outputs(), new_outputs, strict=True):
+        old_out.replaceAllUsesWith(new_out)
+    node.destroy()
+
+
+def inline_unresolvable_submodules(
+    graph: "torch._C.Graph",
+    model: nn.Module,
+    max_passes: int = 1024,
+) -> int:
+    """Inline every `prim::CallMethod` whose target class is not importable.
+
+    Iterates until fixed point: an inlined body may itself contain further
+    CallMethods that also need inlining. `max_passes` bounds the loop
+    against pathological non-termination on weirdly structured graphs;
+    raise it for unusually deep nested inlines, lower it to fail fast
+    when debugging.
+
+    Returns the count of inlined calls.
+    """
+    inlined = 0
+    for _ in range(max_passes):
+        target = _find_inlineable_callmethod(graph)
+        if target is None:
+            return inlined
+        _inline_one_callmethod(graph, target, model)
+        inlined += 1
+    raise RuntimeError(
+        f"inline_unresolvable_submodules did not converge after "
+        f"{max_passes} passes ({inlined} inlined so far)"
+    )

--- a/torch_to_nnef/torch_graph/jit_utils.py
+++ b/torch_to_nnef/torch_graph/jit_utils.py
@@ -1,0 +1,46 @@
+"""Shared utilities for JIT graph traversal and qualname parsing.
+
+These small helpers are used by `jit_inline`, `jit_passes`, and the
+recursive parser in `ir_helpers`. Centralized here to avoid duplication.
+"""
+
+from __future__ import annotations
+
+import typing as T
+
+import torch  # noqa: F401  -- kept for type-hint forward refs
+
+
+def walk_nodes(graph_or_block) -> T.Iterator["torch._C.Node"]:
+    """Yield nodes recursively, descending into prim::If / prim::Loop blocks."""
+    for node in graph_or_block.nodes():
+        yield node
+        for blk in node.blocks():
+            yield from walk_nodes(blk)
+
+
+def parse_jit_qualname(qualname: str) -> T.Tuple[str, str]:
+    """Return ``(module_path, class_name)`` for a `__torch__.*` qualname.
+
+    Strips the `__torch__.` prefix and `___torch_mangle_*` mangling
+    segments; the trailing path component is the class name and the
+    rest is the import path. Returns ``("", "")`` when `qualname` is
+    not a `__torch__.*` class reference.
+
+    Examples:
+        ``"__torch__.vad.model.SileroBlock"`` ->
+        ``("vad.model", "SileroBlock")``
+
+        ``"__torch__.torch.nn.modules.rnn.___torch_mangle_8.LSTM"`` ->
+        ``("torch.nn.modules.rnn", "LSTM")``
+    """
+    if not qualname.startswith("__torch__."):
+        return "", ""
+    parts = [
+        p
+        for p in qualname[len("__torch__.") :].split(".")
+        if "___torch_mangle_" not in p
+    ]
+    if len(parts) < 2:
+        return "", ""
+    return ".".join(parts[:-1]), parts[-1]


### PR DESCRIPTION
Second of the 5-PR stack, on top of #88.

`inline_unresolvable_submodules(graph, model)` walks a JIT graph and inlines exactly the `prim::CallMethod` nodes whose target class isn't on the Python import path (e.g. Silero-VAD's `vad.*` modules), while leaving every importable `torch.nn.*` call intact so the existing module-level extractors still fire.

Iterates until fixed point. Uses `Graph.insertGraph` to clone the submodule body and rewires GetAttr chains through the parent's path automatically.

Tests cover: no-op when fully resolvable, idempotence, monkeypatched `ModuleNotFoundError` to force the inline path, plus a Silero-VAD JIT integration test (gated on `silero_vad` availability) confirming only `vad.*` calls are inlined.

## Stack

Part of a 5-PR stack: #88 (IR + parser bug fixes) -> **#89 (this PR)** -> #90 (graph hardening passes) -> #91 (aten lstm_cell + canonical RNN) -> #92 (`harden_jit_for_export` helper + Silero demo).
