### PR TITLE
docs: fall back to torch 2.8 ONNX page when generating for torch >= 2.9

### DIFF
--- a/docs/contributing/generate_support_page.py
+++ b/docs/contributing/generate_support_page.py
@@ -99,6 +99,12 @@ class AliasManager:
 #: back to this one to keep the "is core" column populated.
 LAST_TORCH_VERSION_WITH_IR_DOC = "2.9"
 
+#: Last torch version that ships
+#: ``onnx_torchscript_supported_aten_ops.html``. Starting at 2.9 the
+#: TorchScript ONNX exporter was retired and that page 404s; fall back
+#: to this one so the ONNX comparison column doesn't simply disappear.
+LAST_TORCH_VERSION_WITH_ONNX_DOC = "2.8"
+
 
 class FetchFromTorchVersion:
     def __init__(self, torch_version: str):
@@ -107,6 +113,10 @@ class FetchFromTorchVersion:
         # IR list (fallback or not). Used by the markdown header so the
         # `is core` link points at the page that was scraped.
         self.resolved_ir_url: Optional[str] = None
+        # Set by `get_onnx_support`: the URL that yielded the ONNX
+        # support listing. `None` if no ONNX data could be fetched at
+        # all (the section is then omitted).
+        self.resolved_onnx_url: Optional[str] = None
 
     @property
     def url_ir(self) -> str:
@@ -123,6 +133,14 @@ class FetchFromTorchVersion:
     def onnx_support_url(self) -> str:
         return (
             f"https://docs.pytorch.org/docs/{self.torch_version}/"
+            "onnx_torchscript_supported_aten_ops.html"
+        )
+
+    @property
+    def onnx_support_url_fallback(self) -> str:
+        return (
+            "https://docs.pytorch.org/docs/"
+            f"{LAST_TORCH_VERSION_WITH_ONNX_DOC}/"
             "onnx_torchscript_supported_aten_ops.html"
         )
 
@@ -163,25 +181,9 @@ class FetchFromTorchVersion:
             self.resolved_ir_url = self.url_ir_fallback
         return official_aten_names, official_prim_names
 
-    def get_onnx_support(self) -> tuple[Set[str], Set[str]]:
-        """Fetch the TorchScript-ONNX per-op support page.
-
-        PyTorch removed this page after torch 2.8 (TorchScript ONNX
-        export was deprecated in favour of `torch.onnx.export(dynamo=
-        True)`), and the new dynamo path doesn't ship a tabular
-        per-op page. Return empty sets when the URL 404s so callers
-        can drop the ONNX section gracefully.
-        """
-        resp = rq.get(self.onnx_support_url, timeout=20)
-        if resp.status_code == 404:
-            warnings.warn(
-                f"ONNX support page not found at {self.onnx_support_url} "
-                "(removed in torch 2.9+). Skipping ONNX comparison.",
-                stacklevel=2,
-            )
-            return set(), set()
-        assert resp.status_code == 200
-        soup = bs4.BeautifulSoup(resp.content, "html.parser")
+    @staticmethod
+    def _parse_onnx_page(html: bytes) -> tuple[Set[str], Set[str]]:
+        soup = bs4.BeautifulSoup(html, "html.parser")
         supported_ops = {
             _.text.replace("aten::", "")
             for _ in soup.find(id="id1").find_all("span", {"class": "pre"})
@@ -193,6 +195,37 @@ class FetchFromTorchVersion:
             if "aten::" in _.text
         }
         return supported_ops, unsupported_ops
+
+    def get_onnx_support(self) -> tuple[Set[str], Set[str]]:
+        """Fetch the TorchScript-ONNX per-op support page.
+
+        PyTorch removed this page after torch 2.8 (TorchScript ONNX
+        export was deprecated in favour of `torch.onnx.export(dynamo=
+        True)`), and the new dynamo path doesn't ship a tabular
+        per-op page. Fall back to the last torch version that still
+        ships the page so the ONNX comparison column survives; the
+        link in the section header points at whichever URL actually
+        served the data.
+        """
+        resp = rq.get(self.onnx_support_url, timeout=20)
+        if resp.status_code == 200:
+            self.resolved_onnx_url = self.onnx_support_url
+            return self._parse_onnx_page(resp.content)
+        if resp.status_code == 404:
+            warnings.warn(
+                f"ONNX support page not found at {self.onnx_support_url} "
+                "(removed in torch 2.9+); falling back to "
+                f"{self.onnx_support_url_fallback} for the ONNX column.",
+                stacklevel=2,
+            )
+            fallback = rq.get(self.onnx_support_url_fallback, timeout=20)
+            if fallback.status_code == 200:
+                self.resolved_onnx_url = self.onnx_support_url_fallback
+                return self._parse_onnx_page(fallback.content)
+        # Both the requested version and the fallback failed; let the
+        # caller drop the ONNX section.
+        self.resolved_onnx_url = None
+        return set(), set()
 
     def get_aten_torch_from_code(self) -> List[str]:
         aten_torch_from_code = sorted(
@@ -533,10 +566,22 @@ def build_markdown_page(torch_version: str):
             support_n_ops_label="`torch_to_nnef`",
         )
         if onnx_supported or onnx_unsupported:
