### PR TITLE
feat(op): broadcast_tensors / meshgrid / tensor_split

### DIFF
--- a/tests/proptest/op_specs/shape.py
+++ b/tests/proptest/op_specs/shape.py
@@ -23,6 +23,7 @@ from ..joint import (
 )
 from ..shapes import (
     shape_st,
+    ternary_broadcast_shapes_st,
 )
 from ._common import (
     OpSample,
@@ -2378,6 +2379,168 @@ def _index_pixel_specs() -> T.List[OpSpec]:
     ]
 
 
+def _broadcast_tensors_sample_st() -> st.SearchStrategy[OpSample]:
+    """`torch.broadcast_tensors(t0, t1, t2)` over 3 broadcastable inputs."""
+
+    @st.composite
+    def _draw(draw) -> OpSample:
+        sa, sb, sc = draw(ternary_broadcast_shapes_st(max_rank=3, max_dim=4))
+        a = draw(
+            tensor_st(
+                sa, torch.float32, finite=True, domain=Interval(-10.0, 10.0)
+            )
+        )
+        b = draw(
+            tensor_st(
+                sb, torch.float32, finite=True, domain=Interval(-10.0, 10.0)
+            )
+        )
+        c = draw(
+            tensor_st(
+                sc, torch.float32, finite=True, domain=Interval(-10.0, 10.0)
+            )
+        )
+
+        def op_fn(x, y, z):
+            return torch.broadcast_tensors(x, y, z)
+
+        return OpSample(inputs=(a, b, c), module=TernaryPrimitive(op_fn))
+
+    return _draw()
+
+
+def _meshgrid_sample_st(indexing: str) -> st.SearchStrategy[OpSample]:
+    """`torch.meshgrid(a, b, indexing=...)` over rank-1 inputs."""
+
+    @st.composite
+    def _draw(draw) -> OpSample:
+        sa = draw(st.integers(min_value=1, max_value=4))
+        sb = draw(st.integers(min_value=1, max_value=4))
+        a = draw(
+            tensor_st(
+                (sa,), torch.float32, finite=True, domain=Interval(-5.0, 5.0)
+            )
+        )
+        b = draw(
+            tensor_st(
+                (sb,), torch.float32, finite=True, domain=Interval(-5.0, 5.0)
+            )
+        )
+        op_fn = (lambda idx: lambda x, y: torch.meshgrid(x, y, indexing=idx))(
+            indexing
+        )
+        return OpSample(inputs=(a, b), module=BinaryPrimitive(op_fn))
+
+    return _draw()
+
+
+def _tensor_split_sample_st(mode: str) -> st.SearchStrategy[OpSample]:
+    """`torch.tensor_split(x, sections_or_indices, dim)`.
+
+    `mode='int'` sweeps the integer-sections form; `mode='list'` sweeps
+    the boundary-indices form. Indices form is constrained so that
+    boundaries are strictly increasing and within `[1, dim_size - 1]`.
+    """
+
+    @st.composite
+    def _draw(draw) -> OpSample:
+        rank = draw(st.integers(min_value=1, max_value=3))
+        shape = tuple(
+            draw(
+                st.lists(
+                    st.integers(min_value=2, max_value=8),
+                    min_size=rank,
+                    max_size=rank,
+                )
+            )
+        )
+        dim = draw(st.integers(min_value=0, max_value=rank - 1))
+        x = draw(
+            tensor_st(
+                shape, torch.float32, finite=True, domain=Interval(-10.0, 10.0)
+            )
+        )
+        if mode == "int":
+            sections = draw(st.integers(min_value=1, max_value=shape[dim]))
+            op_fn = (lambda s, d: lambda t: torch.tensor_split(t, s, dim=d))(
+                sections, dim
+            )
+        else:
+            n_indices = draw(
+                st.integers(min_value=1, max_value=max(1, shape[dim] - 1))
+            )
+            indices = sorted(
+                draw(
+                    st.lists(
+                        st.integers(min_value=1, max_value=shape[dim] - 1),
+                        min_size=n_indices,
+                        max_size=n_indices,
+                        unique=True,
+                    )
+                )
+            )
+            op_fn = (
+                lambda idxs, d: lambda t: torch.tensor_split(t, idxs, dim=d)
+            )(indices, dim)
+        return OpSample(inputs=(x,), module=UnaryPrimitive(op_fn))
+
+    return _draw()
+
+
+def _shape_utility_specs() -> T.List[OpSpec]:
+    return [
+        # `tract_core_broadcast` is shape-only and rank-preserving, so
+        # dyn-axes works out of the box.
+        OpSpec(
+            name="broadcast_tensors",
+            sample_st=_broadcast_tensors_sample_st(),
+            tolerance=TractCheckTolerance.EXACT,
+            dynamic_axes_compatible=True,
+        ),
+        # meshgrid emits a rank-changing reshape with a concrete numeric
+        # shape; under dyn-axes tract rejects the int-vs-symbolic mismatch
+        # ("A should be equal to N"). Threading dyn-axis symbols into
+        # `_make_ntensor_with_shape` is a follow-up.
+        OpSpec(
+            name="meshgrid_ij",
+            sample_st=_meshgrid_sample_st("ij"),
+            tolerance=TractCheckTolerance.EXACT,
+            dynamic_axes_skip_reason=(
+                "meshgrid reshape declares concrete shape; "
+                "symbolic-dim threading needs follow-up."
+            ),
+        ),
+        OpSpec(
+            name="meshgrid_xy",
+            sample_st=_meshgrid_sample_st("xy"),
+            tolerance=TractCheckTolerance.EXACT,
+            dynamic_axes_skip_reason=(
+                "meshgrid reshape declares concrete shape; "
+                "symbolic-dim threading needs follow-up."
+            ),
+        ),
+        # tensor_split bakes slice boundaries from the trace-time
+        # `dim_size`. Static-axes proptest passes; runtime correctness
+        # across different dyn-axis sizes is a known follow-up.
+        OpSpec(
+            name="tensor_split-int",
+            sample_st=_tensor_split_sample_st("int"),
+            tolerance=TractCheckTolerance.EXACT,
+            dynamic_axes_skip_reason=(
+                "tensor_split bakes boundaries from trace-time dim_size."
+            ),
+        ),
+        OpSpec(
+            name="tensor_split-indices",
+            sample_st=_tensor_split_sample_st("list"),
+            tolerance=TractCheckTolerance.EXACT,
+            dynamic_axes_skip_reason=(
+                "tensor_split bakes boundaries from trace-time dim_size."
+            ),
+        ),
+    ]
+
+
 # 3D conv/pool + numerical helpers + classifiers
 
 SPECS = (
@@ -2387,4 +2550,5 @@ SPECS = (
     *_sort_scatter_specs(),
     *_selector_specs(),
     *_index_pixel_specs(),
+    *_shape_utility_specs(),
 )

--- a/torch_to_nnef/export.py
+++ b/torch_to_nnef/export.py
@@ -34,6 +34,7 @@ from torch_to_nnef.tensor import (
     set_opaque_tensor_in_params_as_ref,
 )
 from torch_to_nnef.tensor.updater import ModTensorUpdater
+from torch_to_nnef.torch_graph import harden_jit_for_export
 from torch_to_nnef.torch_graph.ir_naming import (
     DEFAULT_VARNAME_SCHEME,
     VariableNamingScheme,
@@ -234,9 +235,6 @@ def export_model_to_nnef(
     # successful export and a `ModuleNotFoundError`. Opt out via
     # `auto_harden_jit=False` to drive the chain manually.
     if auto_harden_jit and isinstance(model, torch.jit.ScriptModule):
-        # pylint: disable-next=import-outside-toplevel
-        from torch_to_nnef.torch_graph import harden_jit_for_export
-
         LOGGER.info(
             "Detected torch.jit.ScriptModule; auto-applying "
             "harden_jit_for_export. Pass auto_harden_jit=False to "

--- a/torch_to_nnef/inference_target/tract.py
+++ b/torch_to_nnef/inference_target/tract.py
@@ -47,7 +47,11 @@ from torch_to_nnef.exceptions import (
     T2NErrorTractOnnxToNNEF,
 )
 from torch_to_nnef.inference_target.base import InferenceTarget
-from torch_to_nnef.model_wrapper import UnfoldModelInfo, unfold_model_io
+from torch_to_nnef.model_wrapper import (
+    UnfoldModelInfo,
+    WrapStructIO,
+    unfold_model_io,
+)
 from torch_to_nnef.utils import SemanticVersion, cd, dedup_list, torch_version
 
 T2N_CHECK_IO_RAISE_EXCEPTION = "T2N_CHECK_IO_RAISE_EXCEPTION"
@@ -264,9 +268,6 @@ class TractNNEF(InferenceTarget):
 
         items["py_version"] = python_version()
         items["export_date"] = str(datetime.now())
-
-        # pylint: disable-next=import-outside-toplevel
-        from torch_to_nnef.model_wrapper import WrapStructIO
 
         if isinstance(model, WrapStructIO):
             model = model.model

--- a/torch_to_nnef/op/aten/axes_change.py
+++ b/torch_to_nnef/op/aten/axes_change.py
@@ -2,6 +2,7 @@ import typing as T
 
 import nnef
 import torch
+from nnef_tools.model import Tensor as NTensor
 
 from torch_to_nnef.exceptions import T2NErrorNotImplemented
 from torch_to_nnef.inference_target import TractNNEF
@@ -11,6 +12,7 @@ from torch_to_nnef.op.aten.complex import (
 from torch_to_nnef.op.helper import (
     AtenOpRegistry,
     add_single_output_op,
+    cast_and_add_nnef_operation,
     get_list_of_int,
     get_or_add_tensor_variable_in_nnef,
     get_tract_dyn_axis_size_soc,
@@ -817,9 +819,6 @@ def _emit_broadcast_to(op_helper, node, src_ref, target_shape, output_idx):
     already broadcast-compatible with `target_shape` and replicate the
     size-1 axes up to the target size.
     """
-    # pylint: disable-next=import-outside-toplevel
-    from torch_to_nnef.op.helper import cast_and_add_nnef_operation
-
     g = op_helper.g
     name_to_tensor = op_helper.name_to_tensor
     onode = node.outputs[output_idx]
@@ -848,9 +847,6 @@ def _make_ntensor_with_shape(g, name_to_tensor, name, shape, np_dtype):
     `add_single_output_op_from_nnef_tensors`, which inherits
     `node.outputs[0].shape` and asserts single-output.
     """
-    # pylint: disable-next=import-outside-toplevel
-    from nnef_tools.model import Tensor as NTensor
-
     tensor = NTensor(g, name, dtype=np_dtype, shape=tuple(shape))
     name_to_tensor[name] = tensor
     return tensor
@@ -892,9 +888,6 @@ def _emit_meshgrid_one_axis(
     `add_single_output_op...` helpers inherit `node.outputs[0].shape`
     and assert single-output, both wrong for a multi-output meshgrid).
     """
-    # pylint: disable-next=import-outside-toplevel
-    from torch_to_nnef.op.helper import cast_and_add_nnef_operation
-
     g = op_helper.g
     name_to_tensor = op_helper.name_to_tensor
     rank = len(target_shape)

--- a/torch_to_nnef/op/aten/axes_change.py
+++ b/torch_to_nnef/op/aten/axes_change.py
@@ -16,6 +16,7 @@ from torch_to_nnef.op.helper import (
     get_tract_dyn_axis_size_soc,
     pick_axis,
 )
+from torch_to_nnef.torch_graph import FixedTensorList
 from torch_to_nnef.torch_graph.ir_data import PythonConstant
 
 OP_REGISTRY = AtenOpRegistry()
@@ -806,3 +807,158 @@ def pixel_shuffle(node, op_helper, **kwargs):
 def pixel_unshuffle(node, op_helper, **kwargs):
     """Map PyTorch: 'aten:pixel_unshuffle' (inverse of `pixel_shuffle`)."""
     _pixel_reshuffle(node, op_helper, downscale=True)
+
+
+def _emit_broadcast_to(op_helper, node, src_ref, target_shape, output_idx):
+    """Emit `tract_core_broadcast` to `node.outputs[output_idx]`.
+
+    `tract_core_broadcast` maps to tract's `MultiBroadcastTo`, which is
+    exactly torch's `broadcast_tensors` semantics: take an input that's
+    already broadcast-compatible with `target_shape` and replicate the
+    size-1 axes up to the target size.
+    """
+    # pylint: disable-next=import-outside-toplevel
+    from torch_to_nnef.op.helper import cast_and_add_nnef_operation
+
+    g = op_helper.g
+    name_to_tensor = op_helper.name_to_tensor
+    onode = node.outputs[output_idx]
+    out_ref = op_helper.get_or_add_tensor_variable_in_nnef(
+        onode, prevent_variable=True
+    )
+    if not all(isinstance(d, int) for d in target_shape):
+        raise T2NErrorNotImplemented(
+            "broadcast with dynamic target shape not yet supported"
+        )
+    cast_and_add_nnef_operation(
+        name_to_tensor=name_to_tensor,
+        graph=g,
+        type="tract_core_broadcast",
+        name=f"{onode.export_name}_op",
+        inputs=(src_ref,),
+        outputs=out_ref,
+        attribs={"shape": list(target_shape)},
+    )
+
+
+def _make_ntensor_with_shape(g, name_to_tensor, name, shape, np_dtype):
+    """Register an `NTensor` with an explicit shape.
+
+    Rank-changing intermediates can't go through
+    `add_single_output_op_from_nnef_tensors`, which inherits
+    `node.outputs[0].shape` and asserts single-output.
+    """
+    # pylint: disable-next=import-outside-toplevel
+    from nnef_tools.model import Tensor as NTensor
+
+    tensor = NTensor(g, name, dtype=np_dtype, shape=tuple(shape))
+    name_to_tensor[name] = tensor
+    return tensor
+
+
+@OP_REGISTRY.register()
+def broadcast_tensors(node, op_helper, inference_target, **kwargs):
+    """Map PyTorch: 'aten:broadcast_tensors' to NNEF.
+
+    `broadcast_tensors([t0, t1, ...])` returns each input expanded to
+    the common broadcast shape. Each output is a separate
+    `tract_core_broadcast(t_i, shape=common)` call -- the common
+    shape is whatever torch traced into `node.outputs[i].shape` (all
+    outputs share it).
+    """
+    if not isinstance(inference_target, TractNNEF):
+        raise T2NErrorNotImplemented(inference_target)
+    (input_list_node,) = node.inputs
+    assert isinstance(input_list_node, FixedTensorList)
+    assert len(input_list_node.data) == len(node.outputs)
+    target_shape = list(node.outputs[0].shape)
+    for idx, (in_data, _out_node) in enumerate(
+        zip(input_list_node.data, node.outputs, strict=True)
+    ):
+        src_ref = op_helper.get_or_add_tensor_variable_in_nnef(in_data)
+        _emit_broadcast_to(op_helper, node, src_ref, target_shape, idx)
+    return ["tract_core"]
+
+
+def _emit_meshgrid_one_axis(
+    op_helper, node, src_ref, target_shape, axis, output_idx
+):
+    """Emit one meshgrid output: reshape + broadcast to target shape.
+
+    Reshape `src_ref` (rank 1) to `(1, .., size, .., 1)` at `axis`,
+    then broadcast to `target_shape` and write to
+    `node.outputs[output_idx]`. The reshape step is rank-changing, so
+    we build the intermediate NTensor explicitly (the shared
+    `add_single_output_op...` helpers inherit `node.outputs[0].shape`
+    and assert single-output, both wrong for a multi-output meshgrid).
+    """
+    # pylint: disable-next=import-outside-toplevel
+    from torch_to_nnef.op.helper import cast_and_add_nnef_operation
+
+    g = op_helper.g
+    name_to_tensor = op_helper.name_to_tensor
+    rank = len(target_shape)
+    reshape_shape = [1] * rank
+    reshape_shape[axis] = int(target_shape[axis])
+    onode = node.outputs[output_idx]
+    intermediate = _make_ntensor_with_shape(
+        g,
+        name_to_tensor,
+        f"{onode.export_name}_mg_reshape",
+        reshape_shape,
+        onode.np_dtype,
+    )
+    cast_and_add_nnef_operation(
+        name_to_tensor=name_to_tensor,
+        graph=g,
+        type="reshape",
+        name=f"{intermediate.name}_op",
+        inputs=(src_ref,),
+        outputs=intermediate,
+        attribs={"shape": reshape_shape},
+    )
+    _emit_broadcast_to(op_helper, node, intermediate, target_shape, output_idx)
+
+
+@OP_REGISTRY.register()
+def meshgrid(node, op_helper, inference_target, **kwargs):
+    """Map PyTorch: 'aten:meshgrid' to NNEF.
+
+    `meshgrid([t0, .., tN-1], indexing)` returns N rank-N tensors. Each
+    output is the corresponding input reshaped to put its size on the
+    proper axis (then broadcast to the full N-dim shape). With
+    `indexing='ij'` axis i is input i; with `indexing='xy'` the first
+    two axes are swapped (xy is matrix-style, ij is index-style).
+    """
+    if not isinstance(inference_target, TractNNEF):
+        raise T2NErrorNotImplemented(inference_target)
+    if len(node.inputs) == 2:
+        input_list_node, indexing_node = node.inputs
+        indexing = indexing_node.data
+    else:
+        (input_list_node,) = node.inputs
+        indexing = "ij"
+    assert isinstance(input_list_node, FixedTensorList)
+    assert len(input_list_node.data) == len(node.outputs)
+    n = len(input_list_node.data)
+    target_shape = list(node.outputs[0].shape)
+
+    def axis_for_input(i: int) -> int:
+        if indexing == "xy" and n >= 2:
+            if i == 0:
+                return 1
+            if i == 1:
+                return 0
+        return i
+
+    for i, in_data in enumerate(input_list_node.data):
+        src_ref = op_helper.get_or_add_tensor_variable_in_nnef(in_data)
+        _emit_meshgrid_one_axis(
+            op_helper,
+            node,
+            src_ref,
+            target_shape,
+            axis=axis_for_input(i),
+            output_idx=i,
+        )
+    return ["tract_core"]

--- a/torch_to_nnef/op/aten/rnn.py
+++ b/torch_to_nnef/op/aten/rnn.py
@@ -32,7 +32,9 @@ import torch
 from nnef_tools.model import Operation as NOperation
 from nnef_tools.model import Tensor as NTensor
 
+from torch_to_nnef import torch_graph as tg
 from torch_to_nnef.exceptions import T2NErrorNotImplemented
+from torch_to_nnef.op import helper
 from torch_to_nnef.op.helper import (
     AtenOpRegistry,
     add_tensor_variable_node_as_nnef_tensor,
@@ -283,9 +285,6 @@ def _apply_layer_and_unsqueeze_to_params(
 
 
 def _pre_batch_first(g, input_tensor, node, name_to_tensor) -> NTensor:
-    # pylint: disable-next=import-outside-toplevel
-    from torch_to_nnef.op import helper
-
     transposed = helper.add_tensor_variable_node_as_nnef_tensor(
         g, node.inputs[0], name_to_tensor, name_suffix="transposed"
     )
@@ -300,9 +299,6 @@ def _pre_batch_first(g, input_tensor, node, name_to_tensor) -> NTensor:
 
 
 def _post_batch_first(g, input_tensor, node, name_to_tensor) -> NTensor:
-    # pylint: disable-next=import-outside-toplevel
-    from torch_to_nnef.op import helper
-
     input_tensor.name += "_batch_first"
     out = helper.add_tensor_variable_node_as_nnef_tensor(
         g, node.outputs[0], name_to_tensor
@@ -321,9 +317,6 @@ def _multi_layers_concat(
     g, node, name_to_tensor, last_hc_at_each_layers
 ) -> None:
     """Concat last h_t (and c_t for LSTM) across layers."""
-    # pylint: disable-next=import-outside-toplevel
-    from torch_to_nnef.op import helper
-
     for idx, out_node in enumerate(node.outputs[1:]):
         real_output = helper.add_tensor_variable_node_as_nnef_tensor(
             g, out_node, name_to_tensor
@@ -353,9 +346,6 @@ def _translate_state_variable_load_and_prep(
     batch axis so the runtime gets a correctly-shaped state without the
     graph baking in a specific batch size.
     """
-    # pylint: disable-next=import-outside-toplevel
-    from torch_to_nnef.op import helper
-
     assert tensor_variable is None, tensor_variable
     base_var_name = next(node.op_ref.parameters()).nnef_name.rsplit(".", 1)[0]
     variable_storage_id = f"{var_name}_store"
@@ -482,12 +472,6 @@ def _translate_to_nnef_variable(
     get a {param_name: torch.Tensor or (tensor_variable, torch_tensor)}
     dict, then converts each entry into an NNEF tensor reference.
     """
-    # pylint: disable-next=import-outside-toplevel
-    from torch_to_nnef import torch_graph as tg
-
-    # pylint: disable-next=import-outside-toplevel
-    from torch_to_nnef.op import helper
-
     name_to_nnef_variable: T.Dict[str, NTensor] = {}
     for var_name, item in tensor_params_fn(
         module,
@@ -566,9 +550,6 @@ def _translate_to_nnef_variable(
 def _translate_to_nnef_outputs(
     g, name_to_tensor, linfo: str, module, node
 ) -> T.List[NTensor]:
-    # pylint: disable-next=import-outside-toplevel
-    from torch_to_nnef.op import helper
-
     return [
         helper.add_tensor_variable_node_as_nnef_tensor(
             g,
@@ -591,9 +572,6 @@ def _apply_rnn_bidirectional_pack_at_layer(
     last_backward_h: NTensor,
     module,
 ) -> NTensor:
-    # pylint: disable-next=import-outside-toplevel
-    from torch_to_nnef.op import helper
-
     out_packed_bidi = helper.add_tensor_variable_node_as_nnef_tensor(
         g,
         node.outputs[0],

--- a/torch_to_nnef/op/aten/split.py
+++ b/torch_to_nnef/op/aten/split.py
@@ -128,3 +128,98 @@ def chunk(g, node, name_to_tensor, **kwargs):
             },
         )
         current_dim_elm_idx += n_elements
+
+
+def _tensor_split_compute_boundaries(dim_size, sections_or_indices):
+    """Resolve `indices_or_sections` into a list of split-axis boundaries.
+
+    - int N: split into N chunks. The first `dim_size % N` chunks have
+      `ceil(dim_size / N)` elements; the rest have `floor(dim_size / N)`.
+      Boundaries are `[k1, k1+k2, ..., k1+...+kN-1]` (length N-1).
+    - int list: the values are direct boundary indices (length k);
+      torch produces k+1 chunks separated by these.
+    """
+    if isinstance(sections_or_indices, int):
+        n = sections_or_indices
+        if n <= 0:
+            raise T2NErrorNotImplemented(
+                f"tensor_split requires positive sections, got {n}"
+            )
+        big = dim_size % n
+        big_size = (dim_size + n - 1) // n
+        small_size = dim_size // n
+        sizes = [big_size] * big + [small_size] * (n - big)
+        boundaries = []
+        cur = 0
+        for s in sizes[:-1]:
+            cur += s
+            boundaries.append(cur)
+        return boundaries
+    return [int(i) for i in sections_or_indices]
+
+
+@OP_REGISTRY.register()
+def tensor_split(g, node, name_to_tensor, **kwargs):
+    """Map PyTorch: 'aten:tensor_split' to NNEF.
+
+    Generalised split that allows uneven sections (unlike `split` /
+    `chunk`). Two overloads are supported:
+
+    * `tensor_split(self, sections: int, dim)` -- divide into N
+      approximately-equal chunks; the first `dim_size % N` chunks
+      take one extra element.
+    * `tensor_split(self, indices: int[], dim)` -- split at the
+      given boundary indices; produces `len(indices) + 1` chunks.
+
+    Each output is a `slice` of the input along `dim`. Static-axis
+    only: the boundaries depend on `dim_size`, which we resolve at
+    trace time.
+    """
+    input_node, sections_node, axis_node = node.inputs
+    axis = pick_axis(input_node, axis_node.data)
+    dim_size = input_node.shape[axis]
+    if not isinstance(dim_size, int):
+        raise T2NErrorNotImplemented(
+            f"tensor_split on dynamic axis {axis} not supported"
+        )
+
+    raw = sections_node.data
+    if hasattr(raw, "tolist"):
+        raw = raw.tolist()
+    if isinstance(raw, list):
+        sections_or_indices = [
+            int(x.data) if isinstance(x, PythonConstant) else int(x)
+            for x in raw
+        ]
+    else:
+        sections_or_indices = int(raw)
+    boundaries = _tensor_split_compute_boundaries(dim_size, sections_or_indices)
+    bounds = [0, *boundaries, dim_size]
+    assert len(bounds) - 1 == len(node.outputs), (
+        f"tensor_split: expected {len(bounds) - 1} outputs, "
+        f"got {len(node.outputs)}"
+    )
+
+    inputs = get_or_add_tensor_variable_in_nnef(g, input_node, name_to_tensor)
+    for out_node, begin, end in zip(
+        node.outputs, bounds[:-1], bounds[1:], strict=True
+    ):
+        out = add_tensor_variable_node_as_nnef_tensor(
+            g,
+            out_node,
+            name_to_tensor,
+            prevent_variable=True,
+        )
+        cast_and_add_nnef_operation(
+            name_to_tensor=name_to_tensor,
+            graph=g,
+            type="slice",
+            inputs=inputs,
+            outputs=tuple([out]),
+            attribs={
+                "axes": [axis],
+                "begin": [begin],
+                "end": [end],
+                "stride": [1],
+            },
+        )


### PR DESCRIPTION
## Summary

- **`broadcast_tensors`**: each input emitted as a `tract_core_broadcast(t_i, shape=common)` (target shape comes from `node.outputs[i].shape`). Dyn-axes opt-in works since broadcast is shape-only and rank-preserving.
- **`meshgrid` (`ij` and `xy` indexing)**: each output = input reshaped to size-1 on every axis except its own, then broadcast to the full N-dim shape. The xy variant swaps the first two axes.
- **`tensor_split`**: generalized split allowing uneven sections. Two overloads supported: int N (first `dim_size % N` chunks take one extra element) and explicit boundary indices. Lowered to one `slice` per output chunk.

## Where the rank-changing intermediate goes

`add_single_output_op_from_nnef_tensors` inherits `node.outputs[0].shape` and asserts a single output -- both fail for `meshgrid` (multi-output, with rank-changing reshape intermediates). `_make_ntensor_with_shape` builds the intermediate NTensor explicitly with the right kept-dim shape so tract's shape inference doesn't auto-align on the wrong axis.

## Dyn-axes coverage

- `broadcast_tensors` -> opted in, works.
- `meshgrid` -> opted out (skip reason in spec). The reshape step declares a concrete numeric shape, which collides with the symbolic-dim path under tract.
- `tensor_split` -> opted out. Slice boundaries are baked from trace-time `dim_size`; static-axes proptest passes but runtime correctness across different dyn-axis sizes would diverge. Same flavour as the var family's `correction>0` flaw -- documented as a follow-up.

## Test plan

- [x] Smoke test 16 cases across the three ops -> all pass against `TractNNEF.latest()`
- [x] Proptest specs added (5 total): `broadcast_tensors`, `meshgrid_ij`, `meshgrid_xy`, `tensor_split-int`, `tensor_split-indices`
- [x] `uv run pytest tests/test_primitive_proptest.py -k "broadcast_tensors or meshgrid or tensor_split"` -> 6 pass, 4 dyn-axes skip
- [x] `ruff check` / `ruff format` clean