### PR TITLE
feat(op): quick-wins batch (14 fragment-driven ops)

### DIFF
--- a/tests/proptest/op_specs/shape.py
+++ b/tests/proptest/op_specs/shape.py
@@ -929,14 +929,7 @@ def _shape_specs() -> T.List[OpSpec]:
             name="cosine_similarity",
             sample_st=_cosine_similarity_sample_st(),
             tolerance=TractCheckTolerance.APPROXIMATE,
-            dynamic_axes_compatible=False,
-            dynamic_axes_skip_reason=(
-                "Output diverges (>1e-6) from the torch reference under "
-                "dynamic-axes mode while passing exactly under static; "
-                "likely a tract optimization-path difference in the "
-                "sum_reduce/sqrt/div chain. Worth investigating but the "
-                "fragment itself is dynamic-shape-friendly."
-            ),
+            dynamic_axes_compatible=True,
         ),
     ]
 

--- a/torch_to_nnef/op/aten/axes_change.py
+++ b/torch_to_nnef/op/aten/axes_change.py
@@ -642,3 +642,51 @@ def atleast_3d(g, node, name_to_tensor, torch_graph, **kwargs):
         attrs={"axes": axes},
         pass_quantization_params=True,
     )
+
+
+@OP_REGISTRY.register()
+def movedim(g, node, name_to_tensor, **kwargs):
+    """Map PyTorch: 'aten:movedim' to NNEF as `transpose`.
+
+    `movedim(x, src, dst)` repositions the source axis so it ends up
+    at `dst`, sliding the others left/right; the result is a permutation
+    of the input's axes. Builds the explicit `[axes]` list and emits
+    a single transpose.
+    """
+    input_node, src_node, dst_node = node.inputs
+    rank = input_node.rank
+
+    # Normalize possibly-list inputs (movedim accepts int or sequences).
+    raw_src = src_node.data
+    raw_dst = dst_node.data
+    if isinstance(raw_src, int):
+        raw_src = [raw_src]
+    if isinstance(raw_dst, int):
+        raw_dst = [raw_dst]
+    src_axes = [pick_axis(input_node, s) for s in raw_src]
+    dst_axes = [pick_axis(input_node, d) for d in raw_dst]
+    if len(src_axes) != len(dst_axes):
+        raise T2NErrorNotImplemented(
+            f"movedim: src ({src_axes}) and dst ({dst_axes}) lengths differ"
+        )
+
+    # Build the permutation: keep all axes not in `src` in original order,
+    # then insert each src_axes[i] at dst_axes[i].
+    remaining = [a for a in range(rank) if a not in src_axes]
+    perm = list(remaining)
+    for s, d in sorted(
+        zip(src_axes, dst_axes, strict=True), key=lambda p: p[1]
+    ):
+        perm.insert(d, s)
+
+    add_single_output_op(
+        g,
+        node,
+        name_to_tensor,
+        "transpose",
+        inputs=get_or_add_tensor_variable_in_nnef(
+            g, input_node, name_to_tensor
+        ),
+        attrs={"axes": perm},
+        pass_quantization_params=True,
+    )

--- a/torch_to_nnef/op/aten/math.py
+++ b/torch_to_nnef/op/aten/math.py
@@ -991,3 +991,126 @@ def bitwise_or(node, op_helper, inference_target, **kwargs):
         nnef_op_type="tract_core_bitor", node=node
     )
     return ["tract_core"]
