### PR TITLE
feat(op): instance_norm + max_pool1d_with_indices

### DIFF
--- a/tests/proptest/op_specs/conv_pool.py
+++ b/tests/proptest/op_specs/conv_pool.py
@@ -73,8 +73,13 @@ def _pool2d_sample_st(
 def _pool1d_sample_st(
     op: T.Callable[..., torch.Tensor],
     allow_padding: bool = True,
+    op_kwargs: T.Optional[T.Dict[str, T.Any]] = None,
 ) -> st.SearchStrategy[OpSample]:
-    """1D pool. See `_pool2d_sample_st` for `allow_padding` rationale."""
+    """1D pool. See `_pool2d_sample_st` for `allow_padding` rationale.
+
+    `op_kwargs` are passed through to the wrapped op (e.g.
+    `return_indices=True` for `max_pool1d`).
+    """
 
     @st.composite
     def _draw(draw) -> OpSample:
@@ -97,7 +102,11 @@ def _pool1d_sample_st(
             )
         )
         wrapped = partial(
-            op, kernel_size=kernel, stride=stride, padding=padding
+            op,
+            kernel_size=kernel,
+            stride=stride,
+            padding=padding,
+            **(op_kwargs or {}),
         )
         return OpSample(inputs=(x,), module=UnaryPrimitive(wrapped))
 
@@ -152,6 +161,14 @@ def _pool_specs() -> T.List[OpSpec]:
             name="max_pool1d",
             sample_st=_pool1d_sample_st(F.max_pool1d),
             tolerance=EXACT,
