### PR TITLE
release: cut 0.24.0 (JIT-only export, harden helper, Silero demo)

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.23.2
+current_version = 0.24.0
 commit = True
 tag = True
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 
 ## [Unreleased]
 
+## [0.24.0] - 2026-05-07
+
 ### Added
 - **JIT-only model export support** (`torch.jit.ScriptModule` with non-importable inner classes, e.g. Silero-VAD's `silero_vad.jit`).
   - `torch_to_nnef.harden_jit_for_export(model, args, *, freeze=True, diagnostics=None)`: high-level helper that bundles freeze + selective inline + size folds + scalar arithmetic + constant Ifs + tuple round-trip folds + `prim::data` strip + assertion-If strip + data-dependent If fold.

--- a/packages/llm/pyproject.toml
+++ b/packages/llm/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "torch_to_nnef_llm"
-version = "0.23.2"
+version = "0.24.0"
 description = "LLM and PEFT export to NNEF via torch-to-nnef."
 authors = [{ name = "Julien Balian", email = "julien.balian@sonos.com" }]
 license = "MIT AND Apache-2.0"

--- a/packages/nemo-asr/pyproject.toml
+++ b/packages/nemo-asr/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "torch_to_nnef_nemo_asr"
-version = "0.23.2"
+version = "0.24.0"
 description = "NeMo ASR export to NNEF via torch-to-nnef."
 authors = [{ name = "Julien Balian", email = "julien.balian@sonos.com" }]
 license = "MIT AND Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "torch_to_nnef"
-version = "0.23.2"
+version = "0.24.0"
 description = "Any PyTorch Model to NNEF file format."
 authors = [{ name = "Julien Balian", email = "julien.balian@sonos.com" }]
 license = "MIT AND Apache-2.0"

--- a/torch_to_nnef/__init__.py
+++ b/torch_to_nnef/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Julien Balian"""
 __email__ = "julien.balian@sonos.com"
-__version__ = "0.23.2"
+__version__ = "0.24.0"
 
 from torch_to_nnef.export import (
     export_model_to_nnef,

--- a/uv.lock
+++ b/uv.lock
@@ -5724,7 +5724,7 @@ wheels = [
 
 [[package]]
 name = "torch-to-nnef"
-version = "0.23.2"
+version = "0.24.0"
 source = { editable = "." }
 dependencies = [
     { name = "mako" },
@@ -5828,7 +5828,7 @@ test = [
 
 [[package]]
 name = "torch-to-nnef-llm"
-version = "0.23.2"
+version = "0.24.0"
 source = { editable = "packages/llm" }
 dependencies = [
     { name = "huggingface-hub" },
@@ -5884,7 +5884,7 @@ test = [
 
 [[package]]
 name = "torch-to-nnef-nemo-asr"
-version = "0.23.2"
+version = "0.24.0"
 source = { editable = "packages/nemo-asr" }
 dependencies = [
     { name = "nemo-toolkit", extra = ["asr"] },


### PR DESCRIPTION
## Summary

Promotes the stale `[Unreleased]` CHANGELOG section to a dated `0.24.0` entry and bumps the version across all the places listed in `.bumpversion.cfg`.

The Unreleased section had accumulated several substantive features (JIT-only model export, `harden_jit_for_export` helper, auto-detect of `torch.jit.ScriptModule`, direct aten RNN op handlers, new `lstm_cell` NNEF fragment, `examples/silero_vad/` demo, tutorial 12) without a release tag. This is the "cut a release" answer to that.

### Files

- `CHANGELOG.md`: `[Unreleased]` content moved under `[0.24.0] - 2026-05-07`; an empty `[Unreleased]` skeleton stays on top for the next cycle.
- `pyproject.toml`, `packages/llm/pyproject.toml`, `packages/nemo-asr/pyproject.toml`: `0.23.2` -> `0.24.0`.
- `torch_to_nnef/__init__.py`: `__version__` bump.
- `.bumpversion.cfg`: `current_version` bump (kept in sync so future `bumpversion patch` works from the new base).
- `uv.lock`: 3 package version entries.

### Why minor (0.24.0) not patch (0.23.3)

The Unreleased section adds new public API (`harden_jit_for_export`, individual passes exposed under `torch_to_nnef.torch_graph`, new direct aten RNN handlers, new `auto_harden_jit` parameter on `export_model_to_nnef`). SemVer minor.

### Tagging is explicit

`release.yml` only triggers on `v*` tag push. This PR does **not** push a tag, so PyPI publish stays a manual step. After merge, run:

```sh
git checkout main && git pull
git tag -a v0.24.0 -m "release 0.24.0"
git push origin v0.24.0
```

## Test plan

- [ ] CI green on this branch
- [ ] `release.yml` `changelog_reader` step is happy with the `[0.24.0]` heading once the tag is pushed (validation_depth=10 in release.yml)