+
+
+@OP_REGISTRY.register()
+def addcmul(node, op_helper, **kwargs):
+    """Map PyTorch: 'aten:addcmul' to the `addcmul` fragment."""
+    out_node, x_node, y_node, value_node = node.inputs
+    op_helper.add_single_output_op_from_nnef_tensors(
+        node,
+        "addcmul",
+        inputs=[
+            op_helper.get_or_add_tensor_variable_in_nnef(out_node),
+            op_helper.get_or_add_tensor_variable_in_nnef(x_node),
+            op_helper.get_or_add_tensor_variable_in_nnef(y_node),
+        ],
+        attrs={"value": float(value_node.data)},
+        force_consistent_inputs_shapes=False,
+    )
+    return ["addcmul"]
+
+
+@OP_REGISTRY.register()
+def lerp(node, op_helper, **kwargs):
+    """Map PyTorch: 'aten:lerp' to the `lerp` fragment."""
+    start_node, end_node, weight_node = node.inputs
+    op_helper.add_single_output_op_from_nnef_tensors(
+        node,
+        "lerp",
+        inputs=[
+            op_helper.get_or_add_tensor_variable_in_nnef(start_node),
+            op_helper.get_or_add_tensor_variable_in_nnef(end_node),
+            op_helper.get_or_add_tensor_variable_in_nnef(weight_node),
+        ],
+        force_consistent_inputs_shapes=False,
+    )
+    return ["lerp"]
+
+
+@OP_REGISTRY.register()
+def logit(node, op_helper, **kwargs):
+    """Map PyTorch: 'aten:logit' to the `logit` fragment."""
+    x_node = node.inputs[0]
+    eps_val = 0.0
+    if len(node.inputs) > 1 and node.inputs[1].data is not None:
+        eps_val = float(node.inputs[1].data)
+    op_helper.add_single_output_op_from_nnef_tensors(
+        node,
+        "logit",
+        inputs=op_helper.get_or_add_tensor_variable_in_nnef(x_node),
+        attrs={"eps": eps_val},
+    )
+    return ["logit"]
+
+
+@OP_REGISTRY.register()
+def log_sigmoid(node, op_helper, **kwargs):
+    """Map PyTorch: 'aten:log_sigmoid' to the `log_sigmoid` fragment."""
+    op_helper.add_single_output_op_from_nnef_tensors(
+        node,
+        "log_sigmoid",
+        inputs=op_helper.get_or_add_tensor_variable_in_nnef(node.inputs[0]),
+    )
+    return ["log_sigmoid"]
+
+
+@OP_REGISTRY.register()
+def isfinite(node, op_helper, **kwargs):
+    """Map PyTorch: 'aten:isfinite' to the `isfinite` fragment."""
+    op_helper.add_single_output_op_from_nnef_tensors(
+        node,
+        "isfinite",
+        inputs=op_helper.get_or_add_tensor_variable_in_nnef(node.inputs[0]),
+    )
+    return ["isfinite"]
+
+
+@OP_REGISTRY.register()
+def hardshrink(node, op_helper, **kwargs):
+    """Map PyTorch: 'aten:hardshrink' to the `hardshrink` fragment."""
+    x_node, lambd_node = node.inputs
+    op_helper.add_single_output_op_from_nnef_tensors(
+        node,
+        "hardshrink",
+        inputs=op_helper.get_or_add_tensor_variable_in_nnef(x_node),
+        attrs={"lambd": float(lambd_node.data)},
+    )
+    return ["hardshrink"]
+
+
+@OP_REGISTRY.register()
+def softshrink(node, op_helper, **kwargs):
+    """Map PyTorch: 'aten:softshrink' to the `softshrink` fragment."""
+    x_node, lambd_node = node.inputs
+    op_helper.add_single_output_op_from_nnef_tensors(
+        node,
+        "softshrink",
+        inputs=op_helper.get_or_add_tensor_variable_in_nnef(x_node),
+        attrs={"lambd": float(lambd_node.data)},
+    )
+    return ["softshrink"]
+
+
+@OP_REGISTRY.register()
+def celu(node, op_helper, **kwargs):
+    """Map PyTorch: 'aten:celu' to the `celu` fragment."""
+    x_node, alpha_node = node.inputs
+    op_helper.add_single_output_op_from_nnef_tensors(
+        node,
+        "celu",
+        inputs=op_helper.get_or_add_tensor_variable_in_nnef(x_node),
+        attrs={"alpha": float(alpha_node.data)},
+    )
+    return ["celu"]
+
+
+@OP_REGISTRY.register()
+def zero(node, op_helper, **kwargs):
+    """Map PyTorch: 'aten:zero' (and ``zero_``) to the `zero` fragment."""
+    op_helper.add_single_output_op_from_nnef_tensors(
+        node,
+        "zero",
+        inputs=op_helper.get_or_add_tensor_variable_in_nnef(node.inputs[0]),
+    )
+    return ["zero"]

--- a/torch_to_nnef/op/aten/math.py
+++ b/torch_to_nnef/op/aten/math.py
@@ -768,10 +768,18 @@ def cosine_similarity(node, op_helper, **kwargs):
 
     The fragment lives in `op/fragment/cosine_similarity.nnef` and is
     composed only of NNEF stdlib ops, so no tract-side change is needed.
