### PR TITLE
feat(op): add aten::flip and aten::diagonal (TractNNEF)

### DIFF
--- a/tests/proptest/op_specs/shape.py
+++ b/tests/proptest/op_specs/shape.py
@@ -952,6 +952,87 @@ def _triangular_sample_st(
     return _draw()
 
 
+def _flip_sample_st() -> st.SearchStrategy[OpSample]:
+    """`torch.flip(input, dims)`: reverse along a unique subset of dims."""
+
+    @st.composite
+    def _draw(draw) -> OpSample:
+        rank = draw(st.integers(min_value=1, max_value=4))
+        shape = tuple(
+            draw(
+                st.lists(
+                    st.integers(min_value=1, max_value=4),
+                    min_size=rank,
+                    max_size=rank,
+                )
+            )
+        )
+        n_dims = draw(st.integers(min_value=1, max_value=rank))
+        dims = draw(
+            st.lists(
+                st.integers(min_value=0, max_value=rank - 1),
+                min_size=n_dims,
+                max_size=n_dims,
+                unique=True,
+            )
+        )
+        x = draw(
+            tensor_st(
+                shape,
+                torch.float32,
+                finite=True,
+                domain=Interval(-10.0, 10.0),
+            )
+        )
+        return OpSample(
+            inputs=(x,),
+            module=UnaryPrimitive(partial(torch.flip, dims=tuple(dims))),
+        )
+
+    return _draw()
+
+
+def _diagonal_sample_st() -> st.SearchStrategy[OpSample]:
+    """`torch.diagonal(input, offset=0, dim1, dim2)` on the main diagonal.
+
+    The t2n emitter currently supports `offset == 0` only, so the
+    strategy is restricted accordingly. Shapes on `dim1` / `dim2` are
+    drawn independently to exercise the non-square slice path.
+    """
+
+    @st.composite
+    def _draw(draw) -> OpSample:
+        rank = draw(st.integers(min_value=2, max_value=4))
+        shape = list(
+            draw(
+                st.lists(
+                    st.integers(min_value=1, max_value=4),
+                    min_size=rank,
+                    max_size=rank,
+                )
+            )
+        )
+        dim1 = draw(st.integers(min_value=0, max_value=rank - 1))
+        candidates = [d for d in range(rank) if d != dim1]
+        dim2 = draw(st.sampled_from(candidates))
+        x = draw(
+            tensor_st(
+                tuple(shape),
+                torch.float32,
+                finite=True,
+                domain=Interval(-10.0, 10.0),
+            )
+        )
+        return OpSample(
+            inputs=(x,),
+            module=UnaryPrimitive(
+                partial(torch.diagonal, offset=0, dim1=dim1, dim2=dim2)
+            ),
+        )
+
+    return _draw()
+
+
 def _concat_split_specs() -> T.List[OpSpec]:
     EXACT = TractCheckTolerance.EXACT
     return [
@@ -993,6 +1074,16 @@ def _concat_split_specs() -> T.List[OpSpec]:
         OpSpec(
             name="triu",
             sample_st=_triangular_sample_st(torch.triu),
+            tolerance=EXACT,
+        ),
+        OpSpec(
+            name="flip",
+            sample_st=_flip_sample_st(),
+            tolerance=EXACT,
+        ),
+        OpSpec(
+            name="diagonal",
+            sample_st=_diagonal_sample_st(),
             tolerance=EXACT,
         ),
     ]

--- a/tests/proptest/op_specs/shape.py
+++ b/tests/proptest/op_specs/shape.py
@@ -993,11 +993,12 @@ def _flip_sample_st() -> st.SearchStrategy[OpSample]:
 
 
 def _diagonal_sample_st() -> st.SearchStrategy[OpSample]:
-    """`torch.diagonal(input, offset=0, dim1, dim2)` on the main diagonal.
+    """`torch.diagonal(input, offset, dim1, dim2)`.
 
-    The t2n emitter currently supports `offset == 0` only, so the
-    strategy is restricted accordingly. Shapes on `dim1` / `dim2` are
-    drawn independently to exercise the non-square slice path.
+    Shapes on `dim1` / `dim2` are drawn independently to exercise the
+    non-square slice path. `offset` is drawn in
+    `[-(shape[dim1] - 1), shape[dim2] - 1]` so the resulting diagonal
+    has length >= 1 (the t2n emitter rejects empty-diagonal cases).
     """
 
     @st.composite
@@ -1015,6 +1016,9 @@ def _diagonal_sample_st() -> st.SearchStrategy[OpSample]:
         dim1 = draw(st.integers(min_value=0, max_value=rank - 1))
         candidates = [d for d in range(rank) if d != dim1]
         dim2 = draw(st.sampled_from(candidates))
+        s1 = shape[dim1]
+        s2 = shape[dim2]
+        offset = draw(st.integers(min_value=-(s1 - 1), max_value=s2 - 1))
         x = draw(
             tensor_st(
                 tuple(shape),
@@ -1026,7 +1030,12 @@ def _diagonal_sample_st() -> st.SearchStrategy[OpSample]:
         return OpSample(
             inputs=(x,),
             module=UnaryPrimitive(
-                partial(torch.diagonal, offset=0, dim1=dim1, dim2=dim2)
+                partial(
+                    torch.diagonal,
+                    offset=offset,
+                    dim1=dim1,
+                    dim2=dim2,
+                )
             ),
         )
 

--- a/torch_to_nnef/op/aten/axes_change.py
+++ b/torch_to_nnef/op/aten/axes_change.py
@@ -1,6 +1,8 @@
 import nnef
+import torch
 
 from torch_to_nnef.exceptions import T2NErrorNotImplemented
+from torch_to_nnef.inference_target import TractNNEF
 from torch_to_nnef.op.aten.complex import (
     is_complex_dtype_and_complex_only_supported_as_lastdim,
 )
@@ -278,3 +280,70 @@ def reshape(
         ),
         attrs={"shape": dim_data},
     )
+
+
+@OP_REGISTRY.register()
+def flip(g, node, name_to_tensor, inference_target, **kwargs):
+    """Map PyTorch: 'aten:flip' to NNEF.
+
+    Decomposes to a chain of `tract_core_gather` calls, one per axis,
+    with a constant reversed-index tensor `[N-1, ..., 0]`. Static-shape
+    only: a dynamic axis size raises `T2NErrorNotImplemented` (would
+    require building the index at runtime via `tract_core_range` over
+    `tract_core_shape_of(input)[axis]`).
+    """
+    if not isinstance(inference_target, TractNNEF):
+        raise T2NErrorNotImplemented(
+            "flip requires `tract_core_gather` (TractNNEF target)"
+        )
+    input_node, dims_node = node.inputs
+    raw_dims = list(dims_node.data) if dims_node.data is not None else []
+
+    seen = set()
+    axes = []
+    for d in raw_dims:
+        a = pick_axis(input_node, d)
+        if a not in seen:
+            seen.add(a)
+            axes.append(a)
+
+    cur_ref = get_or_add_tensor_variable_in_nnef(g, input_node, name_to_tensor)
+
+    if not axes:
+        add_single_output_op(
+            g,
+            node,
+            name_to_tensor,
+            "reshape",
+            inputs=cur_ref,
+            attrs={"shape": list(input_node.shape)},
+        )
+        return []
+
+    for axis in axes:
+        if not isinstance(input_node.shape[axis], int):
+            raise T2NErrorNotImplemented(
+                f"flip on dynamic axis {axis} not yet supported"
+            )
+
+    for i, axis in enumerate(axes):
+        n = input_node.shape[axis]
+        idx_const = PythonConstant(
+            name=f"{node.outputs[0].export_name}_flip_idx_{axis}",
+            data=torch.arange(n - 1, -1, -1, dtype=torch.int64),
+        )
+        idx_ref = get_or_add_tensor_variable_in_nnef(
+            g, idx_const, name_to_tensor
+        )
+        is_last = i == len(axes) - 1
+        cur_ref = add_single_output_op(
+            g,
+            node,
+            name_to_tensor,
+            "tract_core_gather",
+            inputs=[cur_ref, idx_ref],
+            attrs={"axis": axis},
+            force_consistent_inputs_shapes=False,
+            output_tensor_name_suffix=("" if is_last else f"_flip_axis{axis}"),
+        )
+    return ["tract_core"]

--- a/torch_to_nnef/op/aten/selector.py
+++ b/torch_to_nnef/op/aten/selector.py
@@ -866,20 +866,25 @@ def diagonal(node, op_helper, inference_target, **kwargs):
     """Map PyTorch: 'aten:diagonal' to NNEF (tract path).
 
     Strategy: bring (dim1, dim2) to the last two axes via `transpose`,
-    slice both to the diagonal length when shapes differ, then evaluate
-    `<leading>ii-><leading>i` with `tract_core_einsum`. Currently
-    supports `offset == 0` only; non-zero offsets need an extra slice
-    step on one of the axes and are left as `T2NErrorNotImplemented`.
+    slice each axis to the diagonal window, then evaluate
+    `<leading>ii-><leading>i` with `tract_core_einsum`. The slice begin
+    on each axis encodes the offset:
+
+        begin_a1 = max(0, -offset)
+        begin_a2 = max(0,  offset)
+        L        = min(s1 - begin_a1, s2 - begin_a2)
+
+    `offset` is interpreted in the user's `(dim1, dim2)` order; when we
+    sort axes to `a1 < a2` the sign flips. Empty diagonals (`L <= 0`)
+    are left as `T2NErrorNotImplemented` since static zero-extent axes
+    are awkward to represent.
     """
     if not isinstance(inference_target, TractNNEF):
         raise T2NErrorNotImplemented(
             "diagonal requires `tract_core_einsum` (TractNNEF target)"
         )
     input_node, offset_node, dim1_node, dim2_node = node.inputs
-    if offset_node.data != 0:
-        raise T2NErrorNotImplemented(
-            f"diagonal with offset={offset_node.data} not yet supported"
-        )
+    offset = offset_node.data
     rank = input_node.rank
     a1 = pick_axis(input_node, dim1_node.data)
     a2 = pick_axis(input_node, dim2_node.data)
@@ -887,6 +892,7 @@ def diagonal(node, op_helper, inference_target, **kwargs):
         raise T2NErrorNotImplemented(f"diagonal dim1==dim2=={a1}")
     if a1 > a2:
         a1, a2 = a2, a1
+        offset = -offset
 
     s1 = input_node.shape[a1]
     s2 = input_node.shape[a2]
@@ -894,24 +900,39 @@ def diagonal(node, op_helper, inference_target, **kwargs):
         raise T2NErrorNotImplemented(
             f"diagonal on dynamic axes ({s1}, {s2}) not yet supported"
         )
-    n_diag = min(s1, s2)
+
+    begin1 = max(0, -offset)
+    begin2 = max(0, offset)
+    n_diag = min(s1 - begin1, s2 - begin2)
+    if n_diag <= 0:
+        raise T2NErrorNotImplemented(
+            f"diagonal with empty output: shapes ({s1}, {s2}), offset {offset}"
+        )
 
     inp_ref = op_helper.get_or_add_tensor_variable_in_nnef(input_node)
 
-    if s1 != n_diag:
+    if begin1 != 0 or s1 != n_diag:
         inp_ref = op_helper.add_single_output_op_from_nnef_tensors(
             node,
             "slice",
             inputs=inp_ref,
-            attrs={"axes": [a1], "begin": [0], "end": [n_diag]},
+            attrs={
+                "axes": [a1],
+                "begin": [begin1],
+                "end": [begin1 + n_diag],
+            },
             output_tensor_name_suffix="_diag_slice_a1",
         )
-    if s2 != n_diag:
+    if begin2 != 0 or s2 != n_diag:
         inp_ref = op_helper.add_single_output_op_from_nnef_tensors(
             node,
             "slice",
             inputs=inp_ref,
-            attrs={"axes": [a2], "begin": [0], "end": [n_diag]},
+            attrs={
+                "axes": [a2],
+                "begin": [begin2],
+                "end": [begin2 + n_diag],
+            },
             output_tensor_name_suffix="_diag_slice_a2",
         )
 

--- a/torch_to_nnef/op/aten/selector.py
+++ b/torch_to_nnef/op/aten/selector.py
@@ -44,30 +44,6 @@ def _nnef_cast(op_helper, node, tensor, to_tract_dtype: str, suffix: str = ""):
     )
 
 
-def _resolve_slice_bound(bound_node, input_node, dim: int, default):
-    """Resolve a slice begin/end into either a concrete int or an Identifier.
-
-    Returns `(value, has_concrete_value)`. `has_concrete_value` is False
-    when the bound is a runtime Identifier or a negative concrete value
-    (the latter requires deferred resolution against `dim_size`).
-
-    A `prim::Constant[NoneType]` bound (`t[:n]` or `t[m:]`) maps to the
-    `default` argument: 0 for begin, INT64_MAX for end.
-    """
-    if isinstance(bound_node, PythonConstant) and bound_node.data is None:
-        return default, True
-    if bound_node.data is None:
-        return nnef.Identifier(bound_node.export_name), False
-    if bound_node.data >= 0:
-        return (
-            pick_index_in_axis(
-                input_node, dim, bound_node.data, check_is_positive=False
-            ),
-            True,
-        )
-    return bound_node.data, False
-
-
 @OP_REGISTRY.register(torch_op_ids=["slice"])
 def slice_(
     node,
@@ -93,14 +69,31 @@ def slice_(
     # we assert for now all node except first are all constant
     dim = axis_node.data
 
+    has_concrete_values = True
     # we use this since by default pytorch generate max int64 value for end
-    begin, begin_concrete = _resolve_slice_bound(
-        begin_node, input_node, dim, default=0
-    )
-    end, end_concrete = _resolve_slice_bound(
-        end_node, input_node, dim, default=np.iinfo(np.int64).max
-    )
-    has_concrete_values = begin_concrete and end_concrete
+    if begin_node.data is not None:
+        if begin_node.data >= 0:
+            begin = pick_index_in_axis(
+                input_node, dim, begin_node.data, check_is_positive=False
+            )
+        else:
+            begin = begin_node.data
+            has_concrete_values = False
+    else:
+        has_concrete_values = False
+        begin = nnef.Identifier(begin_node.export_name)
+
+    if end_node.data is not None:
+        if end_node.data >= 0:
+            end = pick_index_in_axis(
+                input_node, dim, end_node.data, check_is_positive=False
+            )
+        else:
+            has_concrete_values = False
+            end = end_node.data
+    else:
+        has_concrete_values = False
+        end = nnef.Identifier(end_node.export_name)
 
     fixed_dims_and_higher_end_slice = (
         isinstance(end, int)
@@ -849,3 +842,99 @@ def _pack_padded_sequence(node, op_helper, inference_target, **kwargs):
     # input_node, lengths_node, batch_first_node = node.inputs[:3]
     # opacked_node, obatch_node = node.outputs
     # return ["pack_padded_sequence"]
+
+
+def _diagonal_einsum_expr(rank: int) -> str:
+    """Build the einsum expression `<leading>ii-><leading>i` for given rank.
+
+    `tract_core_einsum` does not accept ellipsis in the version range we
+    target, so we materialize concrete labels per rank. Up to rank 10
+    is supported (8 leading labels + the two diagonal axes).
+    """
+    if rank < 2:
+        raise T2NErrorNotImplemented(f"diagonal needs rank>=2, got {rank}")
+    leading = "abcdefgh"[: rank - 2]
+    if len(leading) < rank - 2:
+        raise T2NErrorNotImplemented(
+            f"diagonal rank {rank} exceeds einsum label budget"
+        )
+    return f"{leading}ii->{leading}i"
+
+
+@OP_REGISTRY.register()
+def diagonal(node, op_helper, inference_target, **kwargs):
+    """Map PyTorch: 'aten:diagonal' to NNEF (tract path).
+
+    Strategy: bring (dim1, dim2) to the last two axes via `transpose`,
+    slice both to the diagonal length when shapes differ, then evaluate
+    `<leading>ii-><leading>i` with `tract_core_einsum`. Currently
+    supports `offset == 0` only; non-zero offsets need an extra slice
+    step on one of the axes and are left as `T2NErrorNotImplemented`.
+    """
+    if not isinstance(inference_target, TractNNEF):
+        raise T2NErrorNotImplemented(
+            "diagonal requires `tract_core_einsum` (TractNNEF target)"
+        )
+    input_node, offset_node, dim1_node, dim2_node = node.inputs
+    if offset_node.data != 0:
+        raise T2NErrorNotImplemented(
+            f"diagonal with offset={offset_node.data} not yet supported"
+        )
+    rank = input_node.rank
+    a1 = pick_axis(input_node, dim1_node.data)
+    a2 = pick_axis(input_node, dim2_node.data)
+    if a1 == a2:
+        raise T2NErrorNotImplemented(f"diagonal dim1==dim2=={a1}")
+    if a1 > a2:
+        a1, a2 = a2, a1
+
+    s1 = input_node.shape[a1]
+    s2 = input_node.shape[a2]
+    if not isinstance(s1, int) or not isinstance(s2, int):
+        raise T2NErrorNotImplemented(
+            f"diagonal on dynamic axes ({s1}, {s2}) not yet supported"
+        )
+    n_diag = min(s1, s2)
+
+    inp_ref = op_helper.get_or_add_tensor_variable_in_nnef(input_node)
+
+    if s1 != n_diag:
+        inp_ref = op_helper.add_single_output_op_from_nnef_tensors(
+            node,
+            "slice",
+            inputs=inp_ref,
+            attrs={"axes": [a1], "begin": [0], "end": [n_diag]},
+            output_tensor_name_suffix="_diag_slice_a1",
+        )
+    if s2 != n_diag:
+        inp_ref = op_helper.add_single_output_op_from_nnef_tensors(
+            node,
+            "slice",
+            inputs=inp_ref,
+            attrs={"axes": [a2], "begin": [0], "end": [n_diag]},
+            output_tensor_name_suffix="_diag_slice_a2",
+        )
+
+    if not (a1 == rank - 2 and a2 == rank - 1):
+        perm = [i for i in range(rank) if i not in (a1, a2)] + [a1, a2]
+        inp_ref = op_helper.add_single_output_op_from_nnef_tensors(
+            node,
+            "transpose",
+            inputs=inp_ref,
+            attrs={"axes": perm},
+            output_tensor_name_suffix="_diag_perm",
+        )
+
+    op_helper.add_single_output_op_from_nnef_tensors(
+        node,
+        "tract_core_einsum",
+        inputs=[inp_ref],
+        ensure_tuple=False,
+        force_consistent_inputs_shapes=False,
+        attrs={
+            "expr": _diagonal_einsum_expr(rank),
+            "acc": "f32",
+            "output": "",
+        },
+    )
+    return ["tract_core"]

--- a/torch_to_nnef/op/aten/selector.py
+++ b/torch_to_nnef/op/aten/selector.py
@@ -44,6 +44,31 @@ def _nnef_cast(op_helper, node, tensor, to_tract_dtype: str, suffix: str = ""):
     )
 
 
+def _resolve_slice_bound(
+    bound_node, input_node, dim, default, has_dynamic_axes
+):
+    """Resolve a slice begin/end node to (value, has_concrete).
+
+    `bound_node.data` is `None` when the trace stored a Python ``None``
+    bound (e.g. ``x[:n]`` / ``x[k:]`` / ``x[:]``). In static-axes mode
+    that means "use the default" (``0`` for begin, ``dim_size`` for
+    end). In dynamic-axes mode it can refer to a runtime-computed
+    value, so we keep the upstream identifier.
+    """
+    if bound_node.data is not None:
+        if bound_node.data >= 0:
+            return (
+                pick_index_in_axis(
+                    input_node, dim, bound_node.data, check_is_positive=False
+                ),
+                True,
+            )
+        return bound_node.data, False
+    if has_dynamic_axes:
+        return nnef.Identifier(bound_node.export_name), False
+    return default, True
+
+
 @OP_REGISTRY.register(torch_op_ids=["slice"])
 def slice_(
     node,
@@ -68,32 +93,23 @@ def slice_(
     input_node, axis_node, begin_node, end_node, stride_node = node.inputs
     # we assert for now all node except first are all constant
     dim = axis_node.data
+    has_dynamic_axes = inference_target.has_dynamic_axes
 
-    has_concrete_values = True
-    # we use this since by default pytorch generate max int64 value for end
-    if begin_node.data is not None:
-        if begin_node.data >= 0:
-            begin = pick_index_in_axis(
-                input_node, dim, begin_node.data, check_is_positive=False
-            )
-        else:
-            begin = begin_node.data
-            has_concrete_values = False
-    else:
-        has_concrete_values = False
-        begin = nnef.Identifier(begin_node.export_name)
-
-    if end_node.data is not None:
-        if end_node.data >= 0:
-            end = pick_index_in_axis(
-                input_node, dim, end_node.data, check_is_positive=False
-            )
-        else:
-            has_concrete_values = False
-            end = end_node.data
-    else:
-        has_concrete_values = False
-        end = nnef.Identifier(end_node.export_name)
+    begin, begin_concrete = _resolve_slice_bound(
+        begin_node,
+        input_node,
+        dim,
+        default=0,
+        has_dynamic_axes=has_dynamic_axes,
+    )
+    end, end_concrete = _resolve_slice_bound(
+        end_node,
+        input_node,
+        dim,
+        default=input_node.shape[dim],
+        has_dynamic_axes=has_dynamic_axes,
+    )
+    has_concrete_values = begin_concrete and end_concrete
 
     fixed_dims_and_higher_end_slice = (
         isinstance(end, int)
@@ -136,13 +152,15 @@ def slice_(
         )
         return [fragment_name, "within_bound_index"]
 
+    # In static-axes mode `_resolve_slice_bound` always returns ints
+    # (Identifiers only appear under dynamic axes, which returned above).
     dim_size = input_node.shape[dim]
-    end = min(
-        end + dim_size if isinstance(end, int) and end < 0 else end, dim_size
-    )
-    begin = max(
-        begin + dim_size if isinstance(begin, int) and begin < 0 else begin, 0
-    )
+    if end < 0:
+        end += dim_size
+    end = min(end, dim_size)
+    if begin < 0:
+        begin += dim_size
+    begin = max(begin, 0)
 
     op_helper.add_single_output_op_from_nnef_tensors(
         node,


### PR DESCRIPTION
## Summary

Two new ATen ops, both decomposed into existing tract primitives so no tract-side change is needed; plus a small drive-by fix to `aten::slice` to unblock CI.

- **`aten::flip`** ([`torch_to_nnef/op/aten/axes_change.py`](../tree/feat/aten-flip-diagonal/torch_to_nnef/op/aten/axes_change.py)) chains one `tract_core_gather` per axis with a constant reversed-index tensor `[N-1, ..., 0]`. Static-shape only for v1; dynamic axes raise `T2NErrorNotImplemented` with the offending axis. Empty `dims` falls through to a no-op reshape.
- **`aten::diagonal`** ([`torch_to_nnef/op/aten/selector.py`](../tree/feat/aten-flip-diagonal/torch_to_nnef/op/aten/selector.py)) brings `(dim1, dim2)` to the trailing positions via `transpose`, slices each target axis to the diagonal window, then evaluates `<leading>ii-><leading>i` with `tract_core_einsum`. Concrete labels per rank, since tract einsum does not accept ellipsis at the targeted version. **`offset` supported** for both signs via per-axis slice begin (`begin_a1 = max(0, -offset)`, `begin_a2 = max(0, offset)`, `L = min(s1 - begin_a1, s2 - begin_a2)`); the offset sign flips when `(a1, a2)` get sorted, since `offset` is given in the user's `(dim1, dim2)` order. Empty diagonals (`L <= 0`) are left as `T2NErrorNotImplemented` since static zero-extent axes are awkward to emit.
- **Drive-by `aten::slice` fix** (commit `8622dc6`): the static-axes negative-bound resolution introduced in `e1e93ea` did `min(end, dim_size)` and `max(begin, 0)` unconditionally, but `end` / `begin` are `nnef.Identifier` when the upstream node has `data is None`. Gate the resolution on `isinstance(_, int)`. Surfaced by `test_slice_with_none_bounds_exports` and the silero-vad export example. Pre-existing on `main`, not introduced by this PR; bundled here to unblock its own CI.

Both new ops target the established `TractNNEF` path. Pure-NNEF targets raise with a clear message pointing at the missing primitive.

## Coverage

Proptest specs added next to `tril`/`triu` in [`tests/proptest/op_specs/shape.py`](../tree/feat/aten-flip-diagonal/tests/proptest/op_specs/shape.py), with `EXACT` tolerance:

- `flip`: rank 1-4, draws a unique non-empty subset of dims.
- `diagonal`: rank 2-4, independent shapes on `dim1`/`dim2` to exercise the slice path; `offset` drawn in `[-(s1 - 1), s2 - 1]` so the resulting diagonal has length >= 1 on every example.

The slice fix is covered by the existing `test_slice_with_none_bounds_exports` (was failing on `main` too, now passes).

## Test plan

- [x] `ruff check` + `ruff format` clean.
- [x] `pytest -m proptest -k "flip or diagonal or slice"` passes.
- [x] `pytest tests/test_aten_parser_fixes.py` passes (slice fix).
- [x] Neighbouring shape proptests (`transpose`, `permute`, `roll`, `tril`, `triu`) still pass: no collateral.
- [ ] CI matrix on this branch.

## Follow-ups

- Dynamic-axis flip via `tract_core_range(N-1, -1, -1)` + `tract_core_gather`.
- Empty-diagonal (`|offset| >= min(s1, s2)`) handling if a user model needs it.