+            onnx_url = fetcher.resolved_onnx_url or fetcher.onnx_support_url
+            onnx_section_msg = (
+                f"builtin PyTorch `ONNX` support based on "
+                f"[this page]({onnx_url})"
+            )
+            if onnx_url != fetcher.onnx_support_url:
+                onnx_section_msg += (
+                    f" (the page for torch {fetcher.torch_version} was "
+                    f"removed upstream in torch 2.9+; falling back to "
+                    f"torch {LAST_TORCH_VERSION_WITH_ONNX_DOC} which is "
+                    "the last version that still ships the TorchScript "
+                    "ONNX support listing)"
+                )
             write_operator_support(
                 "ONNX",
-                "builtin PyTorch `ONNX` support based on "
-                f"[this page]({fetcher.onnx_support_url})",
+                onnx_section_msg,
                 aten_torch_from_code,
                 onnx_supported,
                 official_aten_names=official_aten_names,

--- a/docs/contributing/supported_operators.md
+++ b/docs/contributing/supported_operators.md
@@ -898,6 +898,896 @@ We filter out 'backward' and 'sym' operators from the listing since they are unw
     </table>
     </div>
 
+=== "ONNX"
+
+
+    Total matched operators in builtin PyTorch `ONNX` support based on [this page](https://docs.pytorch.org/docs/2.8/onnx_torchscript_supported_aten_ops.html) (the page for torch 2.11 was removed upstream in torch 2.9+; falling back to torch 2.8 which is the last version that still ships the TorchScript ONNX support listing) compared to:
+
+    - core PyTorch opset:
+
+    [=123/138 "123/138"]
+
+    -  and support from full `aten::`: 
+
+    [=320/862 "320/862"]
+
+     (total operators listed as supported by PyTorch's TorchScript ONNX exporter being 348)
+
+    <div class="op-filter-container" markdown="0">
+    <form class="op-filter-form">
+    <label><input type="radio" name="op-filter-ONNX" value="all" checked> All</label>
+    <label><input type="radio" name="op-filter-ONNX" value="supported"> Supported only</label>
+    <label><input type="radio" name="op-filter-ONNX" value="unsupported"> Unsupported only</label>
+    </form>
+    <table class="op-table">
+    <thead><tr><th>translated</th><th>aten name</th><th>aliases</th><th>can in-place</th><th>is core</th></tr></thead>
+    <tbody>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.abs.html">abs</a></td><td>absolute</td><td>✅</td><td>✅</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.acos.html">acos</a></td><td>arccos</td><td>✅</td><td>✅</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.acosh.html">acosh</a></td><td>arccosh</td><td>✅</td><td>✅</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.adaptive_avg_pool1d.html">adaptive_avg_pool1d</a></td><td></td><td>❌</td><td>✅</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.add.html">add</a></td><td></td><td>✅</td><td>✅</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.addmm.html">addmm</a></td><td></td><td>✅</td><td>✅</td></tr>
+    <tr class="op-row supported"><td>✅</td><td>alias</td><td></td><td>❌</td><td>✅</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.amax.html">amax</a></td><td></td><td>❌</td><td>✅</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.amin.html">amin</a></td><td></td><td>❌</td><td>✅</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.any.html">any</a></td><td></td><td>❌</td><td>✅</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.arange.html">arange</a></td><td></td><td>❌</td><td>✅</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.argmax.html">argmax</a></td><td></td><td>❌</td><td>✅</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.argmin.html">argmin</a></td><td></td><td>❌</td><td>✅</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.as_strided.html">as_strided</a></td><td></td><td>✅</td><td>✅</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.asin.html">asin</a></td><td>arcsin</td><td>✅</td><td>✅</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.asinh.html">asinh</a></td><td>arcsinh</td><td>✅</td><td>✅</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.atan.html">atan</a></td><td>arctan</td><td>✅</td><td>✅</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.atan2.html">atan2</a></td><td>arctan2</td><td>✅</td><td>✅</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.atanh.html">atanh</a></td><td>arctanh</td><td>✅</td><td>✅</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.avg_pool1d.html">avg_pool1d</a></td><td></td><td>❌</td><td>✅</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.avg_pool2d.html">avg_pool2d</a></td><td></td><td>❌</td><td>✅</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.avg_pool3d.html">avg_pool3d</a></td><td></td><td>❌</td><td>✅</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.bitwise_and.html">bitwise_and</a></td><td></td><td>✅</td><td>✅</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.bitwise_not.html">bitwise_not</a></td><td></td><td>✅</td><td>✅</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.bitwise_or.html">bitwise_or</a></td><td></td><td>✅</td><td>✅</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.bitwise_xor.html">bitwise_xor</a></td><td></td><td>✅</td><td>✅</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.bmm.html">bmm</a></td><td></td><td>❌</td><td>✅</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.cat.html">cat</a></td><td>concat, concatenate</td><td>❌</td><td>✅</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.ceil.html">ceil</a></td><td></td><td>✅</td><td>✅</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.clamp.html">clamp</a></td><td>clip</td><td>✅</td><td>✅</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.clone.html">clone</a></td><td></td><td>❌</td><td>✅</td></tr>
+    <tr class="op-row supported"><td>✅</td><td>col2im</td><td></td><td>❌</td><td>✅</td></tr>
+    <tr class="op-row supported"><td>✅</td><td>constant_pad_nd</td><td></td><td>❌</td><td>✅</td></tr>
+    <tr class="op-row supported"><td>✅</td><td>convolution</td><td></td><td>❌</td><td>✅</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>copy</td><td></td><td>✅</td><td>✅</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.cos.html">cos</a></td><td></td><td>✅</td><td>✅</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.cosh.html">cosh</a></td><td></td><td>✅</td><td>✅</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.cumsum.html">cumsum</a></td><td></td><td>✅</td><td>✅</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.diagonal.html">diagonal</a></td><td></td><td>❌</td><td>✅</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.div.html">div</a></td><td>divide, true_divide</td><td>✅</td><td>✅</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.elu.html">elu</a></td><td></td><td>✅</td><td>✅</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.embedding.html">embedding</a></td><td></td><td>❌</td><td>✅</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.empty.html">empty</a></td><td></td><td>❌</td><td>✅</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.empty_strided.html">empty_strided</a></td><td></td><td>❌</td><td>✅</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.eq.html">eq</a></td><td></td><td>✅</td><td>✅</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.erf.html">erf</a></td><td>special_erf</td><td>✅</td><td>✅</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.exp.html">exp</a></td><td></td><td>✅</td><td>✅</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.Tensor.expand.html">expand</a></td><td></td><td>❌</td><td>✅</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.expm1.html">expm1</a></td><td>special_expm1</td><td>✅</td><td>✅</td></tr>
+    <tr class="op-row supported"><td>✅</td><td>fill</td><td></td><td>✅</td><td>✅</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.flip.html">flip</a></td><td></td><td>❌</td><td>✅</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.floor.html">floor</a></td><td></td><td>✅</td><td>✅</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.fmod.html">fmod</a></td><td></td><td>✅</td><td>✅</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.full.html">full</a></td><td></td><td>❌</td><td>✅</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.full_like.html">full_like</a></td><td></td><td>❌</td><td>✅</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.gather.html">gather</a></td><td></td><td>❌</td><td>✅</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.ge.html">ge</a></td><td>greater_equal</td><td>✅</td><td>✅</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.gelu.html">gelu</a></td><td></td><td>✅</td><td>✅</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>grid_sampler_2d</td><td></td><td>❌</td><td>✅</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.gt.html">gt</a></td><td>greater</td><td>✅</td><td>✅</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.hardtanh.html">hardtanh</a></td><td></td><td>✅</td><td>✅</td></tr>
+    <tr class="op-row supported"><td>✅</td><td>index</td><td></td><td>❌</td><td>✅</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.Tensor.index_put.html">index_put</a></td><td></td><td>✅</td><td>✅</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.index_select.html">index_select</a></td><td></td><td>❌</td><td>✅</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.isinf.html">isinf</a></td><td></td><td>❌</td><td>✅</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.isnan.html">isnan</a></td><td></td><td>❌</td><td>✅</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.le.html">le</a></td><td>less_equal</td><td>✅</td><td>✅</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.leaky_relu.html">leaky_relu</a></td><td></td><td>✅</td><td>✅</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.log.html">log</a></td><td></td><td>✅</td><td>✅</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.log10.html">log10</a></td><td></td><td>✅</td><td>✅</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.log1p.html">log1p</a></td><td>special_log1p</td><td>✅</td><td>✅</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.log2.html">log2</a></td><td></td><td>✅</td><td>✅</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.logical_and.html">logical_and</a></td><td></td><td>✅</td><td>✅</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.logical_not.html">logical_not</a></td><td></td><td>✅</td><td>✅</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.logical_or.html">logical_or</a></td><td></td><td>✅</td><td>✅</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.logical_xor.html">logical_xor</a></td><td></td><td>✅</td><td>✅</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.lt.html">lt</a></td><td>less</td><td>✅</td><td>✅</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.Tensor.masked_scatter.html">masked_scatter</a></td><td></td><td>✅</td><td>✅</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.max.html">max</a></td><td></td><td>❌</td><td>✅</td></tr>
+    <tr class="op-row supported"><td>✅</td><td>max_pool2d_with_indices</td><td></td><td>❌</td><td>✅</td></tr>
+    <tr class="op-row supported"><td>✅</td><td>max_pool3d_with_indices</td><td></td><td>❌</td><td>✅</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.maximum.html">maximum</a></td><td></td><td>❌</td><td>✅</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.mean.html">mean</a></td><td></td><td>❌</td><td>✅</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.min.html">min</a></td><td></td><td>❌</td><td>✅</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.minimum.html">minimum</a></td><td></td><td>❌</td><td>✅</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.mm.html">mm</a></td><td></td><td>❌</td><td>✅</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.mul.html">mul</a></td><td>multiply</td><td>✅</td><td>✅</td></tr>
+    <tr class="op-row supported"><td>✅</td><td>native_dropout</td><td></td><td>❌</td><td>✅</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>native_group_norm</td><td></td><td>❌</td><td>✅</td></tr>
+    <tr class="op-row supported"><td>✅</td><td>native_layer_norm</td><td></td><td>❌</td><td>✅</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.ne.html">ne</a></td><td>not_equal</td><td>✅</td><td>✅</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.neg.html">neg</a></td><td>negative</td><td>✅</td><td>✅</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nonzero.html">nonzero</a></td><td></td><td>❌</td><td>✅</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.permute.html">permute</a></td><td></td><td>❌</td><td>✅</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.pow.html">pow</a></td><td></td><td>✅</td><td>✅</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.prod.html">prod</a></td><td></td><td>❌</td><td>✅</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.rand.html">rand</a></td><td></td><td>❌</td><td>✅</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.randn.html">randn</a></td><td></td><td>❌</td><td>✅</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.randperm.html">randperm</a></td><td></td><td>❌</td><td>✅</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.reciprocal.html">reciprocal</a></td><td></td><td>✅</td><td>✅</td></tr>
+    <tr class="op-row supported"><td>✅</td><td>reflection_pad1d</td><td></td><td>❌</td><td>✅</td></tr>
+    <tr class="op-row supported"><td>✅</td><td>reflection_pad2d</td><td></td><td>❌</td><td>✅</td></tr>
+    <tr class="op-row supported"><td>✅</td><td>reflection_pad3d</td><td></td><td>❌</td><td>✅</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.relu.html">relu</a></td><td></td><td>✅</td><td>✅</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.remainder.html">remainder</a></td><td></td><td>✅</td><td>✅</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.Tensor.repeat.html">repeat</a></td><td></td><td>❌</td><td>✅</td></tr>
+    <tr class="op-row supported"><td>✅</td><td>replication_pad2d</td><td></td><td>❌</td><td>✅</td></tr>
+    <tr class="op-row supported"><td>✅</td><td>replication_pad3d</td><td></td><td>❌</td><td>✅</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.round.html">round</a></td><td>special_round</td><td>✅</td><td>✅</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.rsqrt.html">rsqrt</a></td><td></td><td>✅</td><td>✅</td></tr>
+    <tr class="op-row supported"><td>✅</td><td>scalar_tensor</td><td></td><td>❌</td><td>✅</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.scatter.html">scatter</a></td><td></td><td>✅</td><td>✅</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.scatter_add.html">scatter_add</a></td><td></td><td>✅</td><td>✅</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.scatter_reduce.html">scatter_reduce</a></td><td></td><td>✅</td><td>✅</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.select.html">select</a></td><td></td><td>❌</td><td>✅</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.select_scatter.html">select_scatter</a></td><td></td><td>❌</td><td>✅</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.sigmoid.html">sigmoid</a></td><td>special_expit</td><td>✅</td><td>✅</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.sign.html">sign</a></td><td></td><td>✅</td><td>✅</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.sin.html">sin</a></td><td></td><td>✅</td><td>✅</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.sinh.html">sinh</a></td><td></td><td>✅</td><td>✅</td></tr>
+    <tr class="op-row supported"><td>✅</td><td>slice</td><td></td><td>❌</td><td>✅</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.slice_scatter.html">slice_scatter</a></td><td></td><td>❌</td><td>✅</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.sort.html">sort</a></td><td></td><td>❌</td><td>✅</td></tr>
+    <tr class="op-row supported"><td>✅</td><td>split_with_sizes</td><td></td><td>❌</td><td>✅</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.sqrt.html">sqrt</a></td><td></td><td>✅</td><td>✅</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.squeeze.html">squeeze</a></td><td></td><td>✅</td><td>✅</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.sub.html">sub</a></td><td>subtract</td><td>✅</td><td>✅</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.sum.html">sum</a></td><td></td><td>❌</td><td>✅</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.tan.html">tan</a></td><td></td><td>✅</td><td>✅</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.tanh.html">tanh</a></td><td></td><td>✅</td><td>✅</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.topk.html">topk</a></td><td></td><td>❌</td><td>✅</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.trunc.html">trunc</a></td><td>fix</td><td>✅</td><td>✅</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.unsqueeze.html">unsqueeze</a></td><td></td><td>✅</td><td>✅</td></tr>
+    <tr class="op-row supported"><td>✅</td><td>upsample_bilinear2d</td><td></td><td>❌</td><td>✅</td></tr>
+    <tr class="op-row supported"><td>✅</td><td>upsample_nearest2d</td><td></td><td>❌</td><td>✅</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.var.html">var</a></td><td></td><td>❌</td><td>✅</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.Tensor.view.html">view</a></td><td></td><td>❌</td><td>✅</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.where.html">where</a></td><td></td><td>❌</td><td>✅</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.adaptive_avg_pool2d.html">adaptive_avg_pool2d</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.adaptive_avg_pool3d.html">adaptive_avg_pool3d</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.adaptive_max_pool1d.html">adaptive_max_pool1d</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.adaptive_max_pool2d.html">adaptive_max_pool2d</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.adaptive_max_pool3d.html">adaptive_max_pool3d</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.addbmm.html">addbmm</a></td><td></td><td>✅</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.addcdiv.html">addcdiv</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.addcmul.html">addcmul</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.addmv.html">addmv</a></td><td></td><td>✅</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.addr.html">addr</a></td><td></td><td>✅</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td>affine_grid_generator</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>alias_copy</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>align_as</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>align_tensors</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>align_to</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.all.html">all</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>all_gather_into_tensor</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>all_reduce</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.allclose.html">allclose</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.alpha_dropout.html">alpha_dropout</a></td><td></td><td>✅</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.aminmax.html">aminmax</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.angle.html">angle</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td>append</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.argsort.html">argsort</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.argwhere.html">argwhere</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>as_strided_copy</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>as_strided_scatter</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.as_tensor.html">as_tensor</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.atleast_1d.html">atleast_1d</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.atleast_2d.html">atleast_2d</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.atleast_3d.html">atleast_3d</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.baddbmm.html">baddbmm</a></td><td></td><td>✅</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.bartlett_window.html">bartlett_window</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.batch_norm.html">batch_norm</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>batch_norm_elemt</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>batch_norm_gather_stats</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>batch_norm_gather_stats_with_counts</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>batch_norm_stats</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>batch_norm_update_stats</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.bernoulli.html">bernoulli</a></td><td></td><td>✅</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>bias_addmm</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.bilinear.html">bilinear</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>bin</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.binary_cross_entropy.html">binary_cross_entropy</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.binary_cross_entropy_with_logits.html">binary_cross_entropy_with_logits</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.bincount.html">bincount</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>binomial</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.bitwise_left_shift.html">bitwise_left_shift</a></td><td></td><td>✅</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.bitwise_right_shift.html">bitwise_right_shift</a></td><td></td><td>✅</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.blackman_window.html">blackman_window</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.block_diag.html">block_diag</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.broadcast_tensors.html">broadcast_tensors</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.broadcast_to.html">broadcast_to</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.bucketize.html">bucketize</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.can_cast.html">can_cast</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>capitalize</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.cartesian_prod.html">cartesian_prod</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>cauchy</td><td></td><td>✅</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.Tensor.ccol_indices.html">ccol_indices</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>ccol_indices_copy</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.cdist.html">cdist</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.celu.html">celu</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>center</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.chain_matmul.html">chain_matmul</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.Tensor.chalf.html">chalf</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>channel_shuffle</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.cholesky.html">cholesky</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.cholesky_inverse.html">cholesky_inverse</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.cholesky_solve.html">cholesky_solve</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>choose_qparams_optimized</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>chr</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.chunk.html">chunk</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td>clamp_max</td><td></td><td>✅</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td>clamp_min</td><td></td><td>✅</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>clear</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.Tensor.coalesce.html">coalesce</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.Tensor.col_indices.html">col_indices</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>col_indices_copy</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.column_stack.html">column_stack</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.combinations.html">combinations</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.complex.html">complex</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>confirmed_by_owner</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.conj.html">conj</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.conj_physical.html">conj_physical</a></td><td></td><td>✅</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.Tensor.contiguous.html">contiguous</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>conv</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.conv1d.html">conv1d</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.conv2d.html">conv2d</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.conv3d.html">conv3d</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>conv_depthwise3d</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td>conv_tbc</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.conv_transpose1d.html">conv_transpose1d</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.conv_transpose2d.html">conv_transpose2d</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.conv_transpose3d.html">conv_transpose3d</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>convolution_overrideable</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>convrelu</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>copy_sparse_to_sparse</td><td></td><td>✅</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>copy_to</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.copysign.html">copysign</a></td><td></td><td>✅</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.corrcoef.html">corrcoef</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.cosine_embedding_loss.html">cosine_embedding_loss</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.cosine_similarity.html">cosine_similarity</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>count</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.count_nonzero.html">count_nonzero</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.Tensor.cpu.html">cpu</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.cross.html">cross</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td>cross_entropy_loss</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.Tensor.crow_indices.html">crow_indices</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>crow_indices_copy</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.ctc_loss.html">ctc_loss</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.Tensor.cuda.html">cuda</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>cudnn_affine_grid_generator</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>cudnn_batch_norm</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>cudnn_convolution</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>cudnn_convolution_add_relu</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>cudnn_convolution_relu</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>cudnn_convolution_transpose</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>cudnn_grid_sampler</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>cudnn_is_acceptable</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.cummax.html">cummax</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.cummin.html">cummin</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.cumprod.html">cumprod</a></td><td></td><td>✅</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.cumulative_trapezoid.html">cumulative_trapezoid</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>data</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.deg2rad.html">deg2rad</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>degrees</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.Tensor.dense_dim.html">dense_dim</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.dequantize.html">dequantize</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.Tensor.detach.html">detach</a></td><td></td><td>✅</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>detach_copy</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.Tensor.device.html">device</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.diag.html">diag</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.diag_embed.html">diag_embed</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.diagflat.html">diagflat</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>diagonal_copy</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.diagonal_scatter.html">diagonal_scatter</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>dict</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.diff.html">diff</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.digamma.html">digamma</a></td><td>special_digamma, special_psi</td><td>✅</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.Tensor.dim.html">dim</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.dist.html">dist</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>divmod</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.dot.html">dot</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.dropout.html">dropout</a></td><td></td><td>✅</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.dsplit.html">dsplit</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.dstack.html">dstack</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>dtype</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.linalg.eig.html">eig</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.einsum.html">einsum</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.Tensor.element_size.html">element_size</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.embedding_bag.html">embedding_bag</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td>embedding_renorm</td><td></td><td>✅</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.empty_like.html">empty_like</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>empty_permuted</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>empty_quantized</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.enable_grad.html">enable_grad</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>endswith</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.equal.html">equal</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.erfc.html">erfc</a></td><td>special_erfc</td><td>✅</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.erfinv.html">erfinv</a></td><td>special_erfinv</td><td>✅</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.exp2.html">exp2</a></td><td>special_exp2</td><td>✅</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.Tensor.expand_as.html">expand_as</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>expandtabs</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>exponential</td><td></td><td>✅</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>extend</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.eye.html">eye</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>fabs</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>factorial</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.fake_quantize_per_channel_affine.html">fake_quantize_per_channel_affine</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>fake_quantize_per_channel_affine_cachemask</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.fake_quantize_per_tensor_affine.html">fake_quantize_per_tensor_affine</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>fake_quantize_per_tensor_affine_cachemask</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.feature_alpha_dropout.html">feature_alpha_dropout</a></td><td></td><td>✅</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td>feature_dropout</td><td></td><td>✅</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>fft_fftfreq</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>fft_ihfft2</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>fft_ihfftn</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>fft_irfftn</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>fft_rfftfreq</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>fft_rfftn</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.Tensor.fill_diagonal_.html">fill_diagonal_</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>find</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.flatten.html">flatten</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>flatten_dense_tensors</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.fliplr.html">fliplr</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.flipud.html">flipud</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.float_power.html">float_power</a></td><td></td><td>✅</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.floor_divide.html">floor_divide</a></td><td></td><td>✅</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td>floordiv</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.fmax.html">fmax</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.fmin.html">fmin</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>foo</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>fork</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>format</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.frac.html">frac</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.fractional_max_pool2d.html">fractional_max_pool2d</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.fractional_max_pool3d.html">fractional_max_pool3d</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.frexp.html">frexp</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td>frobenius_norm</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.from_file.html">from_file</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>fused_moving_avg_obs_fake_quant</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>gamma</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.gcd.html">gcd</a></td><td></td><td>✅</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>geometric</td><td></td><td>✅</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.geqrf.html">geqrf</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>get</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>get_autocast_dtype</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.Tensor.get_device.html">get_device</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>get_gradients</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>get_pool_ceil_padding</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>getelem</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.glu.html">glu</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>glu_jvp</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.Tensor.grad.html">grad</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td>grid_sampler</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>grid_sampler_3d</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.group_norm.html">group_norm</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td>gru</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>gru_cell</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.hamming_window.html">hamming_window</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.hann_window.html">hann_window</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.hardshrink.html">hardshrink</a></td><td></td><td>✅</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.hardsigmoid.html">hardsigmoid</a></td><td></td><td>✅</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.hardswish.html">hardswish</a></td><td></td><td>✅</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>has_torch_function</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>hash</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.hash_tensor.html">hash_tensor</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.heaviside.html">heaviside</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>hex</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.hinge_embedding_loss.html">hinge_embedding_loss</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.histc.html">histc</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.histogram.html">histogram</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.histogramdd.html">histogramdd</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.hsplit.html">hsplit</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.hspmm.html">hspmm</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.hstack.html">hstack</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.huber_loss.html">huber_loss</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.hypot.html">hypot</a></td><td></td><td>✅</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.i0.html">i0</a></td><td>special_i0</td><td>✅</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.igamma.html">igamma</a></td><td>special_gammainc</td><td>✅</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.igammac.html">igammac</a></td><td>special_gammaincc</td><td>✅</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>iinfo</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td>im2col</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.imag.html">imag</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.index_add.html">index_add</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.index_copy.html">index_copy</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.Tensor.index_fill.html">index_fill</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>index_put_impl_</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.index_reduce.html">index_reduce</a></td><td></td><td>✅</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.Tensor.indices.html">indices</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>indices_copy</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.initial_seed.html">initial_seed</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.inner.html">inner</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td>insert</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.instance_norm.html">instance_norm</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.Tensor.int_repr.html">int_repr</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>is_autocast_cpu_enabled</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>is_autocast_enabled</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.Tensor.is_coalesced.html">is_coalesced</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.is_complex.html">is_complex</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.is_conj.html">is_conj</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.Tensor.is_contiguous.html">is_contiguous</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.Tensor.is_cuda.html">is_cuda</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.is_floating_point.html">is_floating_point</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.is_grad_enabled.html">is_grad_enabled</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.Tensor.is_leaf.html">is_leaf</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>is_non_overlapping_and_dense</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.is_nonzero.html">is_nonzero</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>is_owner</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.Tensor.is_pinned.html">is_pinned</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>is_same_size</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>is_scripting</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.Tensor.is_set_to.html">is_set_to</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.Tensor.is_signed.html">is_signed</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>is_strides_like_format</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>isalnum</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>isalpha</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.isclose.html">isclose</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>isdecimal</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>isdigit</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.isfinite.html">isfinite</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>isidentifier</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.isin.html">isin</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>islower</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.isneginf.html">isneginf</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>isnumeric</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.isposinf.html">isposinf</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>isprintable</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.isreal.html">isreal</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>isspace</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.istft.html">istft</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>istitle</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>isupper</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.Tensor.item.html">item</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>items</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>join</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.kaiser_window.html">kaiser_window</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>keys</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.kl_div.html">kl_div</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.kron.html">kron</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.kthvalue.html">kthvalue</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.l1_loss.html">l1_loss</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.layer_norm.html">layer_norm</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.lcm.html">lcm</a></td><td></td><td>✅</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.ldexp.html">ldexp</a></td><td></td><td>✅</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td>len</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.lerp.html">lerp</a></td><td></td><td>✅</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.lgamma.html">lgamma</a></td><td></td><td>✅</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td>lift</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>lift_fresh</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>lift_fresh_copy</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>linalg__powsum</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>linalg_cholesky_ex</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>linalg_cond</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td>linalg_cross</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td>linalg_det</td><td>det</td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>linalg_diagonal</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>linalg_eig</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>linalg_eigh</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>linalg_eigvals</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>linalg_eigvalsh</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>linalg_householder_product</td><td>orgqr</td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>linalg_inv</td><td>inverse</td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>linalg_inv_ex</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>linalg_ldl_factor_ex</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>linalg_ldl_solve</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>linalg_lstsq</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>linalg_lu</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>linalg_lu_factor_ex</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>linalg_lu_solve</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>linalg_matrix_exp</td><td>matrix_exp</td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td>linalg_matrix_norm</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>linalg_matrix_power</td><td>matrix_power</td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>linalg_matrix_rank</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td>linalg_norm</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>linalg_pinv</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>linalg_qr</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>linalg_slogdet</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>linalg_solve</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>linalg_solve_triangular</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>linalg_svd</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>linalg_tensorinv</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>linalg_tensorsolve</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td>linalg_vector_norm</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.linear.html">linear</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.linspace.html">linspace</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td>list</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>list_with_default</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>ljust</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>local_value</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>log_normal</td><td></td><td>✅</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td>log_sigmoid</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>log_sigmoid_forward</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.log_softmax.html">log_softmax</a></td><td>special_log_softmax</td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.logaddexp.html">logaddexp</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.logaddexp2.html">logaddexp2</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.logcumsumexp.html">logcumsumexp</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.logdet.html">logdet</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.logit.html">logit</a></td><td>special_logit</td><td>✅</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.logspace.html">logspace</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.logsumexp.html">logsumexp</a></td><td>special_logsumexp</td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>lower</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td>lstm</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td>lstm_cell</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>lstrip</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.linalg.lstsq.html">lstsq</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.lu_solve.html">lu_solve</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.lu_unpack.html">lu_unpack</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>mH</td><td>adjoint</td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>mT</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.manual_seed.html">manual_seed</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.margin_ranking_loss.html">margin_ranking_loss</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.Tensor.masked_fill.html">masked_fill</a></td><td></td><td>✅</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.masked_select.html">masked_select</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>mathremainder</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.matmul.html">matmul</a></td><td>linalg_matmul</td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>matrix_H</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.linalg.matrix_rank.html">matrix_rank</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.max_pool1d.html">max_pool1d</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td>max_pool1d_with_indices</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.max_pool2d.html">max_pool2d</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.max_pool3d.html">max_pool3d</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.max_unpool2d.html">max_unpool2d</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.max_unpool3d.html">max_unpool3d</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.median.html">median</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.meshgrid.html">meshgrid</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>miopen_batch_norm</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>miopen_convolution</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>miopen_convolution_add_relu</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>miopen_convolution_relu</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>miopen_convolution_transpose</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>miopen_ctc_loss</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>miopen_depthwise_convolution</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>miopen_rnn</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.mish.html">mish</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>mkldnn_adaptive_avg_pool2d</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>mkldnn_convolution</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>mkldnn_linear</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>mkldnn_max_pool2d</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>mkldnn_max_pool3d</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>mkldnn_reorder_conv2d_weight</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>mkldnn_reorder_conv3d_weight</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>mkldnn_rnn_layer</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.mode.html">mode</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>modf</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.movedim.html">movedim</a></td><td>moveaxis</td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>mps_linear</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.mse_loss.html">mse_loss</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.msort.html">msort</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.multi_margin_loss.html">multi_margin_loss</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.multilabel_margin_loss.html">multilabel_margin_loss</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>multilabel_margin_loss_forward</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.multinomial.html">multinomial</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.mv.html">mv</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.mvlgamma.html">mvlgamma</a></td><td>special_multigammaln</td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nan_to_num.html">nan_to_num</a></td><td></td><td>✅</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nanmean.html">nanmean</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nanmedian.html">nanmedian</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nanquantile.html">nanquantile</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nansum.html">nansum</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.narrow.html">narrow</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.narrow_copy.html">narrow_copy</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>native_batch_norm</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>native_channel_shuffle</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>native_multi_head_self_attention</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>native_norm</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>neq</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>nested_to_padded_tensor</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.Tensor.new_empty.html">new_empty</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>new_empty_strided</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.Tensor.new_full.html">new_full</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.Tensor.new_ones.html">new_ones</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.Tensor.new_zeros.html">new_zeros</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nextafter.html">nextafter</a></td><td></td><td>✅</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.nll_loss.html">nll_loss</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td>nll_loss2d</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>nll_loss_forward</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td>nll_loss_nd</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>node</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td>nonzero_numpy</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>nonzero_static</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.norm.html">norm</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>norm_except_dim</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.normal.html">normal</a></td><td></td><td>✅</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>normal_functional</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>nuclear_norm</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.numel.html">numel</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td>numpy_T</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>oct</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.one_hot.html">one_hot</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.ones.html">ones</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.ones_like.html">ones_like</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>op</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>op_name</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>ord</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.ormqr.html">ormqr</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.outer.html">outer</a></td><td>ger</td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>output_nr</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>owner</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>owner_name</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.pad.html">pad</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>pad_sequence</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.pairwise_distance.html">pairwise_distance</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>partition</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.pdist.html">pdist</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>percentFormat</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>permute_copy</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.Tensor.pin_memory.html">pin_memory</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.linalg.pinv.html">pinv</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.pinverse.html">pinverse</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.pixel_shuffle.html">pixel_shuffle</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.pixel_unshuffle.html">pixel_unshuffle</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>pointwise_placeholder</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.poisson.html">poisson</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.poisson_nll_loss.html">poisson_nll_loss</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.polar.html">polar</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.polygamma.html">polygamma</a></td><td>special_polygamma</td><td>✅</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td>pop</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>popitem</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.positive.html">positive</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.prelu.html">prelu</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.promote_types.html">promote_types</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>put</td><td></td><td>✅</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.Tensor.q_per_channel_axis.html">q_per_channel_axis</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.Tensor.q_per_channel_scales.html">q_per_channel_scales</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.Tensor.q_per_channel_zero_points.html">q_per_channel_zero_points</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.Tensor.q_scale.html">q_scale</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.Tensor.q_zero_point.html">q_zero_point</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.qr.html">qr</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.Tensor.qscheme.html">qscheme</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.quantile.html">quantile</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>quantize</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.quantize_per_channel.html">quantize_per_channel</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.quantize_per_tensor.html">quantize_per_tensor</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>quantize_per_tensor_dynamic</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.quantized_batch_norm.html">quantized_batch_norm</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>quantized_gru</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>quantized_lstm</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.quantized_max_pool1d.html">quantized_max_pool1d</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.quantized_max_pool2d.html">quantized_max_pool2d</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>quantized_max_pool3d</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.rad2deg.html">rad2deg</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>radians</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.rand_like.html">rand_like</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.randint.html">randint</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.randint_like.html">randint_like</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.randn_like.html">randn_like</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>random</td><td></td><td>✅</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.range.html">range</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.ravel.html">ravel</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.real.html">real</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.Tensor.record_stream.html">record_stream</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>reduce_scatter_tensor</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>refine_names</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.relu6.html">relu6</a></td><td></td><td>✅</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>remove</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>rename</td><td></td><td>✅</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.renorm.html">renorm</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.repeat_interleave.html">repeat_interleave</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>replace</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td>replication_pad1d</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.Tensor.requires_grad_.html">requires_grad_</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.reshape.html">reshape</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.Tensor.reshape_as.html">reshape_as</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>resize</td><td></td><td>✅</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.Tensor.resize_as_.html">resize_as_</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>resize_as_sparse</td><td></td><td>✅</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.resolve_conj.html">resolve_conj</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.resolve_neg.html">resolve_neg</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.result_type.html">result_type</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.Tensor.retain_grad.html">retain_grad</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.Tensor.retains_grad.html">retains_grad</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>reverse</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>rfind</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>rindex</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>rjust</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td>rnn_relu</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>rnn_relu_cell</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td>rnn_tanh</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>rnn_tanh_cell</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.roll.html">roll</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.rot90.html">rot90</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.Tensor.row_indices.html">row_indices</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>row_indices_copy</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>rowwise_prune</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>rpartition</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.rrelu.html">rrelu</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>rrelu_with_noise</td><td></td><td>✅</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>rrelu_with_noise_functional</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>rsplit</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>rstrip</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td>rsub</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.save.html">save</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.scaled_dot_product_attention.html">scaled_dot_product_attention</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.searchsorted.html">searchsorted</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.seed.html">seed</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.segment_reduce.html">segment_reduce</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>select_copy</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.selu.html">selu</a></td><td></td><td>✅</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>set</td><td></td><td>✅</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>set_data</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>set_grad_enabled</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>set_source_Tensor_storage_offset</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>setdefault</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.sgn.html">sgn</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.signbit.html">signbit</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.silu.html">silu</a></td><td></td><td>✅</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.sinc.html">sinc</a></td><td>special_sinc</td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.Tensor.size.html">size</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>slice_copy</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>slice_inverse</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>slow_conv3d</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>slow_conv3d_forward</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>slow_conv_dilated2d</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>slow_conv_dilated3d</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>slow_conv_transpose2d</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>slow_conv_transpose3d</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.smm.html">smm</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.smooth_l1_loss.html">smooth_l1_loss</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.soft_margin_loss.html">soft_margin_loss</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.softmax.html">softmax</a></td><td>special_softmax</td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.softplus.html">softplus</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.softshrink.html">softshrink</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.linalg.solve.html">solve</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>sorted</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.sparse_compressed_tensor.html">sparse_compressed_tensor</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.sparse_coo_tensor.html">sparse_coo_tensor</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.Tensor.sparse_dim.html">sparse_dim</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.Tensor.sparse_mask.html">sparse_mask</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>sparse_resize</td><td></td><td>✅</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>sparse_resize_and_clear</td><td></td><td>✅</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>sparse_sampled_addmm</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>special_airy_ai</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>special_bessel_j0</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>special_bessel_j1</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>special_bessel_y0</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>special_bessel_y1</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>special_chebyshev_polynomial_t</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>special_chebyshev_polynomial_u</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>special_chebyshev_polynomial_v</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>special_chebyshev_polynomial_w</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>special_entr</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>special_erfcx</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>special_hermite_polynomial_h</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>special_hermite_polynomial_he</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>special_i0e</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>special_i1</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>special_i1e</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>special_laguerre_polynomial_l</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>special_legendre_polynomial_p</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>special_log_ndtr</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>special_modified_bessel_i0</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>special_modified_bessel_i1</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>special_modified_bessel_k0</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>special_modified_bessel_k1</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>special_ndtr</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>special_ndtri</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>special_scaled_modified_bessel_k0</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>special_scaled_modified_bessel_k1</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>special_shifted_chebyshev_polynomial_t</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>special_shifted_chebyshev_polynomial_u</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>special_shifted_chebyshev_polynomial_v</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>special_shifted_chebyshev_polynomial_w</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>special_spherical_bessel_j0</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>special_xlog1py</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>special_zeta</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.split.html">split</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>split_copy</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>splitlines</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.square.html">square</a></td><td></td><td>✅</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.sspaddmm.html">sspaddmm</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.stack.html">stack</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>startswith</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.std.html">std</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.std_mean.html">std_mean</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.stft.html">stft</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.Tensor.storage_offset.html">storage_offset</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>str</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.Tensor.stride.html">stride</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>strip</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>sum_to</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.svd.html">svd</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>swapcase</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>symbolic_b</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>symeig</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.t.html">t</a></td><td></td><td>✅</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.take.html">take</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.take_along_dim.html">take_along_dim</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.tanhshrink.html">tanhshrink</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.tensor.html">tensor</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.tensor_split.html">tensor_split</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.tensordot.html">tensordot</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>test</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>test_symbol</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>test_vartype</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>test_vartype2</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>thnn_conv2d</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.threshold.html">threshold</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.tile.html">tile</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>title</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.Tensor.to.html">to</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.Tensor.to_dense.html">to_dense</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>to_here</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.Tensor.to_mkldnn.html">to_mkldnn</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>to_padded_tensor</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.trace.html">trace</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.transpose.html">transpose</a></td><td>swapaxes, swapdims</td><td>✅</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.trapezoid.html">trapezoid</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.trapz.html">trapz</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.triangular_solve.html">triangular_solve</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.tril.html">tril</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.tril_indices.html">tril_indices</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.triplet_margin_loss.html">triplet_margin_loss</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.triu.html">triu</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.triu_indices.html">triu_indices</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.Tensor.type_as.html">type_as</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.unbind.html">unbind</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>unbind_copy</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.unflatten.html">unflatten</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>unflatten_dense_tensors</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.unfold.html">unfold</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>unfold_copy</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>uniform</td><td></td><td>✅</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.unique_consecutive.html">unique_consecutive</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td>unique_dim</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>unique_dim_consecutive</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>unknown</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td>unsafe_chunk</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td>unsafe_split</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td>unsafe_split_with_sizes</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>update</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>upper</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.upsample.html">upsample</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td>upsample_bicubic2d</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td>upsample_linear1d</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td>upsample_nearest1d</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td>upsample_nearest3d</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td>upsample_trilinear3d</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.Tensor.values.html">values</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>values_copy</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.vander.html">vander</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.var_mean.html">var_mean</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.vdot.html">vdot</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.Tensor.view_as.html">view_as</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.view_as_complex.html">view_as_complex</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>view_as_complex_copy</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.view_as_real.html">view_as_real</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>view_as_real_copy</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>view_copy</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>view_expand_placeholder</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.vsplit.html">vsplit</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.vstack.html">vstack</a></td><td>row_stack</td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>wait</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>wait_tensor</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>warn</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>warns</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>wrapped_linear_prepack</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>wrapped_quantized_linear_prepacked</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.xlogy.html">xlogy</a></td><td>special_xlogy</td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>your_op</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td>zero</td><td></td><td>✅</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.zeros.html">zeros</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.zeros_like.html">zeros_like</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row unsupported"><td>❌</td><td>zfill</td><td></td><td>❌</td><td>-</td></tr>
+    </tbody>
+    </table>
+    </div>
+
 <script>
 (function () {
   function applyFilter(form) {


### PR DESCRIPTION
Follow-up to #101 (now merged).

When generating against a current torch (2.11 etc.), the ONNX section was being dropped entirely because PyTorch retired the TorchScript ONNX exporter in 2.9 and `onnx_torchscript_supported_aten_ops.html` 404s. That makes the page poorer (the t2n / ONNX comparison disappears).

Mirror the core-IR fallback already in place: when the requested torch version's ONNX page is gone, fetch torch 2.8's instead (last release that still ships the listing). The ONNX section header now records which URL actually fed the data and notes the fallback when active.

The page regenerated for torch 2.11 is part of this PR; both the `TractNNEF` and `ONNX` tabs are present.

## Test plan

- [x] `ruff check` + `ruff format` clean.
- [x] Re-run for 2.11 emits both sections; ONNX header carries the fallback note.
- [x] Re-run against 2.8 still uses the native ONNX URL (fallback only triggers on 404).