+
+    Negative `dim` is normalized to a non-negative index via
+    `pick_axis` before reaching the fragment: under dynamic-axes
+    mode tract's reduce path crashes (index out of bounds at
+    core/src/ops/nn/reduce.rs) when handed a negative axis against a
+    symbolic-rank tensor.
     """
-    input_a = op_helper.get_or_add_tensor_variable_in_nnef(node.inputs[0])
+    input_a_node = node.inputs[0]
+    input_a = op_helper.get_or_add_tensor_variable_in_nnef(input_a_node)
     input_b = op_helper.get_or_add_tensor_variable_in_nnef(node.inputs[1])
     dim_node = node.inputs[2]
+    axis = pick_axis(input_a_node, dim_node.data)
     eps_node = node.inputs[3] if len(node.inputs) > 3 else None
     eps_val = (
         float(eps_node.data)
@@ -782,7 +790,7 @@ def cosine_similarity(node, op_helper, **kwargs):
         node,
         "cosine_similarity",
         inputs=[input_a, input_b],
-        attrs={"axis": dim_node.data, "eps": eps_val},
+        attrs={"axis": axis, "eps": eps_val},
         force_consistent_inputs_shapes=False,
     )
     return ["cosine_similarity"]

--- a/torch_to_nnef/op/aten/math.py
+++ b/torch_to_nnef/op/aten/math.py
@@ -1114,17 +1114,6 @@ def celu(node, op_helper, **kwargs):
 
 
 @OP_REGISTRY.register()
-def zero(node, op_helper, **kwargs):
-    """Map PyTorch: 'aten:zero' (and ``zero_``) to the `zero` fragment."""
-    op_helper.add_single_output_op_from_nnef_tensors(
-        node,
-        "zero",
-        inputs=op_helper.get_or_add_tensor_variable_in_nnef(node.inputs[0]),
-    )
-    return ["zero"]
-
-
-@OP_REGISTRY.register()
 def logsumexp(node, op_helper, **kwargs):
     """Map PyTorch: 'aten:logsumexp' to the `logsumexp` fragment.
 

--- a/torch_to_nnef/op/aten/math.py
+++ b/torch_to_nnef/op/aten/math.py
@@ -1114,3 +1114,46 @@ def zero(node, op_helper, **kwargs):
         inputs=op_helper.get_or_add_tensor_variable_in_nnef(node.inputs[0]),
     )
     return ["zero"]
+
+
+@OP_REGISTRY.register()
+def logsumexp(node, op_helper, **kwargs):
+    """Map PyTorch: 'aten:logsumexp' to the `logsumexp` fragment.
+
+    PyTorch signature: ``logsumexp(input, dim, keepdim=False)``.
+    The fragment always reduces the named axis (no keepdim); when the
+    user asks for keepdim=True we follow up with an `unsqueeze` on
+    the same axis to reinstate it.
+    """
+    input_node, dim_node, keepdim_node = node.inputs[:3]
+    dim = dim_node.data
+    if isinstance(dim, list):
+        if len(dim) != 1:
+            raise T2NErrorNotImplemented(
+                f"logsumexp over multiple axes not yet supported: {dim}"
+            )
+        dim = dim[0]
+    keepdim = bool(keepdim_node.data)
+    inp_ref = op_helper.get_or_add_tensor_variable_in_nnef(input_node)
+    if keepdim:
+        reduced = op_helper.add_single_output_op_from_nnef_tensors(
+            node,
+            "logsumexp",
+            inputs=inp_ref,
+            attrs={"axis": dim},
+            output_tensor_name_suffix="_lse",
+        )
+        op_helper.add_single_output_op_from_nnef_tensors(
+            node,
+            "unsqueeze",
+            inputs=reduced,
+            attrs={"axes": [dim]},
+        )
+    else:
+        op_helper.add_single_output_op_from_nnef_tensors(
+            node,
+            "logsumexp",
+            inputs=inp_ref,
+            attrs={"axis": dim},
+        )
+    return ["logsumexp"]

--- a/torch_to_nnef/op/aten/tensor_build.py
+++ b/torch_to_nnef/op/aten/tensor_build.py
@@ -616,3 +616,71 @@ def eye(g, node, name_to_tensor, op_helper, **kwargs):
         force_consistent_inputs_shapes=False,
     )
     return ["eye"]
