### PR TITLE
docs(tutorial-1): drop deprecated `pretrained=True` for `weights=` API

### DIFF
--- a/docs/tutos/1_getting_started.md
+++ b/docs/tutos/1_getting_started.md
@@ -44,10 +44,10 @@ import torch
 from torchvision import models as vision_mdl
 from torchvision.io import read_image
 
-my_image_model = vision_mdl.vit_b_16(pretrained=True) # (1)!
+classification_task = vision_mdl.ViT_B_16_Weights.IMAGENET1K_V1 # (2)!
+my_image_model = vision_mdl.vit_b_16(weights=classification_task) # (1)!
 
 img = read_image("./Grace_Hopper.jpg")
-classification_task = vision_mdl.ViT_B_16_Weights.IMAGENET1K_V1 # (2)!
 input_data_sample = classification_task.transforms()(
     img.unsqueeze(0)
 )

--- a/examples/dynamic_axes/export_with_batchable.py
+++ b/examples/dynamic_axes/export_with_batchable.py
@@ -6,10 +6,10 @@ from torchvision.io import read_image
 
 from torch_to_nnef import TractNNEF, export_model_to_nnef
 
-my_image_model = vision_mdl.vit_b_16(pretrained=True)
+classification_task = vision_mdl.ViT_B_16_Weights.IMAGENET1K_V1
+my_image_model = vision_mdl.vit_b_16(weights=classification_task)
 
 img = read_image("./Grace_Hopper.jpg")
-classification_task = vision_mdl.ViT_B_16_Weights.IMAGENET1K_V1
 input_data_sample = classification_task.transforms()(img.unsqueeze(0))
 file_path_export = Path("vit_b_16_batchable.nnef.tgz")
 export_model_to_nnef(

--- a/examples/getting_started_py/export.py
+++ b/examples/getting_started_py/export.py
@@ -6,10 +6,10 @@ from torchvision.io import read_image
 
 from torch_to_nnef import TractNNEF, export_model_to_nnef
 
-my_image_model = vision_mdl.vit_b_16(pretrained=True)
+classification_task = vision_mdl.ViT_B_16_Weights.IMAGENET1K_V1
+my_image_model = vision_mdl.vit_b_16(weights=classification_task)
 
 img = read_image("./Grace_Hopper.jpg")
-classification_task = vision_mdl.ViT_B_16_Weights.IMAGENET1K_V1
 input_data_sample = classification_task.transforms()(img.unsqueeze(0))
 file_path_export = Path("vit_b_16.nnef.tgz")
 export_model_to_nnef(

--- a/examples/imageclass-wasm/export_with_batchable.py
+++ b/examples/imageclass-wasm/export_with_batchable.py
@@ -11,10 +11,10 @@ from torch_to_nnef import TractNNEF, export_model_to_nnef
 base_model = vision_mdl.efficientnet_b0
 weights = vision_mdl.EfficientNet_B0_Weights
 
-my_image_model = base_model(pretrained=True)
+classification_task = weights.IMAGENET1K_V1
+my_image_model = base_model(weights=classification_task)
 
 img = read_image("./Grace_Hopper.jpg")
-classification_task = weights.IMAGENET1K_V1
 input_data_sample = classification_task.transforms()(img.unsqueeze(0))
 file_path_export = Path("efficientnet_b0_batchable.nnef.tgz")
 export_model_to_nnef(


### PR DESCRIPTION
## Summary

torchvision's `pretrained=True` kwarg was deprecated back in 0.13 and is now removed / raises on recent versions. Tutorial 1 and the runnable examples it points to were emitting warnings or failing outright depending on the installed torchvision.

Switched to the modern `weights=` API: define the `Weights` enum once, then pass it to both the model factory and the input transform. Same end state.

Files updated:
- `docs/tutos/1_getting_started.md` (the tutorial code block)
- `examples/getting_started_py/export.py` (the runnable example the tutorial links to)
- `examples/dynamic_axes/export_with_batchable.py`
- `examples/imageclass-wasm/export_with_batchable.py`

## Test plan

- [ ] CI green (examples-check covers these scripts)
- [ ] Render tutorial 1 locally / on the doc preview to confirm the annotation popovers still line up after the swap