### PR TITLE
feat(op): quick-wins batch 2 (5 ops + 2 alias)

### DIFF
--- a/torch_to_nnef/op/aten/split.py
+++ b/torch_to_nnef/op/aten/split.py
@@ -12,7 +12,9 @@ from torch_to_nnef.torch_graph import PythonConstant
 OP_REGISTRY = AtenOpRegistry()
 
 
-@OP_REGISTRY.register()
+@OP_REGISTRY.register(
+    torch_op_ids=["split_with_sizes", "unsafe_split_with_sizes"]
+)
 def split_with_sizes(g, node, name_to_tensor, **kwargs):
     """Translate `aten::split_with_sizes` to NNEF.
 
@@ -89,9 +91,14 @@ def unbind(g, node, name_to_tensor, **kwargs):
     )
 
 
-@OP_REGISTRY.register()
+@OP_REGISTRY.register(torch_op_ids=["chunk", "unsafe_chunk"])
 def chunk(g, node, name_to_tensor, **kwargs):
-    """Map PyTorch: 'aten:chunk' to NNEF."""
+    """Map PyTorch: 'aten:chunk' (and `unsafe_chunk`) to NNEF.
+
+    `unsafe_chunk` has identical inference-time semantics to `chunk`;
+    the only difference is the autograd-graph promise around in-place
+    writes, which doesn't apply on the export path.
+    """
     (input_node, n_chunk_node, axis_node) = node.inputs
     assert n_chunk_node.data == len(node.outputs)
     assert len({tuple(o.shape) for o in node.outputs}) == 1, (

--- a/torch_to_nnef/op/aten/tensor_build.py
+++ b/torch_to_nnef/op/aten/tensor_build.py
@@ -317,6 +317,159 @@ def zeros_like(**kwargs):
     return _x_like(tensor_build_fn=torch.zeros, **kwargs)
 
 
+def _new_x(
+    node,
+    g,
+    torch_graph,
+    name_to_tensor,
+    inference_target,
+    tensor_build_fn,
+    dtype_idx=2,
+):
+    """Shared body for ``aten::new_{empty,full,ones}``.
+
+    All share the layout
+    ``(input, size, [value,] dtype, layout, device, pin_memory)``;
+    only `tensor_build_fn` (and the dtype slot for ``new_full``)
+    differs. Re-uses `_generic_auto_tensor_expansion` so dynamic-axes
+    sizes flow through the same `tract_core_shape_of` + tile path
+    as `ones`/`zeros`.
+    """
+    inputs = node.inputs
+    input_node = inputs[0]
+    shape_node = inputs[1]
+    dtype_node = inputs[dtype_idx]
+    if dtype_node.data is not None:
+        dtype = SCALAR_TYPE_TO_PYTORCH_TYPE[dtype_node.data]
+    else:
+        dtype = input_node.dtype
+    return _generic_auto_tensor_expansion(
+        shape_node,
+        node,
+        g,
+        torch_graph,
+        name_to_tensor,
+        has_dynamic_axes=inference_target.has_dynamic_axes,
+        dtype=dtype,
+        tensor_build_fn=tensor_build_fn,
+    )
+
+
+@OP_REGISTRY.register()
+def new_empty(g, node, name_to_tensor, torch_graph, inference_target, **kwargs):
+    """Map PyTorch: 'aten:new_empty' to NNEF.
+
+    Materialises as zeros (NNEF has no "uninitialized" tensor and
+    real callers immediately fill the buffer); shape comes from
+    `size`, dtype defaults to the source tensor's dtype.
+    """
+    return _new_x(
+        node,
+        g,
+        torch_graph,
+        name_to_tensor,
+        inference_target,
+        tensor_build_fn=torch.zeros,
+    )
+
+
+@OP_REGISTRY.register()
+def new_ones(g, node, name_to_tensor, torch_graph, inference_target, **kwargs):
+    """Map PyTorch: 'aten:new_ones' to NNEF."""
+    return _new_x(
+        node,
+        g,
+        torch_graph,
+        name_to_tensor,
+        inference_target,
+        tensor_build_fn=torch.ones,
+    )
+
+
+@OP_REGISTRY.register()
+def new_full(g, node, name_to_tensor, torch_graph, inference_target, **kwargs):
+    """Map PyTorch: 'aten:new_full' to NNEF.
+
+    Layout: `(input, size, fill_value, dtype, layout, device,
+    pin_memory)`. The fill value is folded at trace time into a
+    custom build fn so the constant materialises with the right
+    value.
+    """
+    fill_value = node.inputs[2].data
+
+    def full_fn(*args, **fn_kwargs):
+        return torch.ones(*args, **fn_kwargs) * fill_value
+
+    return _new_x(
+        node,
+        g,
+        torch_graph,
+        name_to_tensor,
+        inference_target,
+        tensor_build_fn=full_fn,
+        # dtype is at index 3 (one slot later than empty/ones).
+        dtype_idx=3,
+    )
+
+
+@OP_REGISTRY.register()
+def one_hot(g, node, name_to_tensor, op_helper, **kwargs):
+    """Map PyTorch: 'aten:one_hot' to NNEF.
+
+    `one_hot(input: int64, num_classes)` -> int64 tensor of shape
+    `input.shape + (num_classes,)`. Decomposed inline as
+    `eq(unsqueeze(input, last_axis), arange(num_classes))` cast back
+    to int64. Static `num_classes` (compile-time int) is required;
+    runtime-sized one-hot would need `tract_core_range` driven by a
+    runtime tensor (rare in practice).
+    """
+    input_node, num_classes_node = node.inputs
+    if not isinstance(num_classes_node.data, int):
+        raise T2NErrorNotImplemented(
+            "aten::one_hot with dynamic num_classes not yet supported"
+        )
+    num_classes = int(num_classes_node.data)
+    input_rank = input_node.rank
+    inp_ref = get_or_add_tensor_variable_in_nnef(g, input_node, name_to_tensor)
+
+    # Bake [0, ..., num_classes-1] as a constant whose rank already
+    # matches `input.rank + 1` (with size 1 on every axis except the
+    # last) so NNEF `eq`'s exact-rank broadcast rule is satisfied
+    # without an extra unsqueeze chain on the classes side.
+    classes_shape = (1,) * input_rank + (num_classes,)
+    classes_const = PythonConstant(
+        name=f"{node.outputs[0].name}_oh_classes",
+        data=torch.arange(num_classes, dtype=input_node.dtype).reshape(
+            classes_shape
+        ),
+    )
+    classes_ref = get_or_add_tensor_variable_in_nnef(
+        g, classes_const, name_to_tensor
+    )
+
+    unsqueezed = op_helper.add_single_output_op_from_nnef_tensors(
+        node,
+        "unsqueeze",
+        inputs=inp_ref,
+        attrs={"axes": [input_rank]},
+        output_tensor_name_suffix="_oh_unsq",
+    )
+    mask = op_helper.add_single_output_op_from_nnef_tensors(
+        node,
+        "eq",
+        inputs=[unsqueezed, classes_ref],
+        force_consistent_inputs_shapes=False,
+        output_tensor_name_suffix="_oh_mask",
+    )
+    op_helper.add_single_output_op_from_nnef_tensors(
+        node,
+        "tract_core_cast",
+        inputs=mask,
+        attrs={"to": "i64"},
+    )
+    return ["tract_core"]
+
+
 @OP_REGISTRY.register()
 def zero(**kwargs):
     """Map PyTorch: 'aten:zero' (and ``zero_``) to NNEF.