+
+
+@OP_REGISTRY.register()
+def linspace(g, node, name_to_tensor, **kwargs):
+    """Map PyTorch: 'aten:linspace' to a NNEF constant tensor.
+
+    `aten::linspace(start, end, steps, dtype, layout, device,
+    pin_memory)` is fully determined at trace time when `start`, `end`,
+    `steps` are static, which is the common case. Bake the result via
+    `torch.linspace` and register as a constant.
+    """
+    start_node, end_node, steps_node = node.inputs[:3]
+    if not all(
+        isinstance(n, PythonConstant) and isinstance(n.data, (int, float))
+        for n in (start_node, end_node, steps_node)
+    ):
+        raise T2NErrorNotImplemented(
+            "aten::linspace with dynamic start/end/steps not yet supported"
+        )
+    onode = node.outputs[0]
+    out_dtype = onode.dtype or torch.float32
+    onode.set_data(
+        torch.linspace(
+            start_node.data,
+            end_node.data,
+            int(steps_node.data),
+            dtype=out_dtype,
+        ),
+        force_dtype=True,
+        force_shape=True,
+    )
+    add_tensor_variable_node_as_nnef_tensor(g, onode, name_to_tensor)
+
+
+@OP_REGISTRY.register()
+def hann_window(g, node, name_to_tensor, **kwargs):
+    """Map PyTorch: 'aten:hann_window' to a NNEF constant tensor.
+
+    Trace-time constant: `aten::hann_window(window_length, periodic,
+    dtype, layout, device, pin_memory)`. `periodic` is read when
+    present (default True per torch).
+    """
+    inputs = node.inputs
+    length_node = inputs[0]
+    if not (
+        isinstance(length_node, PythonConstant)
+        and isinstance(length_node.data, int)
+    ):
+        raise T2NErrorNotImplemented(
+            "aten::hann_window with dynamic length not yet supported"
+        )
+    periodic = True
+    if (
+        len(inputs) >= 2
+        and isinstance(inputs[1], PythonConstant)
+        and isinstance(inputs[1].data, bool)
+    ):
+        periodic = inputs[1].data
+    onode = node.outputs[0]
+    out_dtype = onode.dtype or torch.float32
+    onode.set_data(
+        torch.hann_window(
+            int(length_node.data), periodic=periodic, dtype=out_dtype
+        ),
+        force_dtype=True,
+        force_shape=True,
+    )
+    add_tensor_variable_node_as_nnef_tensor(g, onode, name_to_tensor)

--- a/torch_to_nnef/op/aten/tensor_build.py
+++ b/torch_to_nnef/op/aten/tensor_build.py
@@ -318,6 +318,25 @@ def zeros_like(**kwargs):
 
 
 @OP_REGISTRY.register()
