### PR TITLE
feat(op): scatter family (scatter_add/reduce, select_scatter, slice_scatter)

### DIFF
--- a/tests/proptest/op_specs/shape.py
+++ b/tests/proptest/op_specs/shape.py
@@ -1337,6 +1337,206 @@ def _slice_sample_st() -> st.SearchStrategy[OpSample]:
     return _draw()
 
 
+def _scatter_add_sample_st() -> st.SearchStrategy[OpSample]:
+    """`Tensor.scatter_add(dim, index, src)`: in-place add via scatter."""
+
+    @st.composite
+    def _draw(draw) -> OpSample:
+        rank = draw(st.integers(min_value=1, max_value=3))
+        shape = tuple(
+            draw(
+                st.lists(
+                    st.integers(min_value=2, max_value=4),
+                    min_size=rank,
+                    max_size=rank,
+                )
+            )
+        )
+        dim = draw(st.integers(min_value=0, max_value=rank - 1))
+        idx_dim_size = draw(st.integers(min_value=1, max_value=shape[dim]))
+        idx_shape = list(shape)
+        idx_shape[dim] = idx_dim_size
+        idx = draw(
+            tensor_st(
+                tuple(idx_shape),
+                torch.int64,
+                finite=True,
+                domain=Interval(0, shape[dim] - 1),
+            )
+        )
+        src = draw(
+            tensor_st(
+                tuple(idx_shape),
+                torch.float32,
+                finite=True,
+                domain=Interval(-10.0, 10.0),
+            )
+        )
+        x = draw(
+            tensor_st(
+                shape,
+                torch.float32,
+                finite=True,
+                domain=Interval(-10.0, 10.0),
+            )
+        )
+        op_fn = (lambda d: lambda t, i, s: t.scatter_add(d, i, s))(dim)
+        return OpSample(inputs=(x, idx, src), module=TernaryPrimitive(op_fn))
+
+    return _draw()
+
+
+def _scatter_reduce_sample_st(
+    reduce_mode: str,
+) -> st.SearchStrategy[OpSample]:
+    """`Tensor.scatter_reduce(dim, index, src, reduce, include_self=True)`."""
+
+    @st.composite
+    def _draw(draw) -> OpSample:
+        rank = draw(st.integers(min_value=1, max_value=3))
+        shape = tuple(
+            draw(
+                st.lists(
+                    st.integers(min_value=2, max_value=4),
+                    min_size=rank,
+                    max_size=rank,
+                )
+            )
+        )
+        dim = draw(st.integers(min_value=0, max_value=rank - 1))
+        idx_dim_size = draw(st.integers(min_value=1, max_value=shape[dim]))
+        idx_shape = list(shape)
+        idx_shape[dim] = idx_dim_size
+        idx = draw(
+            tensor_st(
+                tuple(idx_shape),
+                torch.int64,
+                finite=True,
+                domain=Interval(0, shape[dim] - 1),
+            )
+        )
+        src = draw(
+            tensor_st(
+                tuple(idx_shape),
+                torch.float32,
+                finite=True,
+                domain=Interval(-10.0, 10.0),
+            )
+        )
+        x = draw(
+            tensor_st(
+                shape,
+                torch.float32,
+                finite=True,
+                domain=Interval(-10.0, 10.0),
+            )
+        )
+        op_fn = (
+            lambda d, r: lambda t, i, s: t.scatter_reduce(
+                d, i, s, reduce=r, include_self=True
+            )
+        )(dim, reduce_mode)
+        return OpSample(inputs=(x, idx, src), module=TernaryPrimitive(op_fn))
+
+    return _draw()
+
+
+def _select_scatter_sample_st() -> st.SearchStrategy[OpSample]:
+    """`torch.select_scatter(input, src, dim, index)`: write src at index.
+
+    Restricted to rank >= 2 because `tensor_st(())` produces shape `[1]`
+    (1-D), not 0-D, so a rank-1 input + rank-0 src case can't be drawn
+    cleanly. The op itself supports rank 1, but the strategy doesn't.
+    """
+
+    @st.composite
+    def _draw(draw) -> OpSample:
+        rank = draw(st.integers(min_value=2, max_value=3))
+        shape = tuple(
+            draw(
+                st.lists(
+                    st.integers(min_value=1, max_value=4),
+                    min_size=rank,
+                    max_size=rank,
+                )
+            )
+        )
+        dim = draw(st.integers(min_value=0, max_value=rank - 1))
+        index = draw(st.integers(min_value=0, max_value=shape[dim] - 1))
+        # `src` has rank = input.rank - 1 (drops `dim`).
+        src_shape = shape[:dim] + shape[dim + 1 :]
+        x = draw(
+            tensor_st(
+                shape,
+                torch.float32,
+                finite=True,
+                domain=Interval(-10.0, 10.0),
+            )
+        )
+        src = draw(
+            tensor_st(
+                src_shape,
+                torch.float32,
+                finite=True,
+                domain=Interval(-10.0, 10.0),
+            )
+        )
+        op_fn = (lambda d, i: lambda t, s: torch.select_scatter(t, s, d, i))(
+            dim, index
+        )
+        return OpSample(inputs=(x, src), module=BinaryPrimitive(op_fn))
+
+    return _draw()
+
+
+def _slice_scatter_sample_st() -> st.SearchStrategy[OpSample]:
+    """`torch.slice_scatter(input, src, dim, start, end, step=1)`."""
+
+    @st.composite
+    def _draw(draw) -> OpSample:
+        rank = draw(st.integers(min_value=1, max_value=3))
+        shape = tuple(
+            draw(
+                st.lists(
+                    st.integers(min_value=2, max_value=5),
+                    min_size=rank,
+                    max_size=rank,
+                )
+            )
+        )
+        dim = draw(st.integers(min_value=0, max_value=rank - 1))
+        dim_size = shape[dim]
+        start = draw(st.integers(min_value=0, max_value=dim_size - 1))
+        end = draw(st.integers(min_value=start + 1, max_value=dim_size))
+        # `src` matches input shape except at `dim` where it's (end-start).
+        src_shape = list(shape)
+        src_shape[dim] = end - start
+        x = draw(
+            tensor_st(
+                shape,
+                torch.float32,
+                finite=True,
+                domain=Interval(-10.0, 10.0),
+            )
+        )
+        src = draw(
+            tensor_st(
+                tuple(src_shape),
+                torch.float32,
+                finite=True,
+                domain=Interval(-10.0, 10.0),
+            )
+        )
+        op_fn = (
+            lambda d, st_, en: lambda t, s: torch.slice_scatter(
+                t, s, dim=d, start=st_, end=en, step=1
+            )
+        )(dim, start, end)
+        return OpSample(inputs=(x, src), module=BinaryPrimitive(op_fn))
+
+    return _draw()
+
+
 def _sort_scatter_specs() -> T.List[OpSpec]:
     return [
         OpSpec(
@@ -1352,6 +1552,66 @@ def _sort_scatter_specs() -> T.List[OpSpec]:
         OpSpec(
             name="scatter",
             sample_st=_scatter_sample_st(),
+            tolerance=TractCheckTolerance.EXACT,
+        ),
+        # scatter reduction landed in tract 0.23.0-dev.4 (#2109). The
+        # CI runtime is the published 0.22.1, which silently ignores the
+        # NNEF `reduction` attribute and runs overwrite (the t2n
+        # emitter raises T2NErrorNotImplemented under that version).
+        # Flip these to non-xfail once tract 0.23 ships stable.
+        OpSpec(
+            name="scatter_add-xfail",
+            sample_st=_scatter_add_sample_st(),
+            tolerance=TractCheckTolerance.EXACT,
+            xfail_reason=(
+                "tract 0.22.1 lacks ScatterReduction; t2n hard-errors "
+                "below 0.23.0-dev.4."
+            ),
+        ),
+        OpSpec(
+            name="scatter_reduce-sum-xfail",
+            sample_st=_scatter_reduce_sample_st("sum"),
+            tolerance=TractCheckTolerance.EXACT,
+            xfail_reason=(
+                "tract 0.22.1 lacks ScatterReduction; t2n hard-errors "
+                "below 0.23.0-dev.4."
+            ),
+        ),
+        OpSpec(
+            name="scatter_reduce-prod-xfail",
+            sample_st=_scatter_reduce_sample_st("prod"),
+            tolerance=TractCheckTolerance.EXACT,
+            xfail_reason=(
+                "tract 0.22.1 lacks ScatterReduction; t2n hard-errors "
+                "below 0.23.0-dev.4."
+            ),
+        ),
+        OpSpec(
+            name="scatter_reduce-amax-xfail",
+            sample_st=_scatter_reduce_sample_st("amax"),
+            tolerance=TractCheckTolerance.EXACT,
+            xfail_reason=(
+                "tract 0.22.1 lacks ScatterReduction; t2n hard-errors "
+                "below 0.23.0-dev.4."
+            ),
+        ),
+        OpSpec(
+            name="scatter_reduce-amin-xfail",
+            sample_st=_scatter_reduce_sample_st("amin"),
+            tolerance=TractCheckTolerance.EXACT,
+            xfail_reason=(
+                "tract 0.22.1 lacks ScatterReduction; t2n hard-errors "
+                "below 0.23.0-dev.4."
+            ),
+        ),
+        OpSpec(
+            name="select_scatter",
+            sample_st=_select_scatter_sample_st(),
+            tolerance=TractCheckTolerance.EXACT,
+        ),
+        OpSpec(
+            name="slice_scatter",
+            sample_st=_slice_scatter_sample_st(),
             tolerance=TractCheckTolerance.EXACT,
         ),
         OpSpec(

--- a/tests/proptest/op_specs/shape.py
+++ b/tests/proptest/op_specs/shape.py
@@ -1432,8 +1432,10 @@ def _scatter_reduce_sample_st(
             )
         )
         op_fn = (
-            lambda d, r: lambda t, i, s: t.scatter_reduce(
-                d, i, s, reduce=r, include_self=True
+            lambda d, r: (
+                lambda t, i, s: t.scatter_reduce(
+                    d, i, s, reduce=r, include_self=True
+                )
             )
         )(dim, reduce_mode)
         return OpSample(inputs=(x, idx, src), module=TernaryPrimitive(op_fn))
@@ -1528,8 +1530,10 @@ def _slice_scatter_sample_st() -> st.SearchStrategy[OpSample]:
             )
         )
         op_fn = (
-            lambda d, st_, en: lambda t, s: torch.slice_scatter(
-                t, s, dim=d, start=st_, end=en, step=1
+            lambda d, st_, en: (
+                lambda t, s: torch.slice_scatter(
+                    t, s, dim=d, start=st_, end=en, step=1
+                )
             )
         )(dim, start, end)
         return OpSample(inputs=(x, src), module=BinaryPrimitive(op_fn))

--- a/torch_to_nnef/op/aten/selector.py
+++ b/torch_to_nnef/op/aten/selector.py
@@ -823,32 +823,295 @@ def index_select(node, op_helper, inference_target, **kwargs):
     return ["tract_core"]
 
 
+def _emit_scatter_elements(
+    node, op_helper, input_node, dim, indexes_node, src_node, reduction
+):
+    """Common emitter for the scatter family on the TractNNEF path.
+
+    All variants lower to `tract_core_scatter_elements`; the only thing
+    that varies is the `reduction` attribute and which torch overload's
+    inputs we pulled apart upstream.
+    """
+    op_helper.add_single_output_op_from_nnef_tensors(
+        node,
+        "tract_core_scatter_elements",
+        inputs=[
+            op_helper.get_or_add_tensor_variable_in_nnef(input_node),
+            op_helper.get_or_add_tensor_variable_in_nnef(indexes_node),
+            op_helper.get_or_add_tensor_variable_in_nnef(src_node),
+        ],
+        attrs={"axis": dim, "reduction": reduction},
+        force_consistent_inputs_shapes=False,
+    )
+    return ["tract_core"]
+
+
 @OP_REGISTRY.register()
 def scatter(node, op_helper, inference_target, **kwargs):
     """Map PyTorch: 'aten:scatter' to NNEF."""
     input_node, dim_node, indexes_node, src_node = node.inputs
     if not isinstance(inference_target, TractNNEF):
         raise T2NErrorNotImplemented(inference_target)
-
-    # is a select with indexes
-    op_helper.add_single_output_op_from_nnef_tensors(
+    return _emit_scatter_elements(
         node,
-        "tract_core_scatter_elements",
-        inputs=[
-            op_helper.get_or_add_tensor_variable_in_nnef(input_node),
-            op_helper.get_or_add_tensor_variable_in_nnef(
-                indexes_node,
-            ),
-            op_helper.get_or_add_tensor_variable_in_nnef(
-                src_node,
-            ),
-        ],
-        attrs={
-            "axis": dim_node.data,
-        },
-        force_consistent_inputs_shapes=False,
+        op_helper,
+        input_node,
+        dim_node.data,
+        indexes_node,
+        src_node,
+        reduction="none",
     )
-    return ["tract_core"]
+
+
+_SCATTER_REDUCTION_MIN_TRACT_VERSION = "0.23.0-dev.4"
+
+
+def _check_scatter_reduction_supported(inference_target):
+    """Tract gained the NNEF `reduction` attribute in 0.23.0-dev.4 (#2109).
+
+    Earlier releases (incl. the published 0.22.1) silently ignore the
+    attribute and run the default overwrite path, which silently gives
+    wrong answers. Refuse to emit when targeting an older runtime.
+    """
+    if inference_target.version < _SCATTER_REDUCTION_MIN_TRACT_VERSION:
+        raise T2NErrorNotImplemented(
+            f"scatter with reduction needs tract >= "
+            f"{_SCATTER_REDUCTION_MIN_TRACT_VERSION}; got "
+            f"{inference_target.version}"
+        )
+
+
+@OP_REGISTRY.register()
+def scatter_add(node, op_helper, inference_target, **kwargs):
+    """Map PyTorch: 'aten:scatter_add' to NNEF.
+
+    `scatter_add(input, dim, index, src)` accumulates `src` values into
+    `input` at positions selected by `index` along `dim`. Equivalent to
+    `tract_core_scatter_elements` with `reduction="add"`.
+    """
+    if not isinstance(inference_target, TractNNEF):
+        raise T2NErrorNotImplemented(inference_target)
+    _check_scatter_reduction_supported(inference_target)
+    input_node, dim_node, indexes_node, src_node = node.inputs
+    return _emit_scatter_elements(
+        node,
+        op_helper,
+        input_node,
+        dim_node.data,
+        indexes_node,
+        src_node,
+        reduction="add",
+    )
+
+
+_SCATTER_REDUCE_TORCH_TO_TRACT = {
+    "sum": "add",
+    "prod": "mul",
+    "amax": "max",
+    "amin": "min",
+}
+
+
+@OP_REGISTRY.register()
+def scatter_reduce(node, op_helper, inference_target, **kwargs):
+    """Map PyTorch: 'aten:scatter_reduce' to NNEF.
+
+    Maps torch's reduce mode to tract's `ScatterReduction`. `mean` is
+    not in tract's set ({add, mul, min, max}) so we raise; the same goes
+    for `include_self=False`, since tract always reduces against the
+    pre-existing destination value.
+    """
+    if not isinstance(inference_target, TractNNEF):
+        raise T2NErrorNotImplemented(inference_target)
+    _check_scatter_reduction_supported(inference_target)
+    (
+        input_node,
+        dim_node,
+        indexes_node,
+        src_node,
+        reduce_node,
+        include_self_node,
+    ) = node.inputs
+    reduce_str = reduce_node.data
+    if reduce_str not in _SCATTER_REDUCE_TORCH_TO_TRACT:
+        raise T2NErrorNotImplemented(
+            f"scatter_reduce: reduce='{reduce_str}' not supported "
+            "(tract has add/mul/min/max only; no mean)"
+        )
+    if include_self_node.data is False:
+        raise T2NErrorNotImplemented(
+            "scatter_reduce: include_self=False not supported by tract"
+        )
+    return _emit_scatter_elements(
+        node,
+        op_helper,
+        input_node,
+        dim_node.data,
+        indexes_node,
+        src_node,
+        reduction=_SCATTER_REDUCE_TORCH_TO_TRACT[reduce_str],
+    )
+
+
+@OP_REGISTRY.register()
+def select_scatter(node, op_helper, inference_target, **kwargs):
+    """Map PyTorch: 'aten:select_scatter' to NNEF.
+
+    `out = input.clone(); out.select(dim, index).copy_(src)` -- the
+    functional select-write. Decomposes to `slice` + `unsqueeze` +
+    `concat`: replace the (size-1) slab at position `index` along `dim`
+    with `src` (which has rank `input.rank - 1`). Static-shape only.
+    """
+    input_node, src_node, dim_node, index_node = node.inputs
+    dim = pick_axis(input_node, dim_node.data)
+    dim_size = input_node.shape[dim]
+    if not isinstance(dim_size, int):
+        raise T2NErrorNotImplemented(
+            f"select_scatter on dynamic dim {dim} not yet supported"
+        )
+
+    index = index_node.data
+    if index < 0:
+        index += dim_size
+
+    inp_ref = op_helper.get_or_add_tensor_variable_in_nnef(input_node)
+    src_unsq = op_helper.add_single_output_op_from_nnef_tensors(
+        node,
+        "unsqueeze",
+        inputs=op_helper.get_or_add_tensor_variable_in_nnef(src_node),
+        attrs={"axes": [dim]},
+        output_tensor_name_suffix="_ss_src_unsq",
+    )
+
+    parts = []
+    if index > 0:
+        parts.append(
+            op_helper.add_single_output_op_from_nnef_tensors(
+                node,
+                "slice",
+                inputs=inp_ref,
+                attrs={"axes": [dim], "begin": [0], "end": [index]},
+                output_tensor_name_suffix="_ss_left",
+            )
+        )
+    parts.append(src_unsq)
+    if index + 1 < dim_size:
+        parts.append(
+            op_helper.add_single_output_op_from_nnef_tensors(
+                node,
+                "slice",
+                inputs=inp_ref,
+                attrs={
+                    "axes": [dim],
+                    "begin": [index + 1],
+                    "end": [dim_size],
+                },
+                output_tensor_name_suffix="_ss_right",
+            )
+        )
+
+    if len(parts) == 1:
+        # Whole-axis replacement (dim_size == 1): src already covers the
+        # full output. Emit a no-op reshape so the output gets named.
+        op_helper.add_single_output_op_from_nnef_tensors(
+            node,
+            "reshape",
+            inputs=parts[0],
+            attrs={"shape": list(input_node.shape)},
+        )
+    else:
+        op_helper.add_single_output_op_from_nnef_tensors(
+            node,
+            "concat",
+            inputs=parts,
+            ensure_tuple=False,
+            attrs={"axis": dim},
+            force_consistent_inputs_shapes=False,
+        )
+    return []
+
+
+@OP_REGISTRY.register()
+def slice_scatter(node, op_helper, inference_target, **kwargs):
+    """Map PyTorch: 'aten:slice_scatter' to NNEF.
+
+    `out = input.clone(); out[..., start:end:step, ...] = src` -- the
+    functional slice-write. Decomposes to `slice` + `concat`. `step != 1`
+    is rejected (would need an interleave path). Static-shape only.
+    """
+    (
+        input_node,
+        src_node,
+        dim_node,
+        start_node,
+        end_node,
+        step_node,
+    ) = node.inputs
+    if step_node.data != 1:
+        raise T2NErrorNotImplemented(
+            f"slice_scatter step={step_node.data} (only step=1 supported)"
+        )
+    dim = pick_axis(input_node, dim_node.data)
+    dim_size = input_node.shape[dim]
+    if not isinstance(dim_size, int):
+        raise T2NErrorNotImplemented(
+            f"slice_scatter on dynamic dim {dim} not yet supported"
+        )
+
+    start = start_node.data if start_node.data is not None else 0
+    end = end_node.data if end_node.data is not None else dim_size
+    if start < 0:
+        start += dim_size
+    if end < 0:
+        end += dim_size
+    start = max(start, 0)
+    end = min(end, dim_size)
+
+    inp_ref = op_helper.get_or_add_tensor_variable_in_nnef(input_node)
+    src_ref = op_helper.get_or_add_tensor_variable_in_nnef(src_node)
+
+    parts = []
+    if start > 0:
+        parts.append(
+            op_helper.add_single_output_op_from_nnef_tensors(
+                node,
+                "slice",
+                inputs=inp_ref,
+                attrs={"axes": [dim], "begin": [0], "end": [start]},
+                output_tensor_name_suffix="_sls_left",
+            )
+        )
+    parts.append(src_ref)
+    if end < dim_size:
+        parts.append(
+            op_helper.add_single_output_op_from_nnef_tensors(
+                node,
+                "slice",
+                inputs=inp_ref,
+                attrs={"axes": [dim], "begin": [end], "end": [dim_size]},
+                output_tensor_name_suffix="_sls_right",
+            )
+        )
+
+    if len(parts) == 1:
+        # Full-axis replacement (start == 0 and end == dim_size). Emit a
+        # no-op reshape so the output node still gets registered.
+        op_helper.add_single_output_op_from_nnef_tensors(
+            node,
+            "reshape",
+            inputs=parts[0],
+            attrs={"shape": list(input_node.shape)},
+        )
+    else:
+        op_helper.add_single_output_op_from_nnef_tensors(
+            node,
+            "concat",
+            inputs=parts,
+            ensure_tuple=False,
+            attrs={"axis": dim},
+            force_consistent_inputs_shapes=False,
+        )
+    return []
 
 
 @OP_REGISTRY.register()


### PR DESCRIPTION
## Summary

Five new ATen ops in the scatter family, all decomposed into existing tract primitives. No tract-side change required.

| Op | Lowering | Notes |
|---|---|---|
| `aten::scatter_add` | `tract_core_scatter_elements` with `reduction="add"` | needs tract >= 0.23.0-dev.4 |
| `aten::scatter_reduce` | `tract_core_scatter_elements` with mapped reduction | sum/prod/amax/amin only; mean and `include_self=False` rejected |
| `aten::select_scatter` | `slice` + `unsqueeze` + `concat` | works on any tract version |
| `aten::slice_scatter` | `slice` + `concat` | step != 1 rejected; works on any tract version |

## Tract-version dependency on `scatter_*` reduction

The NNEF `reduction` attribute on `tract_core_scatter_elements` landed in tract 0.23.0-dev.4 ([sonos/tract#2109](https://github.com/sonos/tract/pull/2109)). Below that, the runtime silently ignores the attribute and runs the default overwrite path, which silently produces wrong results. The emitter therefore hard-errors when `inference_target.version < "0.23.0-dev.4"` rather than emit a graph that would silently miscompute.

When tract 0.23 ships stable and `TractNNEF.latest_version()` advances past it, the gate becomes a no-op and the proptest xfails can be flipped back.

## Coverage

Proptest specs in `tests/proptest/op_specs/shape.py`:

- `scatter_add` and `scatter_reduce-{sum,prod,amax,amin}`: marked `xfail_reason` because CI runs against tract 0.22.1 which lacks the reduction support; the t2n emitter hard-errors as designed.
- `select_scatter`: live, restricted to rank >= 2 (the strategy can't draw a true 0-D `src` because `tensor_st(())` returns a 1-D shape `[1]`).
- `slice_scatter`: live, full rank range.
- Pre-existing `scatter` proptest still passes (no behavioural change to the no-reduction path; refactored shared emit path into `_emit_scatter_elements`).

## Test plan

- [x] `ruff check` + `ruff format` clean.
- [x] `pytest -m proptest -k "scatter"` passes (3 live + 5 xfail as designed).
- [x] Full proptest sweep: 192 passed, 20 xfailed (5 added by this PR, 15 pre-existing). No regressions.
- [ ] CI matrix on this branch.

## Out of scope (deferred)

- `aten::index_put` -- general advanced-indexing form is hard (needs `tract_core_scatter_nd` indices wrangling); narrow case overlaps scatter_*. Wait for a real model demand.
- `aten::masked_scatter` -- needs `nonzero` / dynamic-extent support.