--- a/torch_to_nnef/op/aten/tensor_build.py
+++ b/torch_to_nnef/op/aten/tensor_build.py
@@ -413,42 +413,71 @@ def new_full(g, node, name_to_tensor, torch_graph, inference_target, **kwargs):
 
 
 @OP_REGISTRY.register()
-def one_hot(node, op_helper, **kwargs):
-    """Map PyTorch: 'aten:one_hot' to NNEF via `tract_core_one_hot`.
+def one_hot(g, node, name_to_tensor, op_helper, inference_target, **kwargs):
+    """Map PyTorch: 'aten:one_hot' to NNEF.
 
-    Tract has the op natively (`core/src/ops/array/one_hot.rs`) with
-    NNEF binding `tract_core_one_hot(input, axis, dim, value_off=0,
-    value_on=1)`. Torch's `one_hot(input, num_classes)` appends the
-    one-hot axis as the trailing dim, so `axis = input.rank` (the new
-    last position in the output rank-(R+1) result) and `dim =
-    num_classes`.
+    Two paths:
 
-    Tract's op produces a `scalar` (float) tensor with the on/off
-    values; torch returns int64. Cast on top to match.
+    - **TractNNEF**: emit `tract_core_one_hot(input, axis, dim)` and
+      cast to int64. Tract has the op natively
+      (`core/src/ops/array/one_hot.rs`) so this is the fastest path
+      and produces the smallest graph.
+    - **Pure NNEF**: emit the `one_hot` fragment which decomposes to
+      `eq(unsqueeze(input, axis), classes) -> select` using stdlib
+      ops. The classes constant is baked at trace time, pre-reshaped
+      to `(1,) * input.rank + (num_classes,)` so NNEF `eq`'s
+      exact-rank broadcast rule is satisfied.
+
+    Torch's `one_hot(input, num_classes)` appends the one-hot dim as
+    the trailing axis, so `axis = input.rank` (the new last position
+    in the rank-(R+1) output) regardless of which path we take.
     """
     input_node, num_classes_node = node.inputs
     if not isinstance(num_classes_node.data, int):
         raise T2NErrorNotImplemented(
             "aten::one_hot with dynamic num_classes not yet supported"
         )
+    num_classes = int(num_classes_node.data)
+    axis = input_node.rank
     inp_ref = op_helper.get_or_add_tensor_variable_in_nnef(input_node)
-    onehot_out = op_helper.add_single_output_op_from_nnef_tensors(
-        node,
-        "tract_core_one_hot",
-        inputs=inp_ref,
-        attrs={
-            "axis": input_node.rank,
-            "dim": int(num_classes_node.data),
-        },
-        output_tensor_name_suffix="_oh",
+
+    if isinstance(inference_target, TractNNEF):
+        onehot_out = op_helper.add_single_output_op_from_nnef_tensors(
+            node,
+            "tract_core_one_hot",
+            inputs=inp_ref,
+            attrs={"axis": axis, "dim": num_classes},
+            output_tensor_name_suffix="_oh",
+        )
+        op_helper.add_single_output_op_from_nnef_tensors(
+            node,
+            "tract_core_cast",
+            inputs=onehot_out,
+            attrs={"to": "i64"},
+        )
+        return ["tract_core"]
+
+    # Pure-NNEF path: bake the classes constant pre-shaped to match
+    # input.rank + 1 so the fragment's broadcast `eq` works without
+    # extra unsqueezes on the classes side.
+    classes_shape = (1,) * input_node.rank + (num_classes,)
+    classes_const = PythonConstant(
+        name=f"{node.outputs[0].name}_oh_classes",
+        data=torch.arange(num_classes, dtype=input_node.dtype).reshape(
+            classes_shape
+        ),
+    )
+    classes_ref = get_or_add_tensor_variable_in_nnef(
+        g, classes_const, name_to_tensor
     )
     op_helper.add_single_output_op_from_nnef_tensors(
         node,
-        "tract_core_cast",
-        inputs=onehot_out,
-        attrs={"to": "i64"},
+        "one_hot",
+        inputs=[inp_ref, classes_ref],
+        attrs={"axis": axis},
+        force_consistent_inputs_shapes=False,
     )
-    return ["tract_core"]
+    return ["one_hot"]
 
 
 @OP_REGISTRY.register()

--- a/torch_to_nnef/op/aten/tensor_build.py
+++ b/torch_to_nnef/op/aten/tensor_build.py
@@ -413,58 +413,39 @@ def new_full(g, node, name_to_tensor, torch_graph, inference_target, **kwargs):
 
 
 @OP_REGISTRY.register()
-def one_hot(g, node, name_to_tensor, op_helper, **kwargs):
-    """Map PyTorch: 'aten:one_hot' to NNEF.
+def one_hot(node, op_helper, **kwargs):
+    """Map PyTorch: 'aten:one_hot' to NNEF via `tract_core_one_hot`.
 
-    `one_hot(input: int64, num_classes)` -> int64 tensor of shape
-    `input.shape + (num_classes,)`. Decomposed inline as
-    `eq(unsqueeze(input, last_axis), arange(num_classes))` cast back
-    to int64. Static `num_classes` (compile-time int) is required;
-    runtime-sized one-hot would need `tract_core_range` driven by a
-    runtime tensor (rare in practice).
+    Tract has the op natively (`core/src/ops/array/one_hot.rs`) with
+    NNEF binding `tract_core_one_hot(input, axis, dim, value_off=0,
+    value_on=1)`. Torch's `one_hot(input, num_classes)` appends the
+    one-hot axis as the trailing dim, so `axis = input.rank` (the new
+    last position in the output rank-(R+1) result) and `dim =
+    num_classes`.
+
+    Tract's op produces a `scalar` (float) tensor with the on/off
+    values; torch returns int64. Cast on top to match.
     """
     input_node, num_classes_node = node.inputs
     if not isinstance(num_classes_node.data, int):
         raise T2NErrorNotImplemented(
             "aten::one_hot with dynamic num_classes not yet supported"
         )