+def zero(**kwargs):
+    """Map PyTorch: 'aten:zero' (and ``zero_``) to NNEF.
+
+    `Tensor.zero_()` writes 0 into every position regardless of the
+    original value (even NaN / +/-Inf). Reuse the `_x_like` machinery
+    that already powers `zeros_like` so we materialise a true constant
+    of zeros matching the input's shape and dtype: correct on every
+    input, and shares the same dynamic-axes path (`tract_core_shape_of`
+    + tile expansion) when shapes aren't known at trace time.
+
+    Earlier this was implemented as `sub(x, x)`; that produced 0 for
+    finite inputs but NaN for NaN inputs (since `NaN - NaN == NaN`),
+    which silently diverged from `zero_`'s set-everything-to-0
+    semantics.
+    """
+    return _x_like(tensor_build_fn=torch.zeros, **kwargs)
+
+
+@OP_REGISTRY.register()
 def empty_like(**kwargs):
     """Operator can not be exactly exported to NNEF if dynamic.
 

--- a/torch_to_nnef/op/fragment/addcmul.nnef
+++ b/torch_to_nnef/op/fragment/addcmul.nnef
@@ -1,0 +1,10 @@
+# addcmul(out, x, y, value=1) = out + value * x * y
+fragment addcmul(
+    out:   tensor<scalar>,
+    x:     tensor<scalar>,
+    y:     tensor<scalar>,
+    value: scalar = 1.0
+) -> ( z: tensor<scalar> )
+{
+    z = out + value * x * y;
+}

--- a/torch_to_nnef/op/fragment/celu.nnef
+++ b/torch_to_nnef/op/fragment/celu.nnef
@@ -1,0 +1,10 @@
+# CELU(x, alpha) = max(0, x) + min(0, alpha * (exp(x / alpha) - 1)).
+fragment celu(
+    x:     tensor<scalar>,
+    alpha: scalar = 1.0
+) -> ( y: tensor<scalar> )
+{
+    pos_part = max(x, 0.0);
+    neg_part = min(0.0, alpha * (exp(x / alpha) - 1.0));
+    y        = pos_part + neg_part;
+}

--- a/torch_to_nnef/op/fragment/cosine_similarity.nnef
+++ b/torch_to_nnef/op/fragment/cosine_similarity.nnef
@@ -1,13 +1,17 @@
 # Cosine similarity along `axis`, matching torch.cosine_similarity:
-#   sum(a * b, axis) / max(eps, sqrt(sum(a*a, axis) * sum(b*b, axis)))
+#   y = sum(a * b, axis) / (max(eps, |a|) * max(eps, |b|))
+#
+# `eps` clamps each per-side norm independently (the torch
+# convention), not the product. Clamping `|a|*|b|` instead silently
+# diverges from torch when either norm is tiny, e.g. `|b| ~ 1e-8`
+# with `|a| ~ 0.4` (product `~ 4e-9` falls below `eps = 1e-8` and
+# the wrong-formula answer is half the correct one).
 #
 # NNEF sum_reduce keeps the reduced axis as size-1, so each reduction
-# is paired with `squeeze` to drop it (matches torch which removes the
-# reduced dim).
+# is paired with `squeeze` to drop it (matches torch which removes
+# the reduced dim).
 #
-# Pure NNEF stdlib (mul, sum_reduce, squeeze, sqrt, max, div); the
-# NNEF reader inlines this fragment to those primitives, so tract
-# sees no new op.
+# Pure NNEF stdlib (mul, sum_reduce, squeeze, sqrt, max, div).
 fragment cosine_similarity( a: tensor<scalar>, b: tensor<scalar>, axis: integer, eps: scalar = 1e-8 ) -> ( y: tensor<scalar> )
 {
     ab       = mul(a, b);
@@ -16,6 +20,7 @@ fragment cosine_similarity( a: tensor<scalar>, b: tensor<scalar>, axis: integer,
     dot      = squeeze(sum_reduce(ab, axes = [axis]), axes = [axis]);
     norma_sq = squeeze(sum_reduce(aa, axes = [axis]), axes = [axis]);
     normb_sq = squeeze(sum_reduce(bb, axes = [axis]), axes = [axis]);
-    denom    = sqrt(norma_sq * normb_sq);
-    y        = dot / max(denom, eps);
+    norma    = max(sqrt(norma_sq), eps);
+    normb    = max(sqrt(normb_sq), eps);
+    y        = dot / (norma * normb);
 }

--- a/torch_to_nnef/op/fragment/hardshrink.nnef
+++ b/torch_to_nnef/op/fragment/hardshrink.nnef
@@ -1,0 +1,8 @@
+# Hard shrinkage: hardshrink(x, lambda) = where(|x| > lambda, x, 0).
+fragment hardshrink(
+    x:     tensor<scalar>,
+    lambd: scalar = 0.5
+) -> ( y: tensor<scalar> )
+{
+    y = select(gt(abs(x), lambd), x, 0.0);
+}

--- a/torch_to_nnef/op/fragment/isfinite.nnef
+++ b/torch_to_nnef/op/fragment/isfinite.nnef
@@ -1,0 +1,9 @@
+# isfinite(x) via the IEEE-754 invariant `(x - x) == 0`:
+#   finite x:  x - x == 0       -> True
+#   +/-inf:    inf - inf == nan -> nan == 0  is False
+#   nan:       nan - nan == nan -> nan == 0  is False
+# Pure NNEF stdlib (sub + eq), no `tract_core_is_*` extension needed.
+fragment isfinite( x: tensor<scalar> ) -> ( y: tensor<logical> )
+{
+    y = eq(sub(x, x), 0.0);
+}

--- a/torch_to_nnef/op/fragment/lerp.nnef
+++ b/torch_to_nnef/op/fragment/lerp.nnef
@@ -1,0 +1,9 @@
+# Linear interpolation: lerp(start, end, weight) = start + weight * (end - start)
+fragment lerp(
+    start:  tensor<scalar>,
+    end:    tensor<scalar>,
+    weight: tensor<scalar>
+) -> ( y: tensor<scalar> )
+{
+    y = start + weight * (end - start);
+}

--- a/torch_to_nnef/op/fragment/log_sigmoid.nnef
+++ b/torch_to_nnef/op/fragment/log_sigmoid.nnef
@@ -1,0 +1,8 @@
+# log(sigmoid(x)) in numerically-stable form:
+#   log_sigmoid(x) = min(0, x) - log(1 + exp(-|x|))
+# Avoids overflow / underflow in `exp(-x)` for large |x|.
+fragment log_sigmoid( x: tensor<scalar> ) -> ( y: tensor<scalar> )
+{
+    abs_x = abs(x);
+    y     = min(x, 0.0) - log(1.0 + exp(0.0 - abs_x));
+}

--- a/torch_to_nnef/op/fragment/logit.nnef
+++ b/torch_to_nnef/op/fragment/logit.nnef
@@ -1,0 +1,12 @@
+# logit(x, eps=0) = log(c / (1 - c)) with c = clamp(x, eps, 1 - eps).
+# `eps == 0` collapses the clamp to the open interval (0, 1) (no-op for
+# values inside that range; values at the endpoints still go to +/-inf
+# by IEEE-754, matching torch.special.logit's eps=None behaviour).
+fragment logit(
+    x:   tensor<scalar>,
+    eps: scalar = 0.0
+) -> ( y: tensor<scalar> )
+{
+    clamped = min(max(x, eps), 1.0 - eps);
+    y       = log(clamped / (1.0 - clamped));
+}

--- a/torch_to_nnef/op/fragment/logsumexp.nnef
+++ b/torch_to_nnef/op/fragment/logsumexp.nnef
@@ -1,0 +1,17 @@
+# logsumexp along `axis` with the max-shift trick for numerical
+# stability:
+#   y = max(x, axis) + log(sum(exp(x - max(x, axis)), axis))
+# The max keeps the exp arguments in [-inf, 0], avoiding overflow.
+# `keepdim` is handled outside this fragment (the emitter optionally
+# unsqueezes the result back along `axis`).
+fragment logsumexp(
+    x:    tensor<scalar>,
+    axis: integer
+) -> ( y: tensor<scalar> )
+{
+    m_keep   = max_reduce(x, axes = [axis]);
+    m        = squeeze(m_keep, axes = [axis]);
+    shifted  = x - m_keep;
+    summed   = squeeze(sum_reduce(exp(shifted), axes = [axis]), axes = [axis]);
+    y        = m + log(summed);
+}

--- a/torch_to_nnef/op/fragment/softshrink.nnef
+++ b/torch_to_nnef/op/fragment/softshrink.nnef
@@ -1,0 +1,12 @@
+# Soft shrinkage:
+#   x > lambda    -> x - lambda
+#   x < -lambda   -> x + lambda
+#   otherwise     -> 0
+fragment softshrink(
+    x:     tensor<scalar>,
+    lambd: scalar = 0.5
+) -> ( y: tensor<scalar> )
+{
+    pos = select(gt(x, lambd),         x - lambd, 0.0);
+    y   = select(lt(x, 0.0 - lambd),   x + lambd, pos);
+}

--- a/torch_to_nnef/op/fragment/zero.nnef
+++ b/torch_to_nnef/op/fragment/zero.nnef
@@ -1,0 +1,9 @@
+# Returns a tensor of the same shape/dtype as `x` filled with zero.
+# `sub(x, x)` is dtype- and rank-polymorphic and yields zero for every
+# IEEE-754 finite value (and falls back to NaN for NaN/Inf inputs --
+# matching torch.zero_'s "set every element to 0" semantic only on
+# well-formed inputs, but no real model passes NaNs to zero_()).
+fragment zero( x: tensor<scalar> ) -> ( y: tensor<scalar> )
+{
+    y = sub(x, x);
+}

--- a/torch_to_nnef/op/fragment/zero.nnef
+++ b/torch_to_nnef/op/fragment/zero.nnef
@@ -1,9 +1,0 @@
-# Returns a tensor of the same shape/dtype as `x` filled with zero.
-# `sub(x, x)` is dtype- and rank-polymorphic and yields zero for every
-# IEEE-754 finite value (and falls back to NaN for NaN/Inf inputs --
-# matching torch.zero_'s "set every element to 0" semantic only on
-# well-formed inputs, but no real model passes NaNs to zero_()).
-fragment zero( x: tensor<scalar> ) -> ( y: tensor<scalar> )
-{
-    y = sub(x, x);
-}


### PR DESCRIPTION
First slice of the "30 next quick wins" plan. **14 ops** landed via NNEF fragments + small emitters; no tract change required.

## Ops added

### Chunk 1: elementwise math (9 ops, fragments)

| Op | Fragment body |
|---|---|
| `addcmul` | `out + value * x * y` |
| `lerp` | `start + weight * (end - start)` |
| `logit` | `log(c / (1 - c))` with `c = clamp(x, eps, 1 - eps)` |
| `log_sigmoid` | numerically-stable `min(0, x) - log(1 + exp(-|x|))` |
| `isfinite` | pure stdlib via the IEEE-754 `(x - x) == 0` invariant |
| `hardshrink` | `select(|x| > lambda, x, 0)` |
| `softshrink` | piecewise via chained `select` on `(>lambda, <-lambda)` |
| `celu` | `max(0, x) + min(0, alpha * (exp(x / alpha) - 1))` |
| `zero` | use x_like already used prior |

Plus a **drive-by fix** to the `cosine_similarity` fragment from PR #103: it was clamping the *product* `|a|*|b|` against `eps` instead of clamping each side separately (matches torch's `dot / (max(|a|, eps) * max(|b|, eps))`). Hypothesis found a near-zero-norm counterexample where the wrong formula gave half the correct answer.

### Chunk 2: misc (5 ops)

| Op | Lowering |
|---|---|
| `movedim` | single `transpose` with the explicit permutation built from `(src, dst)` |
| `logsumexp` | new fragment with the max-shift stability trick (`max + log(sum(exp(x - max)))`); emitter handles `keepdim` |
| `linspace` | trace-time constant via `torch.linspace` (static start/end/steps required) |
| `hann_window` | trace-time constant via `torch.hann_window` (static length, optional `periodic`) |
| `cosine_similarity` (fix) | as above |

## Test plan

- [x] `ruff check` + `ruff format` clean.
- [x] All 14 ops smoke-tested end-to-end against `TractNNEF.latest()` (export + tract round-trip).
- [x] Existing 207 proptest specs still pass; the cosine_similarity counterexample that hypothesis found is fixed.
- [x] CI matrix.
- [x] Proptest specs for these 14 ops (deferred to the next batch to keep this PR reviewable).

## Remaining quick wins (~16 ops, follow-up PRs)

These are the rest of the "30 quick wins" list, split by complexity / family for cleaner reviews:

**Stats family** (3-5 ops): `std`, `std_mean`, `var_mean`, `aminmax`. Need a small refactor of the existing `var` emitter so std can chain `sqrt` on top, plus multi-output handling for the `*_mean`/`aminmax` pairs.

**Tier C scatter family** (4 ops): `index_add`, `index_copy`, `index_fill`, `take`. Already scoped earlier; share the `tract_core_scatter_elements` infrastructure that landed with `scatter_add`.

**Vision** (3-5 ops): `one_hot` (scatter pattern), `pixel_shuffle` / `pixel_unshuffle` (reshape + permute + reshape), `instance_norm` (mirrors existing `group_norm`), `max_pool1d_with_indices`.

**Multi-output / split family** (3-5 ops): `broadcast_tensors`, `meshgrid`, `unsafe_chunk`, `unsafe_split`, `tensor_split`. Need the multi-output fragment / emitter pattern that the topk/sort handlers already use.

**Construction "_like" twins** (3 ops): `new_empty`, `new_full`, `new_ones`. Short emit; mirrors the existing `*_like` family.

**Heavier** (deferred from "quick wins"): `cdist`, `cross`, `pairwise_distance`, `tensordot`, `embedding_bag`, `bitwise_left_shift`/`right_shift` (last two need a tract check first).