### PR TITLE
docs(examples): per-example READMEs, paper/HF links, drop stale TODOs

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -2,7 +2,7 @@
 
 Working code that accompanies the [torch-to-nnef
 documentation](https://sonos.github.io/torch-to-nnef/latest/). Each subdir is
-self-contained -- clone the repo, `cd examples/<name>/`, follow the per-example
+self-contained: clone the repo, `cd examples/<name>/`, follow the per-example
 README.
 
 ## Examples by tutorial
@@ -20,7 +20,7 @@ README.
 | [`vad/`](vad/) | Voice activity detection in wasm | [4. Dynamic axes](https://sonos.github.io/torch-to-nnef/latest/tutos/4_dynamic_axes/) | [demo](https://sonos.github.io/torch-to-nnef/latest/html/demo_vad.html) |
 | [`silero_vad/`](silero_vad/) | Silero-VAD JIT artifact straight to NNEF (`harden_jit_for_export`) | [12. JIT-only models](https://sonos.github.io/torch-to-nnef/latest/tutos/12_jit_only_models/) | -- |
 | [`nemo_asr/`](nemo_asr/) | NeMo ASR (Rust runtime + Python bindings) | [10. NeMo ASR export & eval](https://sonos.github.io/torch-to-nnef/latest/tutos/10_nemo/) | -- |
-| [`image_gen/`](image_gen/) | Stable Diffusion 1.5 export (SDXL / SD3 / Flux planned) | -- (exploration; see PR #71 / #69) | -- |
+| [`image_gen/`](image_gen/) | SD 1.5 + Flux-Schnell + Sana (DiT, mini configs); SDXL / SD3 placeholders | (exploration, no tutorial yet) | -- |
 
 ## Bootstrap helpers
 
@@ -38,5 +38,5 @@ call:
 
 The wasm demos are deployed alongside the docs at
 <https://sonos.github.io/torch-to-nnef/latest/html/>. The HTML source lives
-in [`docs/html/`](../docs/html/) -- the `examples/` subdir produces the wasm
+in [`docs/html/`](../docs/html/); the `examples/` subdir produces the wasm
 module, `docs/html/` hosts the page that loads it.

--- a/examples/dynamic_axes/README.md
+++ b/examples/dynamic_axes/README.md
@@ -1,0 +1,23 @@
+# Dynamic axes patterns
+
+Companion to the [Dynamic axes tutorial](https://sonos.github.io/torch-to-nnef/latest/tutos/4_dynamic_axes/). Three small models exercising the three common dynamic-axes flavors: a fixed-arity transformer, a batchable image model, and a streaming audio model.
+
+## What's exported
+
+| Script | Model | What's dynamic | References |
+| --- | --- | --- | --- |
+| `export_albert_fixed.py` | `albert-base-v2` | sequence length | [![HF](https://img.shields.io/badge/%F0%9F%A4%97-albert--base--v2-yellow)](https://huggingface.co/albert-base-v2) [![arXiv](https://img.shields.io/badge/arXiv-1909.11942-b31b1b.svg)](https://arxiv.org/abs/1909.11942) |
+| `export_with_batchable.py` | `torchvision.models.vit_b_16` | batch dimension | [![HF](https://img.shields.io/badge/%F0%9F%A4%97-google%2Fvit--base--patch16--224-yellow)](https://huggingface.co/google/vit-base-patch16-224) [![arXiv](https://img.shields.io/badge/arXiv-2010.11929-b31b1b.svg)](https://arxiv.org/abs/2010.11929) |
+| `cnn_deepspeech_stream.py` | `torchaudio.models.DeepSpeech` + custom CNN front-end | streaming time axis | [![arXiv](https://img.shields.io/badge/arXiv-1412.5567-b31b1b.svg)](https://arxiv.org/abs/1412.5567) |
+
+## Run
+
+```bash
+cd examples/dynamic_axes
+pip install -r requirements.txt
+python export_albert_fixed.py
+python export_with_batchable.py
+python cnn_deepspeech_stream.py
+```
+
+Each script passes `dynamic_axes={...}` to `export_model_to_nnef` and verifies the resulting NNEF round-trips against tract.

--- a/examples/getting_started_py/README.md
+++ b/examples/getting_started_py/README.md
@@ -1,0 +1,16 @@
+# Getting started: first NNEF export from Python
+
+[![arXiv](https://img.shields.io/badge/arXiv-2010.11929-b31b1b.svg)](https://arxiv.org/abs/2010.11929) [![HF](https://img.shields.io/badge/%F0%9F%A4%97%20Hugging%20Face-google%2Fvit--base--patch16--224-yellow)](https://huggingface.co/google/vit-base-patch16-224)
+
+Minimal end-to-end example used by the [Getting started tutorial](https://sonos.github.io/torch-to-nnef/latest/tutos/1_getting_started/). Loads `torchvision.models.vit_b_16` (ViT-B/16, "An Image is Worth 16x16 Words"), exports to NNEF, and runs the standard tract round-trip check.
+
+## Run
+
+```bash
+cd examples/getting_started_py
+pip install -r requirements.txt
+python export.py    # produces vit_b_16.nnef.tgz + a debug bundle
+python run.py       # loads the archive and runs an inference
+```
+
+`export.py` calls `export_model_to_nnef(check_io=True)` so the export will fail loudly if the NNEF doesn't match PyTorch numerically. Companion Rust example: [`getting_started_rs/`](../getting_started_rs/).

--- a/examples/getting_started_rs/README.md
+++ b/examples/getting_started_rs/README.md
@@ -1,0 +1,16 @@
+# Getting started: first NNEF inference in Rust with tract
+
+[![arXiv](https://img.shields.io/badge/arXiv-2010.11929-b31b1b.svg)](https://arxiv.org/abs/2010.11929) [![HF](https://img.shields.io/badge/%F0%9F%A4%97%20Hugging%20Face-google%2Fvit--base--patch16--224-yellow)](https://huggingface.co/google/vit-base-patch16-224)
+
+Rust counterpart to [`getting_started_py/`](../getting_started_py/). Loads the NNEF archive produced there (ViT-B/16 ImageNet classifier) and runs an inference through [tract](https://github.com/sonos/tract).
+
+## Run
+
+First export the NNEF artifact via the Python example, then:
+
+```bash
+cd examples/getting_started_rs
+cargo run --release -- ../getting_started_py/vit_b_16.nnef.tgz Grace_Hopper.jpg
+```
+
+Prints the predicted ImageNet class id and label.

--- a/examples/image_gen/README.md
+++ b/examples/image_gen/README.md
@@ -13,14 +13,11 @@ torch-to-nnef rather than going through ONNX as an intermediate.
 Each subdir targets one model family and is split by component so the heaviest
 tensors are not all loaded at once:
 
-- `sd15/` -- Stable Diffusion 1.5: VAE decoder, UNet, CLIP text encoder
-- `sdxl/` -- Stable Diffusion XL: two text encoders, larger UNet, VAE
-- `sd3/` -- Stable Diffusion 3 (DiT architecture)
-- `flux_schnell/` -- Flux-Schnell (DiT, 12B): tiny `--mini` config validated
-  end-to-end via `check_io` against tract; full 12B checkpoint export needs
-  a gated HF download.
-- `sana/` -- NVIDIA Sana (DiT, 1.6B / 4.8B): linear-attention DiT with Mix-FFN
-  and DC-AE VAE; tiny `--mini` config validated end-to-end via `check_io`.
+- [`sd15/`](sd15/): Stable Diffusion 1.5. VAE decoder + UNet validated end-to-end via `check_io`. Text encoder not exported here.
+- [`sdxl/`](sdxl/): Stable Diffusion XL. Placeholder; not yet implemented.
+- [`sd3/`](sd3/): Stable Diffusion 3 (DiT). Placeholder; not yet implemented.
+- [`flux_schnell/`](flux_schnell/): Flux-Schnell (DiT, 12B). Tiny `--mini` config validated end-to-end via `check_io`; full 12B checkpoint export needs a gated HF download.
+- [`sana/`](sana/): NVIDIA Sana (DiT, 1.6B / 4.8B). Linear-attention DiT with Mix-FFN and DC-AE VAE. Tiny `--mini` config validated end-to-end via `check_io`.
 
 ## Status
 

--- a/examples/image_gen/flux_schnell/README.md
+++ b/examples/image_gen/flux_schnell/README.md
@@ -1,9 +1,11 @@
-# Flux-Schnell (TODO)
+# Flux-Schnell
 
-Target repo: `black-forest-labs/FLUX.1-schnell`.
+[![HF](https://img.shields.io/badge/%F0%9F%A4%97%20Hugging%20Face-FLUX.1--schnell-yellow)](https://huggingface.co/black-forest-labs/FLUX.1-schnell)
 
-12B-parameter DiT variant. Key challenges for export: model size (may not fit
-a single NNEF tensor file), T5-XXL encoder (11B by itself), double-stream DiT
-blocks with separate image/text token streams.
+12B-parameter DiT variant from Black Forest Labs. Tiny `--mini` config (random weights, full architecture, ~16k params) is validated end-to-end via `check_io` against tract; the full 12B export requires gated HF download and is not exercised in CI.
 
-Suggested order: VAE decoder -> T5 text encoder -> DiT (the hardest).
+Key challenges for the full export: model size (may not fit a single NNEF tensor file), T5-XXL encoder (11B by itself), double-stream DiT blocks with separate image/text token streams.
+
+```bash
+python transformer.py --mini  # tiny config end-to-end check
+```

--- a/examples/image_gen/sana/README.md
+++ b/examples/image_gen/sana/README.md
@@ -1,16 +1,15 @@
 # Sana
 
-Target repo: `Efficient-Large-Model/Sana_1600M_1024px_diffusers`.
+[![HF](https://img.shields.io/badge/%F0%9F%A4%97%20Hugging%20Face-Sana_1600M-yellow)](https://huggingface.co/Efficient-Large-Model/Sana_1600M_1024px_diffusers) [![arXiv](https://img.shields.io/badge/arXiv-2410.10629-b31b1b.svg)](https://arxiv.org/abs/2410.10629)
 
-NVIDIA Sana — efficient text-to-image DiT with two architectural twists vs.
-the Flux/SD3 family already covered in this directory:
+NVIDIA Sana, an efficient text-to-image DiT with two architectural twists vs. the Flux / SD3 family already covered in this directory:
 
 - **Linear attention** (ReLU-based) in self-attention blocks, no softmax.
-- **Mix-FFN** (linear → depth-wise conv → linear) instead of plain FFN.
+- **Mix-FFN** (linear, depth-wise conv, linear) instead of plain FFN.
 - **DC-AE** VAE for very high spatial compression (f32 / f64).
 
-`transformer.py` exports the denoiser. `--mini` instantiates a tiny random-
-weights config (~16k params) that keeps the full architecture so this PR can
-exercise the export path without a gated HF download.
+`transformer.py` exports the denoiser. `--mini` instantiates a tiny random-weights config (~16k params) that keeps the full architecture so the export path is exercised without a gated HF download.
 
-Suggested order: transformer → DC-AE decoder → Gemma-2 / T5 text encoder.
+```bash
+python transformer.py --mini
+```

--- a/examples/image_gen/sd15/README.md
+++ b/examples/image_gen/sd15/README.md
@@ -1,0 +1,21 @@
+# Stable Diffusion 1.5
+
+[![HF](https://img.shields.io/badge/%F0%9F%A4%97%20Hugging%20Face-runwayml%2Fstable--diffusion--v1--5-yellow)](https://huggingface.co/runwayml/stable-diffusion-v1-5) [![arXiv](https://img.shields.io/badge/arXiv-2112.10752-b31b1b.svg)](https://arxiv.org/abs/2112.10752)
+
+First image-generation target in this directory. Two scripts exporting the heaviest components separately so the full checkpoint never sits in memory at once:
+
+- **`vae_decoder.py`**: VAE decoder (latent -> RGB upsample path). Validated end-to-end via `check_io` against tract.
+- **`unet.py`**: UNet denoiser. Validated end-to-end via `check_io` against tract.
+
+The CLIP text encoder is not exported here (small enough to be handled separately if needed).
+
+## Run
+
+```bash
+cd examples/image_gen/sd15
+pip install -r ../requirements.txt
+python vae_decoder.py
+python unet.py
+```
+
+Each script runs `export_model_to_nnef(check_io=True)` so a tract numerical mismatch fails the export loudly.

--- a/examples/image_gen/sd3/README.md
+++ b/examples/image_gen/sd3/README.md
@@ -1,9 +1,7 @@
-# SD3 (TODO)
+# SD3 (not yet implemented)
 
-Target repo: `stabilityai/stable-diffusion-3-medium`.
+[![HF](https://img.shields.io/badge/%F0%9F%A4%97%20Hugging%20Face-stable--diffusion--3--medium-yellow)](https://huggingface.co/stabilityai/stable-diffusion-3-medium) [![arXiv](https://img.shields.io/badge/arXiv-2403.03206-b31b1b.svg)](https://arxiv.org/abs/2403.03206)
 
-Key difference vs SD 1.5 / SDXL: DiT (diffusion transformer) architecture
-instead of UNet. Three text encoders (CLIP-L, CLIP-G, T5-XXL).
+Placeholder for Stable Diffusion 3. Key differences vs. SD 1.5 / SDXL: DiT (diffusion transformer) architecture instead of UNet, and three text encoders (CLIP-L, CLIP-G, T5-XXL).
 
-Start with VAE decoder to validate the upsample path, then the DiT transformer
-(expect attention / rotary-pos-embedding gotchas).
+No export script yet; expected gotchas around attention variants and rotary positional embedding.

--- a/examples/image_gen/sdxl/README.md
+++ b/examples/image_gen/sdxl/README.md
@@ -1,8 +1,10 @@
-# SDXL (TODO)
+# SDXL (not yet implemented)
 
-Target repos:
-- UNet + VAE: `stabilityai/stable-diffusion-xl-base-1.0`
-- Two text encoders (CLIP-L + OpenCLIP G)
+[![HF](https://img.shields.io/badge/%F0%9F%A4%97%20Hugging%20Face-stable--diffusion--xl--base--1.0-yellow)](https://huggingface.co/stabilityai/stable-diffusion-xl-base-1.0) [![arXiv](https://img.shields.io/badge/arXiv-2307.01952-b31b1b.svg)](https://arxiv.org/abs/2307.01952)
 
-Export pattern mirrors `../sd15/vae_decoder.py`. Start with the VAE decoder,
-then text encoders, then the larger UNet.
+Placeholder for Stable Diffusion XL. Components to export when picked up:
+
+- UNet + VAE from `stabilityai/stable-diffusion-xl-base-1.0`
+- Two text encoders: CLIP-L and OpenCLIP G
+
+Export pattern will mirror `../sd15/vae_decoder.py`.

--- a/examples/imageclass-wasm/README.md
+++ b/examples/imageclass-wasm/README.md
@@ -1,0 +1,20 @@
+# Image classifier in wasm
+
+[![arXiv](https://img.shields.io/badge/arXiv-1905.11946-b31b1b.svg)](https://arxiv.org/abs/1905.11946) [![demo](https://img.shields.io/badge/live-demo-brightgreen)](https://sonos.github.io/torch-to-nnef/latest/html/demo_image_classifier.html)
+
+Companion to the [Getting started tutorial](https://sonos.github.io/torch-to-nnef/latest/tutos/1_getting_started/). Exports `torchvision.models.efficientnet_b0` (EfficientNet-B0, "EfficientNet: Rethinking Model Scaling for Convolutional Neural Networks") with a dynamic batch dimension, then compiles a tract-backed Rust crate to WebAssembly so the model runs in-browser.
+
+## Run
+
+```bash
+cd examples/imageclass-wasm
+./run.sh    # bootstraps uv + rust + wasm-pack, exports the NNEF, builds the wasm
+```
+
+The `run.sh` script:
+1. Sets up `.venv` + Rust toolchain via the bootstrap helpers
+2. Runs `export_with_batchable.py` to produce the NNEF archive
+3. Builds the Rust crate to wasm with `wasm-pack`
+4. Drops the wasm + JS glue into `docs/html/` for the live demo
+
+Live demo: [https://sonos.github.io/torch-to-nnef/latest/html/demo_image_classifier.html](https://sonos.github.io/torch-to-nnef/latest/html/demo_image_classifier.html).

--- a/examples/llm_wasm/README.md
+++ b/examples/llm_wasm/README.md
@@ -1,0 +1,22 @@
+# Small LLM in wasm
+
+[![HF](https://img.shields.io/badge/%F0%9F%A4%97%20Hugging%20Face-HuggingFaceTB%2FSmolLM--135M-yellow)](https://huggingface.co/HuggingFaceTB/SmolLM-135M) [![demo](https://img.shields.io/badge/live-demo-brightgreen)](https://sonos.github.io/torch-to-nnef/latest/html/demo_poem_generator.html)
+
+Companion to the [LLM export tutorial](https://sonos.github.io/torch-to-nnef/latest/tutos/5_llm/). Exports HuggingFaceTB's SmolLM-135M (135M-parameter decoder-only LLM) to NNEF via `t2n_export_llm_to_tract`, then compiles a tract-backed Rust crate to WebAssembly for in-browser text generation.
+
+## Run
+
+```bash
+cd examples/llm_wasm
+./run.sh
+```
+
+The `run.sh` script:
+1. Sets up `.venv` + Rust toolchain via the bootstrap helpers
+2. Runs `t2n_export_llm_to_tract -s HuggingFaceTB/SmolLM-135M ...` to produce the NNEF archive bundled with tokenizer / config
+3. Builds the Rust crate to wasm with `wasm-pack` (uses tract's `causal_llm` runtime)
+4. Drops the wasm + JS glue into `docs/html/` for the live demo
+
+Live demo: [https://sonos.github.io/torch-to-nnef/latest/html/demo_poem_generator.html](https://sonos.github.io/torch-to-nnef/latest/html/demo_poem_generator.html).
+
+The tract dependencies are pinned to the `feat/wasm-llm` branch in `Cargo.toml` because the wasm causal-LLM runtime is still maturing in tract main.

--- a/examples/multi_io_py/README.md
+++ b/examples/multi_io_py/README.md
@@ -1,0 +1,15 @@
+# Multi-input / multi-output export (ALBERT)
+
+[![HF](https://img.shields.io/badge/%F0%9F%A4%97%20Hugging%20Face-albert--base--v2-yellow)](https://huggingface.co/albert-base-v2) [![arXiv](https://img.shields.io/badge/arXiv-1909.11942-b31b1b.svg)](https://arxiv.org/abs/1909.11942)
+
+Companion to the [Multiple inputs / outputs tutorial](https://sonos.github.io/torch-to-nnef/latest/tutos/3_multi_inputs_outputs/). Exports `albert-base-v2` (ALBERT, "A Lite BERT for Self-supervised Learning of Language Representations") with multiple input tensors (`input_ids`, `attention_mask`, `token_type_ids`) and the full last hidden state output.
+
+## Run
+
+```bash
+cd examples/multi_io_py
+pip install -r requirements.txt
+python export_albert.py    # produces albert.nnef.tgz
+```
+
+The script wires the tokenizer, runs `export_model_to_nnef` with `input_names` and `output_names` matching ALBERT's forward signature, and verifies tract IO with `check_io=True`.

--- a/examples/quantization_py/README.md
+++ b/examples/quantization_py/README.md
@@ -1,0 +1,18 @@
+# Quantization
+
+Companion to the [Quantization tutorial](https://sonos.github.io/torch-to-nnef/latest/tutos/6_quantization/). Two scripts:
+
+- **`export_toy_cnn_8bit.py`**: minimal int8 PTQ flow on a toy `nn.Conv1d` stack via `torch.ao.quantization` (eager-mode), then exported to NNEF.
+- **`super_quant.py`**: utility for grid-search MSE calibration of weight-only `q4_0` quantization (tract's 4-bit format), built on `torch_to_nnef.tensor.quant`.
+
+No specific upstream model: the toy CNN is constructed in-script. `super_quant.py` is a calibration helper meant to be applied to your own LLM / encoder weights as part of an export pipeline.
+
+## Run
+
+```bash
+cd examples/quantization_py
+pip install -r ../getting_started_py/requirements.txt   # any t2n env works
+python export_toy_cnn_8bit.py
+```
+
+For `super_quant.py`, see the tutorial for usage in context.

--- a/examples/vad/README.md
+++ b/examples/vad/README.md
@@ -1,0 +1,24 @@
+# FSMN-VAD in wasm
+
+[![HF](https://img.shields.io/badge/%F0%9F%A4%97%20Hugging%20Face-funasr%2Ffsmn--vad-yellow)](https://huggingface.co/funasr/fsmn-vad) [![arXiv](https://img.shields.io/badge/arXiv-2103.04450-b31b1b.svg)](https://arxiv.org/abs/2103.04450) [![demo](https://img.shields.io/badge/live-demo-brightgreen)](https://sonos.github.io/torch-to-nnef/latest/html/demo_vad.html)
+
+Exports a [FunASR FSMN-VAD](https://huggingface.co/funasr/fsmn-vad) voice-activity detector to NNEF and compiles a tract-backed Rust crate to WebAssembly for in-browser real-time VAD on a microphone feed.
+
+`py/fsmn_encoder.py` is a copy of FunASR's encoder stripped of the `funasr.register` dependency so the model can be imported standalone. This example also demonstrates dynamic axes at the time dimension (streaming).
+
+For the JIT-only export path (passing a `.jit` artifact directly with no Python source), see the sibling [`silero_vad/`](../silero_vad/) example.
+
+## Run
+
+```bash
+cd examples/vad
+./run.sh
+```
+
+The `run.sh` script:
+1. Sets up `.venv` + Rust toolchain via the bootstrap helpers
+2. Runs `py/export.py` to produce the NNEF archive
+3. Builds the Rust crate to wasm with `wasm-pack`
+4. Drops the wasm + JS glue into `docs/html/` for the live demo
+
+Live demo: [https://sonos.github.io/torch-to-nnef/latest/html/demo_vad.html](https://sonos.github.io/torch-to-nnef/latest/html/demo_vad.html).

--- a/examples/yolo/README.md
+++ b/examples/yolo/README.md
@@ -1,0 +1,22 @@
+# YOLO11 pose estimation in wasm
+
+[![GitHub](https://img.shields.io/badge/GitHub-ultralytics%2Fultralytics-181717?logo=github)](https://github.com/ultralytics/ultralytics) [![demo](https://img.shields.io/badge/live-demo-brightgreen)](https://sonos.github.io/torch-to-nnef/latest/html/demo_pose_estimation.html)
+
+Exports `yolo11n-pose` (Ultralytics YOLO11, nano pose-estimation variant) to NNEF, then compiles a tract-backed Rust crate to WebAssembly for in-browser pose detection on a webcam feed.
+
+## Run
+
+```bash
+cd examples/yolo
+./run.sh
+```
+
+The `run.sh` script:
+1. Sets up `.venv` + Rust toolchain via the bootstrap helpers
+2. Runs `export.py` which downloads `yolo11n-pose.pt` via Ultralytics, monkey-patches their exporter to emit NNEF, and produces the archive
+3. Builds the Rust crate to wasm with `wasm-pack`
+4. Drops the wasm + JS glue into `docs/html/` for the live demo
+
+`export.py` overrides `Exporter.export_nnef` on the Ultralytics side to route through `torch_to_nnef.export_model_to_nnef`. The NMS post-processing is wrapped via `NMSModel` and exported alongside the detection backbone.
+
+Live demo: [https://sonos.github.io/torch-to-nnef/latest/html/demo_pose_estimation.html](https://sonos.github.io/torch-to-nnef/latest/html/demo_pose_estimation.html).


### PR DESCRIPTION
## Summary

Cleanup pass on `examples/` READMEs based on four concrete gaps:

1. **Missing READMEs.** `examples/README.md` advertises that each subdir is self-contained, but 10 subdirs had no README. Added one per example, with the run command, the upstream model, and (where relevant) the live demo link.
2. **Stale TODO markers.** `flux_schnell`, `sana`, `sd3`, `sdxl` were all labelled "(TODO)". Two are actually done end-to-end via `check_io` (`flux_schnell` + `sana` mini configs); the other two are placeholders, now labelled "not yet implemented" rather than implying work-in-progress.
3. **"Suggested order" sentences.** Removed; they did not carry useful information.
4. **Paper / HuggingFace links.** Added shields.io badges on each model-specific README pointing to the HF repo and the arXiv paper (and to the live demo for the wasm examples).

## Test plan

- [ ] CI passes (doc-check + examples-check)
- [ ] Spot-check a few rendered READMEs on GitHub for badge layout