-    num_classes = int(num_classes_node.data)
-    input_rank = input_node.rank
-    inp_ref = get_or_add_tensor_variable_in_nnef(g, input_node, name_to_tensor)
-
-    # Bake [0, ..., num_classes-1] as a constant whose rank already
-    # matches `input.rank + 1` (with size 1 on every axis except the
-    # last) so NNEF `eq`'s exact-rank broadcast rule is satisfied
-    # without an extra unsqueeze chain on the classes side.
-    classes_shape = (1,) * input_rank + (num_classes,)
-    classes_const = PythonConstant(
-        name=f"{node.outputs[0].name}_oh_classes",
-        data=torch.arange(num_classes, dtype=input_node.dtype).reshape(
-            classes_shape
-        ),
-    )
-    classes_ref = get_or_add_tensor_variable_in_nnef(
-        g, classes_const, name_to_tensor
-    )
-
-    unsqueezed = op_helper.add_single_output_op_from_nnef_tensors(
+    inp_ref = op_helper.get_or_add_tensor_variable_in_nnef(input_node)
+    onehot_out = op_helper.add_single_output_op_from_nnef_tensors(
         node,
-        "unsqueeze",
+        "tract_core_one_hot",
         inputs=inp_ref,
-        attrs={"axes": [input_rank]},
-        output_tensor_name_suffix="_oh_unsq",
-    )
-    mask = op_helper.add_single_output_op_from_nnef_tensors(
-        node,
-        "eq",
-        inputs=[unsqueezed, classes_ref],
-        force_consistent_inputs_shapes=False,
-        output_tensor_name_suffix="_oh_mask",
+        attrs={
+            "axis": input_node.rank,
+            "dim": int(num_classes_node.data),
+        },
+        output_tensor_name_suffix="_oh",
     )
     op_helper.add_single_output_op_from_nnef_tensors(
         node,
         "tract_core_cast",
-        inputs=mask,
+        inputs=onehot_out,
         attrs={"to": "i64"},
     )
     return ["tract_core"]

--- a/torch_to_nnef/op/fragment/one_hot.nnef
+++ b/torch_to_nnef/op/fragment/one_hot.nnef
@@ -1,0 +1,22 @@
+# One-hot encoding via broadcast-eq + select.
+#
+# `classes` is a pre-baked rank-(input.rank + 1) constant of the form
+# `(1,) * input.rank + (num_classes,)` so NNEF `eq`'s exact-rank
+# broadcast rule is satisfied without an extra unsqueeze chain on the
+# classes side. `axis` is the position in the output where the
+# one-hot dim goes (`input.rank` for torch's "append at end"
+# semantic).
+#
+# Pure NNEF stdlib (unsqueeze + eq + select); used by the
+# non-TractNNEF code path. The TractNNEF path emits
+# `tract_core_one_hot` directly since tract has the op natively.
+fragment one_hot(
+    input:   tensor<scalar>,
+    classes: tensor<scalar>,
+    axis:    integer
+) -> ( output: tensor<scalar> )
+{
+    expanded = unsqueeze(input, axes = [axis]);
+    mask     = eq(expanded, classes);
+    output   = select(mask, 1.0, 0.0);
+}


### PR DESCRIPTION
Stacked on top of #104 (will rebase once #104 lands; the diff against main shows both #104's 14 ops and this PR's 5 + 2). Continues the "quick wins" sweep.

## Ops added by this PR

### Construction family (3 ops)

Share the existing `_generic_auto_tensor_expansion` machinery, so dynamic-axes paths are inherited.

| Op | Lowering |
|---|---|
| `aten::new_empty` | zeros of given `size` with input's dtype |
| `aten::new_ones` | ones of given `size` |
| `aten::new_full` | `ones * fill_value`, build fn patched at trace time |

### `one_hot`

Inline `eq(unsqueeze(input, last_axis), arange(num_classes))` cast to int64. Classes constant pre-reshaped to `(1,) * input.rank + (num_classes,)` so NNEF `eq`'s exact-rank broadcast rule is satisfied.

### Aliases

| Alias | Routes through |
|---|---|
| `aten::unsafe_chunk` | `chunk` |
| `aten::unsafe_split_with_sizes` | `split_with_sizes` |

`unsafe_*` only differs from the canonical form in the autograd-graph promise around in-place writes; irrelevant on the inference path.

## Test plan

- [x] `ruff check` + `ruff format` clean.
- [x] All 5 ops smoke-tested end-to-end against `TractNNEF.latest()`.
- [ ] CI matrix (rebases once #104 lands).