+        ),
+        OpSpec(
+            name="max_pool1d_with_indices",
+            sample_st=_pool1d_sample_st(
+                F.max_pool1d, op_kwargs={"return_indices": True}
+            ),
+            tolerance=EXACT,
+            dynamic_axes_compatible=True,
         ),
         OpSpec(
             name="max_pool2d",

--- a/tests/proptest/op_specs/norm.py
+++ b/tests/proptest/op_specs/norm.py
@@ -123,6 +123,46 @@ def _layer_norm_sample_st() -> st.SearchStrategy[OpSample]:
     return _draw()
 
 
+def _instance_norm_sample_st(
+    *, ndim: int, affine: bool
+) -> st.SearchStrategy[OpSample]:
+    """`nn.InstanceNorm{1,2,3}d(C, affine=...)` over rank-(2+ndim) input.
+
+    Each `(n, c)` plane is normalized independently. Channel sizes
+    are kept small so per-instance statistics stay numerically stable
+    on the sampled domain.
+    """
+
+    @st.composite
+    def _draw(draw) -> OpSample:
+        c = draw(st.integers(min_value=1, max_value=4))
+        n = draw(st.integers(min_value=1, max_value=3))
+        spatial = tuple(
+            draw(
+                st.lists(
+                    st.integers(min_value=2, max_value=4),
+                    min_size=ndim,
+                    max_size=ndim,
+                )
+            )
+        )
+        shape = (n, c, *spatial)
+        x = draw(
+            tensor_st(
+                shape, torch.float32, finite=True, domain=Interval(-5.0, 5.0)
+            )
+        )
+        layer_cls = {
+            1: nn.InstanceNorm1d,
+            2: nn.InstanceNorm2d,
+            3: nn.InstanceNorm3d,
+        }[ndim]
+        layer = layer_cls(c, affine=affine).eval()
+        return OpSample(inputs=(x,), module=layer)
+
+    return _draw()
+
+
 def _batch_norm1d_sample_st() -> st.SearchStrategy[OpSample]:
     """`nn.BatchNorm1d(C)` over (N, C) or (N, C, L) input."""
 
@@ -269,6 +309,35 @@ def _norm_conv_matmul_specs() -> T.List[OpSpec]:
             name="batch_norm1d",
             sample_st=_batch_norm1d_sample_st(),
             tolerance=VERY,
+        ),
+        # instance_norm: same multi-step f32 reduction as group_norm
+        # (mean/var over spatial dims plus normalization), so the same
+        # SUPER tolerance is needed. The fragment uses `moments` +
+        # `sub`/`add`/`sqrt`/`div` -- all rank-preserving, no concrete
+        # shape declarations, so dyn-axes works straight through.
+        OpSpec(
+            name="instance_norm1d",
+            sample_st=_instance_norm_sample_st(ndim=1, affine=False),
+            tolerance=TractCheckTolerance.SUPER,
+            dynamic_axes_compatible=True,
+        ),
+        OpSpec(
+            name="instance_norm2d",
+            sample_st=_instance_norm_sample_st(ndim=2, affine=False),
+            tolerance=TractCheckTolerance.SUPER,
+            dynamic_axes_compatible=True,
+        ),
+        OpSpec(
+            name="instance_norm2d_affine",
+            sample_st=_instance_norm_sample_st(ndim=2, affine=True),
+            tolerance=TractCheckTolerance.SUPER,
+            dynamic_axes_compatible=True,
+        ),
+        OpSpec(
+            name="instance_norm3d",
+            sample_st=_instance_norm_sample_st(ndim=3, affine=False),
+            tolerance=TractCheckTolerance.SUPER,
+            dynamic_axes_compatible=True,
         ),
         OpSpec(
             # Previously xfailed because the `group_norm.nnef`

--- a/torch_to_nnef/op/aten/norm.py
+++ b/torch_to_nnef/op/aten/norm.py
@@ -144,6 +144,91 @@ def batch_norm(g, node, name_to_tensor, null_ref, inference_target, **kwargs):
     return custom_fragments
 
 
+@OP_REGISTRY.register()
+def instance_norm(node, op_helper, **kwargs):
+    """Map PyTorch: 'aten:instance_norm' to NNEF via a fragment.
+
+    `instance_norm(input, weight?, bias?, running_mean?, running_var?,
+    use_input_stats, momentum, eps, cudnn_enabled)` normalises each
+    `(n, c)` plane independently using `(x - mean) / sqrt(var + eps)`
+    over the spatial axes. The optional affine pair is reshaped to
+    `(1, C, 1, ..., 1)` and applied as a post-multiply / add. The
+    fragment lives in `op/fragment/instance_norm.nnef` and uses only
+    NNEF stdlib (`moments` / `sub` / `add` / `sqrt` / `div`).
+    """
+    input_node = node.inputs[0]
+    weight_node = node.inputs[1]
+    bias_node = node.inputs[2]
+    eps_node = node.inputs[7]
+    eps_val = float(eps_node.data) if eps_node.data is not None else 1e-5
+
+    rank = input_node.rank
+    if rank < 3:
+        raise T2NErrorNotImplemented(
+            f"instance_norm needs rank>=3 (N, C, *spatial); got rank {rank}"
+        )
+    spatial_axes = list(range(2, rank))
+    inp_ref = op_helper.get_or_add_tensor_variable_in_nnef(input_node)
+
+    # `aten::instance_norm` passes `None` for absent weight/bias as
+    # `prim::Constant[NoneType]`, which becomes a t2n `PythonConstant`.
+    # When the user supplies real tensors (whether graph-inputs or
+    # baked weights) they show up as `TensorVariable`, so the
+    # presence test is "not a PythonConstant", not `data is not None`.
+    def _is_real_tensor(p_node):
+        return not (isinstance(p_node, PythonConstant) and p_node.data is None)
+
+    has_weight = _is_real_tensor(weight_node)
+    has_bias = _is_real_tensor(bias_node)
+    affine = has_weight or has_bias
+
+    norm_out = op_helper.add_single_output_op_from_nnef_tensors(
+        node,
+        "instance_norm",
+        inputs=inp_ref,
+        attrs={"axes": spatial_axes, "eps": eps_val},
+        force_consistent_inputs_shapes=False,
+        output_tensor_name_suffix=("in_normed" if affine else ""),
+    )
+
+    if not affine:
+        return ["instance_norm"]
+
+    # Reshape affine params from `(C,)` to `(1, C, 1, ..., 1)` so they
+    # multiply / add along the channel axis without further plumbing.
+    # Done with a NNEF `reshape` op (not in-place IR mutation) because
+    # weight/bias may be graph inputs with `.data is None`.
+    affine_shape = [1, -1] + [1] * (rank - 2)
+
+    def _reshape_affine_param(p_node, suffix):
+        p_ref = op_helper.get_or_add_tensor_variable_in_nnef(p_node)
+        return op_helper.add_single_output_op_from_nnef_tensors(
+            node,
+            "reshape",
+            inputs=p_ref,
+            attrs={"shape": affine_shape},
+            output_tensor_name_suffix=suffix,
+        )
+
+    cur = norm_out
+    if has_weight:
+        weight_ref = _reshape_affine_param(weight_node, "in_w_reshape")
+        cur = op_helper.add_single_output_op_from_nnef_tensors(
+            node,
+            "mul",
+            inputs=[cur, weight_ref],
+            output_tensor_name_suffix=("in_scaled" if has_bias else ""),
+        )
+    if has_bias:
+        bias_ref = _reshape_affine_param(bias_node, "in_b_reshape")
+        op_helper.add_single_output_op_from_nnef_tensors(
+            node,
+            "add",
+            inputs=[cur, bias_ref],
+        )
+    return ["instance_norm"]
+
+
 @OP_REGISTRY.register(
     ["norm", "linalg_vector_norm", "linalg_norm", "frobenius_norm"]
 )

--- a/torch_to_nnef/op/aten/pool.py
+++ b/torch_to_nnef/op/aten/pool.py
@@ -52,6 +52,11 @@ def _pooling_op(
     padding = padding_node.data or []
     kernel_size = kernel_size_node.data or []
     stride = stride_node.data or []
+    # PyTorch defaults `stride` to `kernel_size` when empty / unspecified;
+    # tract's pool ops require stride length matching the input rank, so
+    # propagate that default here.
+    if not stride:
+        stride = list(kernel_size)
     if dilation_node:
         dilation = dilation_node.data or []
     else:
@@ -132,17 +137,25 @@ def max_pool_nd(node, op_helper, **kwargs):
     _pooling_op("max_pool", node.inputs, node, op_helper)
 
 
-@OP_REGISTRY.register(["max_pool2d_with_indices", "max_pool3d_with_indices"])
+@OP_REGISTRY.register(
+    [
+        "max_pool1d_with_indices",
+        "max_pool2d_with_indices",
+        "max_pool3d_with_indices",
+    ]
+)
 def max_pool_nd_with_indices(node, op_helper, **kwargs):
-    """Map PyTorch: 'aten:max_pool{2,3}d_with_indices' to NNEF.
+    """Map PyTorch: 'aten:max_pool{1,2,3}d_with_indices' to NNEF.
 
-    Indices are not representable in NNEF/Tract max_pool, so drop them.
+    Lowers to NNEF stdlib's `max_pool_with_index` fragment which
+    returns both the pooled values and the (per-window argmax)
+    indices. Tract only -- the fragment requires the
+    `argmax_pool` + `sample` primitives behind it.
     """
     if not isinstance(op_helper.inference_target, TractNNEF):
         raise T2NErrorNotImplemented(
             "max_pool_with_index is not supported in TractNNEF yet"
         )
-    # Only keep the pooled values output
     _pooling_op("max_pool_with_index", node.inputs, node, op_helper)
     return ["tract_core"]
 

--- a/torch_to_nnef/op/fragment/instance_norm.nnef
+++ b/torch_to_nnef/op/fragment/instance_norm.nnef
@@ -1,0 +1,22 @@
+# Per-sample, per-channel normalization (`instance_norm`).
+#
+# `axes` are the spatial axes (everything except batch and channel).
+# Mean and variance are computed independently per (n, c) plane via
+# the stdlib `moments` fragment, then we apply
+# `(x - mean) / sqrt(var + eps)`. Affine `* scale + bias` is handled
+# by the python emitter when those tensors are provided -- it's a
+# trivial post-multiply / add and keeps the fragment surface tight.
+#
+# Pure NNEF stdlib (moments / sub / add / sqrt / div).
+fragment instance_norm(
+    input: tensor<scalar>,
+    axes:  integer[],
+    eps:   scalar = 1.0e-5
+) -> ( output: tensor<scalar> )
+{
+    mean, variance = moments(input, axes = axes);
+    centered = sub(input, mean);
+    var_eps  = add(variance, eps);
+    std_dev  = sqrt(var_eps);
+    output   = div(centered, std_dev);
+}


### PR DESCRIPTION
## Summary

- **`instance_norm`** -> fragment `instance_norm.nnef`. Per-(n, c) plane `(x - mean) / sqrt(var + eps)` over the spatial axes, lowered through NNEF stdlib's `moments` fragment (no custom t2n math). The optional affine pair is reshaped from `(C,)` to `(1, C, 1, ..., 1)` via a NNEF `reshape` op and applied post-fragment as a `mul`+`add`. Crucially, the reshape goes through the NNEF graph rather than mutating the IR data in-place, because `aten::instance_norm` lets weight/bias be graph inputs whose `.data is None` (only baked-weight `nn.InstanceNorm{1,2,3}d(affine=True)` modules have data).

- **`max_pool1d_with_indices`** joins the existing `max_pool{2,3}d_with_indices` registration -- t2n-side only needed the 1D overload threaded through; same `_pooling_op("max_pool_with_index", ...)` call.

## Side-fix in `_pooling_op`

When `stride_node.data` is the empty list (PyTorch's "default to kernel_size" sentinel), we now fall back to `kernel_size`. tract rejects shorter stride lists with `stride should be like [1, 1, ...]`; the previous code relied on the user passing stride explicitly. Same fix applies to all `_pooling_op` callers (max/avg pool 1D/2D/3D).

## Why no `embedding_bag` in this PR?

I had it on the queue but it's a 4-output op with variable-length bags expressed as `(idx: 1-D, offsets: 1-D)`, plus three modes (sum/mean/max), plus optional per-sample weights. None of those fit cleanly into a fragment, and tract has no native equivalent. Deferred -- a future PR can decompose to `tract_core_gather` + per-bag slice + reduce, but the lift wasn't worth bundling here.

## Test plan

- [x] Smoke test 8 cases across the two ops (1D / 2D / 3D for instance_norm; default / explicit stride for max_pool1d_with_indices) -> all pass against `TractNNEF.latest()`
- [x] Proptest specs (5): `instance_norm{1d,2d,2d_affine,3d}` (SUPER tolerance) + `max_pool1d_with_indices` (EXACT). All opted into the dyn-axes variant -> 11 pass, 1 skip
- [x] `ruff check` / `ruff format` clean