### PR TITLE
feat(op): add bitwise_left_shift / bitwise_right_shift

### DIFF
--- a/tests/proptest/op_specs/elementwise.py
+++ b/tests/proptest/op_specs/elementwise.py
@@ -795,6 +795,32 @@ def _bitwise_not_sample_st() -> st.SearchStrategy[OpSample]:
     return _draw()
 
 
+def _bitwise_shift_sample_st(
+    op: T.Callable[..., torch.Tensor],
+) -> st.SearchStrategy[OpSample]:
+    """Bitwise shift over int32: non-negative data, shift counts in [0, 30].
+
+    The data interval excludes negatives because right-shift on signed
+    integers is implementation-defined in C++ and tract follows the
+    arithmetic-shift convention; sticking to non-negative inputs keeps
+    the comparison crisp. Shift counts above 30 are UB on 32-bit ints,
+    so we cap them at 30.
+    """
+
+    @st.composite
+    def _draw(draw) -> OpSample:
+        sa, sb = draw(binary_broadcast_shapes_st(max_rank=4, max_dim=6))
+        a = draw(
+            tensor_st(sa, torch.int32, finite=True, domain=Interval(0, 1024))
+        )
+        b = draw(
+            tensor_st(sb, torch.int32, finite=True, domain=Interval(0, 30))
+        )
+        return OpSample(inputs=(a, b), module=BinaryPrimitive(op))
+
+    return _draw()
+
+
 def _zeros_like_sample_st() -> st.SearchStrategy[OpSample]:
     """`torch.zeros_like(input)`: output matches input shape/dtype.
 
@@ -883,6 +909,18 @@ def _bitwise_builder_specs() -> T.List[OpSpec]:
             name="bitwise_not",
             sample_st=_bitwise_not_sample_st(),
             tolerance=EXACT,
+        ),
+        OpSpec(
+            name="bitwise_left_shift",
+            sample_st=_bitwise_shift_sample_st(torch.bitwise_left_shift),
+            tolerance=EXACT,
+            dynamic_axes_compatible=True,
+        ),
+        OpSpec(
+            name="bitwise_right_shift",
+            sample_st=_bitwise_shift_sample_st(torch.bitwise_right_shift),
+            tolerance=EXACT,
+            dynamic_axes_compatible=True,
         ),
         OpSpec(
             name="zeros_like",

--- a/torch_to_nnef/op/aten/math.py
+++ b/torch_to_nnef/op/aten/math.py
@@ -1001,6 +1001,61 @@ def bitwise_or(node, op_helper, inference_target, **kwargs):
     return ["tract_core"]
 
 
+def _emit_bitwise_shift(node, op_helper, inference_target, *, nnef_op_type):
+    """Emit one of tract's shift ops (`tract_shl` / `tract_shr`).
+
+    PythonConstant shift counts (the `<< 2` form) traced as
+    `prim::Constant[int]` lower to NNEF integer literals. tract's
+    NNEF reader binds bare integer literals as TDim (its shape-arith
+    type), and `ShiftLeft` / `ShiftRight` reject TDim at evaluation.
+    Force the constant through a `tract_core_cast` to the data
+    input's dtype so the shift sees a concrete int tensor.
+    """
+    assert len(node.outputs) == 1
+    if not isinstance(inference_target, TractNNEF):
+        raise T2NErrorNotImplemented(inference_target)
+    a_node, b_node = node.inputs
+    a_ref = op_helper.get_or_add_tensor_variable_in_nnef(a_node)
+    if isinstance(b_node, PythonConstant):
+        b_node = b_node.into_tensor_variable()
+        b_ref = op_helper.get_or_add_tensor_variable_in_nnef(b_node)
+        b_ref = op_helper.add_single_output_op_from_nnef_tensors(
+            node,
+            "tract_core_cast",
+            inputs=b_ref,
+            attrs={"to": TORCH_DTYPE_TO_TRACT_STR[a_node.dtype]},
+            output_tensor_name_suffix="shift_count",
+        )
+    else:
+        b_ref = op_helper.get_or_add_tensor_variable_in_nnef(b_node)
+    op_helper.add_single_output_op_from_nnef_tensors(
+        node,
+        nnef_op_type,
+        inputs=[a_ref, b_ref],
+    )
+    return ["tract_core"]
+
+
+@OP_REGISTRY.register(torch_op_ids=["bitwise_left_shift", "__lshift__"])
+def bitwise_left_shift(node, op_helper, inference_target, **kwargs):
+    """Map `aten:bitwise_left_shift` / `<<` op to NNEF -> `tract_shl`.
+
+    Tract's shift ops live under the `tract_core` extension despite
+    the bare `tract_shl` / `tract_shr` names in the registry.
+    """
+    return _emit_bitwise_shift(
+        node, op_helper, inference_target, nnef_op_type="tract_shl"
+    )
+
+
+@OP_REGISTRY.register(torch_op_ids=["bitwise_right_shift", "__rshift__"])
+def bitwise_right_shift(node, op_helper, inference_target, **kwargs):
+    """Map PyTorch: 'aten:bitwise_right_shift' / `>>` op -> `tract_shr`."""
+    return _emit_bitwise_shift(
+        node, op_helper, inference_target, nnef_op_type="tract_shr"
+    )
+
+
 @OP_REGISTRY.register()
 def addcmul(node, op_helper, **kwargs):
     """Map PyTorch: 'aten:addcmul' to the `addcmul` fragment."""


### PR DESCRIPTION
## Summary

- Maps `aten::bitwise_left_shift` (and the `<<` operator form `aten::__lshift__`) to tract's `tract_shl`.
- Maps `aten::bitwise_right_shift` (and `>>` -> `aten::__rshift__`) to tract's `tract_shr`.
- Both ops live under the `tract_core` extension despite the unprefixed registry names.

## Why the explicit cast on Python-scalar shift counts

`a << 2` traces with the `2` as a `prim::Constant[int]`. tract's NNEF reader binds bare integer literals as `TDim` (its shape-arithmetic type), and `ShiftLeft` / `ShiftRight` reject `TDim` at evaluation (`ShiftLeft does not support TDim`). The shared `_emit_bitwise_shift` helper detects PythonConstant shift counts, promotes them to a tensor variable, and forces them through a `tract_core_cast` to the data input's dtype before emitting the shift -- so the shift always sees a concrete int tensor.

## Test plan

- [x] Smoke test 8 cases (i32 / i64 / i8, tensor + tensor, tensor + scalar via `<<`/`>>`, tensor + scalar via explicit `bitwise_*_shift`, 1D / 2D) -> all pass against `TractNNEF.latest()`
- [x] Proptest specs added (`bitwise_left_shift` / `bitwise_right_shift`) opted into the dyn-axes variant -> 4 pass
- [x] `ruff check` / `ruff format` clean