### PR TITLE
feat(op): alias batch (conv_transpose / dstack / v|h|dsplit / count_nonzero)

### DIFF
--- a/docs/contributing/supported_operators.md
+++ b/docs/contributing/supported_operators.md
@@ -19,9 +19,9 @@ We filter out 'backward' and 'sym' operators from the listing since they are unw
 
     -  and support from full `aten::`: 
 
-    [=251/862 "251/862"]
+    [=274/862 "274/862"]
 
-     (total operators listed as supported by `torch_to_nnef` being 283)
+     (total operators listed as supported by `torch_to_nnef` being 306)
 
     <div class="op-filter-container" markdown="0">
     <form class="op-filter-form">
@@ -217,11 +217,11 @@ We filter out 'backward' and 'sym' operators from the listing since they are unw
     <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.binary_cross_entropy_with_logits.html">binary_cross_entropy_with_logits</a></td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.bincount.html">bincount</a></td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row unsupported"><td>❌</td><td>binomial</td><td></td><td>❌</td><td>-</td></tr>
-    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.bitwise_left_shift.html">bitwise_left_shift</a></td><td></td><td>✅</td><td>-</td></tr>
-    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.bitwise_right_shift.html">bitwise_right_shift</a></td><td></td><td>✅</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.bitwise_left_shift.html">bitwise_left_shift</a></td><td></td><td>✅</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.bitwise_right_shift.html">bitwise_right_shift</a></td><td></td><td>✅</td><td>-</td></tr>
     <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.blackman_window.html">blackman_window</a></td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.block_diag.html">block_diag</a></td><td></td><td>❌</td><td>-</td></tr>
-    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.broadcast_tensors.html">broadcast_tensors</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.broadcast_tensors.html">broadcast_tensors</a></td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.broadcast_to.html">broadcast_to</a></td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.bucketize.html">bucketize</a></td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.can_cast.html">can_cast</a></td><td></td><td>❌</td><td>-</td></tr>
@@ -230,7 +230,7 @@ We filter out 'backward' and 'sym' operators from the listing since they are unw
     <tr class="op-row unsupported"><td>❌</td><td>cauchy</td><td></td><td>✅</td><td>-</td></tr>
     <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.Tensor.ccol_indices.html">ccol_indices</a></td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row unsupported"><td>❌</td><td>ccol_indices_copy</td><td></td><td>❌</td><td>-</td></tr>
-    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.cdist.html">cdist</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.cdist.html">cdist</a></td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.celu.html">celu</a></td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row unsupported"><td>❌</td><td>center</td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.chain_matmul.html">chain_matmul</a></td><td></td><td>❌</td><td>-</td></tr>
@@ -261,10 +261,10 @@ We filter out 'backward' and 'sym' operators from the listing since they are unw
     <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.conv3d.html">conv3d</a></td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row unsupported"><td>❌</td><td>conv_depthwise3d</td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row unsupported"><td>❌</td><td>conv_tbc</td><td></td><td>❌</td><td>-</td></tr>
-    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.conv_transpose1d.html">conv_transpose1d</a></td><td></td><td>❌</td><td>-</td></tr>
-    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.conv_transpose2d.html">conv_transpose2d</a></td><td></td><td>❌</td><td>-</td></tr>
-    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.conv_transpose3d.html">conv_transpose3d</a></td><td></td><td>❌</td><td>-</td></tr>
-    <tr class="op-row unsupported"><td>❌</td><td>convolution_overrideable</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.conv_transpose1d.html">conv_transpose1d</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.conv_transpose2d.html">conv_transpose2d</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.conv_transpose3d.html">conv_transpose3d</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td>convolution_overrideable</td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row unsupported"><td>❌</td><td>convrelu</td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row unsupported"><td>❌</td><td>copy_sparse_to_sparse</td><td></td><td>✅</td><td>-</td></tr>
     <tr class="op-row unsupported"><td>❌</td><td>copy_to</td><td></td><td>❌</td><td>-</td></tr>
@@ -273,9 +273,9 @@ We filter out 'backward' and 'sym' operators from the listing since they are unw
     <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.cosine_embedding_loss.html">cosine_embedding_loss</a></td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.cosine_similarity.html">cosine_similarity</a></td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row unsupported"><td>❌</td><td>count</td><td></td><td>❌</td><td>-</td></tr>
-    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.count_nonzero.html">count_nonzero</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.count_nonzero.html">count_nonzero</a></td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.Tensor.cpu.html">cpu</a></td><td></td><td>❌</td><td>-</td></tr>
-    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.cross.html">cross</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.cross.html">cross</a></td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row unsupported"><td>❌</td><td>cross_entropy_loss</td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.Tensor.crow_indices.html">crow_indices</a></td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row unsupported"><td>❌</td><td>crow_indices_copy</td><td></td><td>❌</td><td>-</td></tr>
@@ -314,8 +314,8 @@ We filter out 'backward' and 'sym' operators from the listing since they are unw
     <tr class="op-row unsupported"><td>❌</td><td>divmod</td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.dot.html">dot</a></td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.dropout.html">dropout</a></td><td></td><td>✅</td><td>-</td></tr>
-    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.dsplit.html">dsplit</a></td><td></td><td>❌</td><td>-</td></tr>
-    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.dstack.html">dstack</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.dsplit.html">dsplit</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.dstack.html">dstack</a></td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row unsupported"><td>❌</td><td>dtype</td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.linalg.eig.html">eig</a></td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.einsum.html">einsum</a></td><td></td><td>❌</td><td>-</td></tr>
@@ -403,7 +403,7 @@ We filter out 'backward' and 'sym' operators from the listing since they are unw
     <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.histc.html">histc</a></td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.histogram.html">histogram</a></td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.histogramdd.html">histogramdd</a></td><td></td><td>❌</td><td>-</td></tr>
-    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.hsplit.html">hsplit</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.hsplit.html">hsplit</a></td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.hspmm.html">hspmm</a></td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.hstack.html">hstack</a></td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.huber_loss.html">huber_loss</a></td><td></td><td>❌</td><td>-</td></tr>
@@ -424,7 +424,7 @@ We filter out 'backward' and 'sym' operators from the listing since they are unw
     <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.initial_seed.html">initial_seed</a></td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.inner.html">inner</a></td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row unsupported"><td>❌</td><td>insert</td><td></td><td>❌</td><td>-</td></tr>
-    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.instance_norm.html">instance_norm</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.instance_norm.html">instance_norm</a></td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.Tensor.int_repr.html">int_repr</a></td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row unsupported"><td>❌</td><td>is_autocast_cpu_enabled</td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row unsupported"><td>❌</td><td>is_autocast_enabled</td><td></td><td>❌</td><td>-</td></tr>
@@ -549,13 +549,13 @@ We filter out 'backward' and 'sym' operators from the listing since they are unw
     <tr class="op-row unsupported"><td>❌</td><td>matrix_H</td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.linalg.matrix_rank.html">matrix_rank</a></td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.max_pool1d.html">max_pool1d</a></td><td></td><td>❌</td><td>-</td></tr>
-    <tr class="op-row unsupported"><td>❌</td><td>max_pool1d_with_indices</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td>max_pool1d_with_indices</td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.max_pool2d.html">max_pool2d</a></td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.max_pool3d.html">max_pool3d</a></td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.max_unpool2d.html">max_unpool2d</a></td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.max_unpool3d.html">max_unpool3d</a></td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.median.html">median</a></td><td></td><td>❌</td><td>-</td></tr>
-    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.meshgrid.html">meshgrid</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.meshgrid.html">meshgrid</a></td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row unsupported"><td>❌</td><td>miopen_batch_norm</td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row unsupported"><td>❌</td><td>miopen_convolution</td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row unsupported"><td>❌</td><td>miopen_convolution_add_relu</td><td></td><td>❌</td><td>-</td></tr>
@@ -632,7 +632,7 @@ We filter out 'backward' and 'sym' operators from the listing since they are unw
     <tr class="op-row unsupported"><td>❌</td><td>owner_name</td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.pad.html">pad</a></td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row unsupported"><td>❌</td><td>pad_sequence</td><td></td><td>❌</td><td>-</td></tr>
-    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.pairwise_distance.html">pairwise_distance</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.pairwise_distance.html">pairwise_distance</a></td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row unsupported"><td>❌</td><td>partition</td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.pdist.html">pdist</a></td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row unsupported"><td>❌</td><td>percentFormat</td><td></td><td>❌</td><td>-</td></tr>
@@ -803,8 +803,8 @@ We filter out 'backward' and 'sym' operators from the listing since they are unw
     <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.sspaddmm.html">sspaddmm</a></td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.stack.html">stack</a></td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row unsupported"><td>❌</td><td>startswith</td><td></td><td>❌</td><td>-</td></tr>
-    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.std.html">std</a></td><td></td><td>❌</td><td>-</td></tr>
-    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.std_mean.html">std_mean</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.std.html">std</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.std_mean.html">std_mean</a></td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.stft.html">stft</a></td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.Tensor.storage_offset.html">storage_offset</a></td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row unsupported"><td>❌</td><td>str</td><td></td><td>❌</td><td>-</td></tr>
@@ -820,8 +820,8 @@ We filter out 'backward' and 'sym' operators from the listing since they are unw
     <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.take_along_dim.html">take_along_dim</a></td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.tanhshrink.html">tanhshrink</a></td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.tensor.html">tensor</a></td><td></td><td>❌</td><td>-</td></tr>
-    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.tensor_split.html">tensor_split</a></td><td></td><td>❌</td><td>-</td></tr>
-    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.tensordot.html">tensordot</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.tensor_split.html">tensor_split</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.tensordot.html">tensordot</a></td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row unsupported"><td>❌</td><td>test</td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row unsupported"><td>❌</td><td>test_symbol</td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row unsupported"><td>❌</td><td>test_vartype</td><td></td><td>❌</td><td>-</td></tr>
@@ -871,7 +871,7 @@ We filter out 'backward' and 'sym' operators from the listing since they are unw
     <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.Tensor.values.html">values</a></td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row unsupported"><td>❌</td><td>values_copy</td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.vander.html">vander</a></td><td></td><td>❌</td><td>-</td></tr>
-    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.var_mean.html">var_mean</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.var_mean.html">var_mean</a></td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.vdot.html">vdot</a></td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.Tensor.view_as.html">view_as</a></td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.view_as_complex.html">view_as_complex</a></td><td></td><td>❌</td><td>-</td></tr>
@@ -880,7 +880,7 @@ We filter out 'backward' and 'sym' operators from the listing since they are unw
     <tr class="op-row unsupported"><td>❌</td><td>view_as_real_copy</td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row unsupported"><td>❌</td><td>view_copy</td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row unsupported"><td>❌</td><td>view_expand_placeholder</td><td></td><td>❌</td><td>-</td></tr>
-    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.vsplit.html">vsplit</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.vsplit.html">vsplit</a></td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.vstack.html">vstack</a></td><td>row_stack</td><td>❌</td><td>-</td></tr>
     <tr class="op-row unsupported"><td>❌</td><td>wait</td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row unsupported"><td>❌</td><td>wait_tensor</td><td></td><td>❌</td><td>-</td></tr>

--- a/tests/proptest/op_specs/shape.py
+++ b/tests/proptest/op_specs/shape.py
@@ -2541,6 +2541,168 @@ def _shape_utility_specs() -> T.List[OpSpec]:
     ]
 
 
+class _StackList(torch.nn.Module):
+    """Wrapper for `torch.{vstack,hstack,dstack}([a, b])`."""
+
+    def __init__(self, fn):
+        super().__init__()
+        self.fn = fn
+
+    def forward(self, a, b):
+        return self.fn([a, b])
+
+
+def _axis_stack_sample_st(fn, *, min_rank: int) -> st.SearchStrategy[OpSample]:
+    """Joint shape: two tensors of identical shape, rank>=min_rank.
+
+    `vstack` / `hstack` / `dstack` accept matching shapes (after torch's
+    upstream rank-promotion); we feed them with already-promoted ranks
+    to match what the t2n emitter sees.
+    """
+
+    @st.composite
+    def _draw(draw) -> OpSample:
+        rank = draw(st.integers(min_value=min_rank, max_value=4))
+        shape = tuple(
+            draw(
+                st.lists(
+                    st.integers(min_value=1, max_value=4),
+                    min_size=rank,
+                    max_size=rank,
+                )
+            )
+        )
+        a = draw(
+            tensor_st(
+                shape,
+                torch.float32,
+                finite=True,
+                domain=Interval(-10.0, 10.0),
+            )
+        )
+        b = draw(
+            tensor_st(
+                shape,
+                torch.float32,
+                finite=True,
+                domain=Interval(-10.0, 10.0),
+            )
+        )
+        return OpSample(inputs=(a, b), module=_StackList(fn))
+
+    return _draw()
+
+
+def _axis_split_sample_st(
+    fn, *, dim: int, min_rank: int
+) -> st.SearchStrategy[OpSample]:
+    """`vsplit/hsplit/dsplit(x, sections)`: int sections only.
+
+    Torch's `*split` (unlike `tensor_split`) requires the dim to be
+    divisible by `sections`. The strategy enforces that by drawing
+    `sections` then `multiplier` and setting `shape[dim] = sections *
+    multiplier`.
+    """
+
+    @st.composite
+    def _draw(draw) -> OpSample:
+        rank = draw(st.integers(min_value=min_rank, max_value=4))
+        shape = list(
+            draw(
+                st.lists(
+                    st.integers(min_value=1, max_value=4),
+                    min_size=rank,
+                    max_size=rank,
+                )
+            )
+        )
+        sections = draw(st.integers(min_value=1, max_value=3))
+        mult = draw(st.integers(min_value=1, max_value=3))
+        shape[dim] = sections * mult
+        x = draw(
+            tensor_st(
+                tuple(shape),
+                torch.float32,
+                finite=True,
+                domain=Interval(-10.0, 10.0),
+            )
+        )
+        return OpSample(
+            inputs=(x,),
+            module=UnaryPrimitive(partial(fn, sections=sections)),
+        )
+
+    return _draw()
+
+
+def _count_nonzero_sample_st(*, all_dims: bool) -> st.SearchStrategy[OpSample]:
+    """`torch.count_nonzero(x, dim?)`: half-density mask via {-1, 0, 1}."""
+
+    @st.composite
+    def _draw(draw) -> OpSample:
+        rank = draw(st.integers(min_value=1, max_value=4))
+        shape = tuple(
+            draw(
+                st.lists(
+                    st.integers(min_value=1, max_value=5),
+                    min_size=rank,
+                    max_size=rank,
+                )
+            )
+        )
+        # Sparse-ish input with a real mix of zeros so the count
+        # actually exercises the reduce, not just `numel`.
+        x = draw(
+            tensor_st(shape, torch.int64, finite=True, domain=Interval(-1, 1))
+        )
+        if all_dims:
+            op_fn = lambda t: torch.count_nonzero(t)  # noqa: E731
+        else:
+            dim = draw(st.integers(min_value=0, max_value=rank - 1))
+            op_fn = (lambda d: lambda t: torch.count_nonzero(t, dim=d))(dim)
+        return OpSample(inputs=(x,), module=UnaryPrimitive(op_fn))
+
+    return _draw()
+
+
+def _alias_specs() -> T.List[OpSpec]:
+    return [
+        OpSpec(
+            name="dstack",
+            sample_st=_axis_stack_sample_st(torch.dstack, min_rank=3),
+            tolerance=TractCheckTolerance.EXACT,
+            dynamic_axes_compatible=True,
+        ),
+        OpSpec(
+            name="vsplit",
+            sample_st=_axis_split_sample_st(torch.vsplit, dim=0, min_rank=2),
+            tolerance=TractCheckTolerance.EXACT,
+        ),
+        OpSpec(
+            name="hsplit",
+            sample_st=_axis_split_sample_st(torch.hsplit, dim=1, min_rank=2),
+            tolerance=TractCheckTolerance.EXACT,
+        ),
+        OpSpec(
+            name="dsplit",
+            sample_st=_axis_split_sample_st(torch.dsplit, dim=2, min_rank=3),
+            tolerance=TractCheckTolerance.EXACT,
+        ),
+        OpSpec(
+            name="count_nonzero-dim",
+            sample_st=_count_nonzero_sample_st(all_dims=False),
+            tolerance=TractCheckTolerance.EXACT,
+            dynamic_axes_compatible=True,
+        ),
+        OpSpec(
+            name="count_nonzero-all",
+            sample_st=_count_nonzero_sample_st(all_dims=True),
+            tolerance=TractCheckTolerance.EXACT,
+            dynamic_axes_compatible=True,
+        ),
+    ]
+
+
 # 3D conv/pool + numerical helpers + classifiers
 
 SPECS = (
@@ -2551,4 +2713,5 @@ SPECS = (
     *_selector_specs(),
     *_index_pixel_specs(),
     *_shape_utility_specs(),
+    *_alias_specs(),
 )

--- a/torch_to_nnef/op/aten/concat.py
+++ b/torch_to_nnef/op/aten/concat.py
@@ -84,9 +84,14 @@ def stack(g, node, name_to_tensor, torch_graph, **kwargs):
     )
 
 
-@OP_REGISTRY.register()
-def vstack(g, node, name_to_tensor, torch_graph, **kwargs):
-    """Map PyTorch: 'aten:vstack' to NNEF."""
+def _emit_axis_stack(g, node, name_to_tensor, torch_graph, axis, op_label):
+    """Emit `concat(values, axis=N)` for the v/h/d-stack family.
+
+    Assumes the inputs already have the right rank (torch's
+    rank-promotion for 1-D / 2-D inputs happens upstream of the aten
+    op, so we only see fully-shaped tensors here). Iterates the
+    FixedTensorList and feeds each item to NNEF `concat`.
+    """
     input_node = node.inputs[0]
     assert isinstance(input_node, FixedTensorList)
     inputs = []
@@ -97,7 +102,7 @@ def vstack(g, node, name_to_tensor, torch_graph, **kwargs):
         ):
             torch_graph.printall()
             raise T2NErrorNotImplemented(
-                f"vstack with input_item: {input_item}"
+                f"{op_label} with input_item: {input_item}"
             )
         tensor_ref = get_or_add_tensor_variable_in_nnef(
             g, input_item, name_to_tensor
@@ -109,39 +114,32 @@ def vstack(g, node, name_to_tensor, torch_graph, **kwargs):
         name_to_tensor,
         "concat",
         inputs=inputs,
-        attrs={"axis": 0},
+        attrs={"axis": axis},
         ensure_tuple=False,
     )
+
+
+@OP_REGISTRY.register()
+def vstack(g, node, name_to_tensor, torch_graph, **kwargs):
+    """Map PyTorch: 'aten:vstack' to NNEF (`concat(axis=0)`)."""
+    _emit_axis_stack(g, node, name_to_tensor, torch_graph, 0, "vstack")
 
 
 @OP_REGISTRY.register()
 def hstack(g, node, name_to_tensor, torch_graph, **kwargs):
-    """Map PyTorch: 'aten:hstack' to NNEF."""
-    input_node = node.inputs[0]
-    assert isinstance(input_node, FixedTensorList)
-    inputs = []
-    for input_item in input_node.data:
-        if (
-            input_item.export_name not in name_to_tensor
-            and input_item.data is None
-        ):
-            torch_graph.printall()
-            raise T2NErrorNotImplemented(
-                f"vstack with input_item: {input_item}"
-            )
-        tensor_ref = get_or_add_tensor_variable_in_nnef(
-            g, input_item, name_to_tensor
-        )
-        inputs.append(tensor_ref)
-    add_single_output_op(
-        g,
-        node,
-        name_to_tensor,
-        "concat",
-        inputs=inputs,
-        attrs={"axis": 1},
-        ensure_tuple=False,
-    )
+    """Map PyTorch: 'aten:hstack' to NNEF (`concat(axis=1)`)."""
+    _emit_axis_stack(g, node, name_to_tensor, torch_graph, 1, "hstack")
+
+
+@OP_REGISTRY.register()
+def dstack(g, node, name_to_tensor, torch_graph, **kwargs):
+    """Map PyTorch: 'aten:dstack' to NNEF (`concat(axis=2)`).
+
+    `dstack` stacks tensors along the third axis (depth). Torch
+    promotes 1-D / 2-D inputs to 3-D before reaching the aten op, so
+    we only see rank>=3 inputs here.
+    """
+    _emit_axis_stack(g, node, name_to_tensor, torch_graph, 2, "dstack")
 
 
 @OP_REGISTRY.register()

--- a/torch_to_nnef/op/aten/matmul.py
+++ b/torch_to_nnef/op/aten/matmul.py
@@ -34,9 +34,21 @@ def _get_padding_same_symetric(
 
 
 @OP_REGISTRY.register(
-    # most registred exist in aten but should not be necessary since
-    # _convolution_mode should be rewired to those
-    ["_convolution_mode", "convolution", "conv1d", "conv2d", "conv3d"]
+    # Most of these aten symbols never reach the trace -- pytorch
+    # decomposes them through `aten::_convolution_mode` or
+    # `aten::_convolution` upstream. `convolution_overrideable` is an
+    # autograd hook for backend-specific dispatch; same story. The
+    # registrations are kept so the docs/contributing/supported_operators
+    # page reflects reality (every torch.nn `Conv*d` and
+    # `F.conv*d` form does work in practice via the canonical lowering).
+    [
+        "_convolution_mode",
+        "convolution",
+        "convolution_overrideable",
+        "conv1d",
+        "conv2d",
+        "conv3d",
+    ]
 )
 def _convolution_mode(
     g, node, name_to_tensor, null_ref, inference_target, **kwargs
@@ -123,31 +135,31 @@ def _convolution_mode(
     )
 
 
-@OP_REGISTRY.register()
-def _convolution(g, node, name_to_tensor, null_ref, inference_target, **kwargs):
-    """Map PyTorch: 'aten:_convolution' to NNEF."""
-    (
-        input_node,
-        weight_node,
-        bias_node,
-        stride_node,
-        padding_node,
-        dilation_node,
-        transposed_node,
-        _,  # output_padding_name
-        groups_node,
-        _,  # benchmark_name
-        _,  # deterministic_name
-        _,  # cuda_enabled
-        _,  # allow_tf32
-    ) = node.inputs
+def _emit_conv(
+    g,
+    node,
+    name_to_tensor,
+    null_ref,
+    inference_target,
+    *,
+    input_node,
+    weight_node,
+    bias_node,
+    stride,
+    padding,
+    dilation,
+    groups,
+    transposed,
+):
+    """Emit NNEF `conv` / `deconv` for the convolution family.
 
-    stride = stride_node.data
-    dilation = dilation_node.data
-    padding = padding_node.data
-    groups = groups_node.data
-    transposed = transposed_node.data
-
+    Shared body of `aten::_convolution` and `aten::conv_transpose{1,2,3}d`.
+    Emits `deconv` for `transposed=True`, else `conv`. Transposed convs
+    need a weight repack: torch stores
+    `(in_channels, out_channels // groups, *spatial)`; NNEF's `deconv`
+    expects `(in_channels // groups, out_channels, *spatial)`. The
+    grouped-then-transposed reshape is in-place on `weight_node.data`.
+    """
     # TODO: problem with conv on qtensor for weight or bias
     # since these params can now be dynamic
     # >> all following code need to happen in the graph
@@ -203,6 +215,85 @@ def _convolution(g, node, name_to_tensor, null_ref, inference_target, **kwargs):
             "border": "constant",
         },
         force_consistent_inputs_shapes=False,
+    )
+
+
+@OP_REGISTRY.register()
+def _convolution(g, node, name_to_tensor, null_ref, inference_target, **kwargs):
+    """Map PyTorch: 'aten:_convolution' to NNEF."""
+    (
+        input_node,
+        weight_node,
+        bias_node,
+        stride_node,
+        padding_node,
+        dilation_node,
+        transposed_node,
+        _,  # output_padding_name
+        groups_node,
+        _,  # benchmark_name
+        _,  # deterministic_name
+        _,  # cuda_enabled
+        _,  # allow_tf32
+    ) = node.inputs
+    _emit_conv(
+        g,
+        node,
+        name_to_tensor,
+        null_ref,
+        inference_target,
+        input_node=input_node,
+        weight_node=weight_node,
+        bias_node=bias_node,
+        stride=stride_node.data,
+        padding=padding_node.data,
+        dilation=dilation_node.data,
+        groups=groups_node.data,
+        transposed=transposed_node.data,
+    )
+
+
+@OP_REGISTRY.register(
+    ["conv_transpose1d", "conv_transpose2d", "conv_transpose3d"]
+)
+def conv_transpose_nd(
+    g, node, name_to_tensor, null_ref, inference_target, **kwargs
+):
+    """Map PyTorch: 'aten:conv_transpose{1,2,3}d' to NNEF.
+
+    Marked `CompositeImplicitAutograd` upstream, so PyTorch usually
+    decomposes these to `aten::_convolution(transposed=True)` before
+    the trace reaches t2n. Registering them anyway keeps the support
+    page accurate and gives a working path if PyTorch ever stops
+    decomposing for some platform.
+
+    Signature: `(input, weight, bias?, stride, padding, output_padding,
+    groups, dilation)` -- 8 positional args.
+    """
+    (
+        input_node,
+        weight_node,
+        bias_node,
+        stride_node,
+        padding_node,
+        _,  # output_padding -- not propagated to NNEF deconv
+        groups_node,
+        dilation_node,
+    ) = node.inputs
+    _emit_conv(
+        g,
+        node,
+        name_to_tensor,
+        null_ref,
+        inference_target,
+        input_node=input_node,
+        weight_node=weight_node,
+        bias_node=bias_node,
+        stride=stride_node.data,
+        padding=padding_node.data,
+        dilation=dilation_node.data,
+        groups=groups_node.data,
+        transposed=True,
     )
 
 

--- a/torch_to_nnef/op/aten/reducer.py
+++ b/torch_to_nnef/op/aten/reducer.py
@@ -194,6 +194,119 @@ def prod(node, op_helper, inference_target, **kwargs):
 
 
 @OP_REGISTRY.register()
+def count_nonzero(node, op_helper, inference_target, **kwargs):
+    """Map PyTorch: 'aten:count_nonzero' to NNEF.
+
+    `count_nonzero(input, dim=None)` returns the number of non-zero
+    elements in `input` along `dim` (or globally when `dim=None`) as
+    an int64 scalar / reduced tensor. Decomposed as
+    `ne(x, 0) -> tract_core_cast(i64) -> sum_reduce(axes) -> squeeze`.
+
+    Intermediate NTensors are built explicitly with their kept-dim
+    shapes (rather than going through `add_single_output_op_from_nnef_tensors`
+    which inherits `node.outputs[0].shape`). The shared helper
+    declares the rank-0 final shape on every intermediate, which then
+    trips the rank-align pass: `ne(input, scalar_zero)` sees both
+    operands as "scalar-like" and squeezes the rank-1 input to scalar
+    before evaluating, panicking the downstream `sum_reduce`.
+    """
+    assert len(node.outputs) == 1
+    if not isinstance(inference_target, TractNNEF):
+        raise T2NErrorNotImplemented(inference_target)
+    g = op_helper.g
+    name_to_tensor = op_helper.name_to_tensor
+    input_node = node.inputs[0]
+    dim_node = node.inputs[1] if len(node.inputs) > 1 else None
+    rank = input_node.rank
+    if dim_node is None or dim_node.data is None:
+        axes = list(range(rank))
+    elif isinstance(dim_node.data, int):
+        axes = [pick_axis(input_node, dim_node.data)]
+    else:
+        axes = [pick_axis(input_node, d) for d in dim_node.data]
+
+    inp_ref = op_helper.get_or_add_tensor_variable_in_nnef(input_node)
+    onode = node.outputs[0]
+    base = onode.export_name
+    # The dtype on intermediate NTensors is informational; tract reads
+    # the actual datum type from the op output. Stamping the input's
+    # dtype is fine -- the cast op below switches it to i64.
+    np_dtype = input_node.np_dtype
+
+    def _intermediate(name, shape):
+        t = NTensor(g, name, dtype=np_dtype, shape=tuple(shape))
+        name_to_tensor[name] = t
+        return t
+
+    zero_const = PythonConstant(
+        name=f"{base}_cnz_zero",
+        data=torch.zeros((), dtype=input_node.dtype),
+    )
+    zero_ref = op_helper.get_or_add_tensor_variable_in_nnef(zero_const)
+    full_shape = list(input_node.shape)
+    mask = _intermediate(f"{base}_cnz_mask", full_shape)
+    cast_and_add_nnef_operation(
+        name_to_tensor=name_to_tensor,
+        graph=g,
+        type="ne",
+        name=f"{mask.name}_op",
+        inputs=(inp_ref, zero_ref),
+        outputs=(mask,),
+        attribs={},
+    )
+    int_t = _intermediate(f"{base}_cnz_int", full_shape)
+    cast_and_add_nnef_operation(
+        name_to_tensor=name_to_tensor,
+        graph=g,
+        type="tract_core_cast",
+        name=f"{int_t.name}_op",
+        inputs=(mask,),
+        outputs=(int_t,),
+        attribs={"to": TORCH_DTYPE_TO_TRACT_STR[torch.int64]},
+    )
+    out_ref = op_helper.get_or_add_tensor_variable_in_nnef(
+        onode, prevent_variable=True
+    )
+    if rank == 0:
+        # Edge case: rank-0 input. `sum_reduce` with empty axes is a
+        # no-op identity; emit a reshape to materialize the final
+        # NTensor with the right name.
+        cast_and_add_nnef_operation(
+            name_to_tensor=name_to_tensor,
+            graph=g,
+            type="reshape",
+            name=f"{base}_cnz_reshape",
+            inputs=(int_t,),
+            outputs=(out_ref,),
+            attribs={"shape": []},
+        )
+        return ["tract_core"]
+    kd_shape = list(full_shape)
+    for ax in axes:
+        kd_shape[ax] = 1
+    kd = _intermediate(f"{base}_cnz_kd", kd_shape)
+    cast_and_add_nnef_operation(
+        name_to_tensor=name_to_tensor,
+        graph=g,
+        type="sum_reduce",
+        name=f"{kd.name}_op",
+        inputs=(int_t,),
+        outputs=(kd,),
+        attribs={"axes": axes},
+    )
+    cast_and_add_nnef_operation(
+        name_to_tensor=name_to_tensor,
+        graph=g,
+        type="squeeze",
+        name=f"{base}_cnz_squeeze",
+        inputs=(kd,),
+        outputs=(out_ref,),
+        attribs={"axes": axes},
+    )
+    return ["tract_core"]
+
+
+@OP_REGISTRY.register()
 def aminmax(node, op_helper, **kwargs):
     """Map PyTorch: 'aten:aminmax' to NNEF.
 

--- a/torch_to_nnef/op/aten/split.py
+++ b/torch_to_nnef/op/aten/split.py
@@ -158,29 +158,20 @@ def _tensor_split_compute_boundaries(dim_size, sections_or_indices):
     return [int(i) for i in sections_or_indices]
 
 
-@OP_REGISTRY.register()
-def tensor_split(g, node, name_to_tensor, **kwargs):
-    """Map PyTorch: 'aten:tensor_split' to NNEF.
+def _emit_axis_tensor_split(
+    g, node, name_to_tensor, *, input_node, sections_node, axis, op_label
+):
+    """Emit one `slice` per output chunk along `axis`.
 
-    Generalised split that allows uneven sections (unlike `split` /
-    `chunk`). Two overloads are supported:
-
-    * `tensor_split(self, sections: int, dim)` -- divide into N
-      approximately-equal chunks; the first `dim_size % N` chunks
-      take one extra element.
-    * `tensor_split(self, indices: int[], dim)` -- split at the
-      given boundary indices; produces `len(indices) + 1` chunks.
-
-    Each output is a `slice` of the input along `dim`. Static-axis
-    only: the boundaries depend on `dim_size`, which we resolve at
-    trace time.
+    Shared between `tensor_split` and the fixed-axis aliases
+    `vsplit` / `hsplit` / `dsplit`. Boundaries are pre-computed from
+    the static `dim_size`. `axis` is already resolved to a
+    non-negative index by the caller.
     """
-    input_node, sections_node, axis_node = node.inputs
-    axis = pick_axis(input_node, axis_node.data)
     dim_size = input_node.shape[axis]
     if not isinstance(dim_size, int):
         raise T2NErrorNotImplemented(
-            f"tensor_split on dynamic axis {axis} not supported"
+            f"{op_label} on dynamic axis {axis} not supported"
         )
 
     raw = sections_node.data
@@ -196,7 +187,7 @@ def tensor_split(g, node, name_to_tensor, **kwargs):
     boundaries = _tensor_split_compute_boundaries(dim_size, sections_or_indices)
     bounds = [0, *boundaries, dim_size]
     assert len(bounds) - 1 == len(node.outputs), (
-        f"tensor_split: expected {len(bounds) - 1} outputs, "
+        f"{op_label}: expected {len(bounds) - 1} outputs, "
         f"got {len(node.outputs)}"
     )
 
@@ -223,3 +214,65 @@ def tensor_split(g, node, name_to_tensor, **kwargs):
                 "stride": [1],
             },
         )
+
+
+@OP_REGISTRY.register()
+def tensor_split(g, node, name_to_tensor, **kwargs):
+    """Map PyTorch: 'aten:tensor_split' to NNEF.
+
+    Generalised split that allows uneven sections (unlike `split` /
+    `chunk`). Two overloads are supported:
+
+    * `tensor_split(self, sections: int, dim)` -- divide into N
+      approximately-equal chunks; the first `dim_size % N` chunks
+      take one extra element.
+    * `tensor_split(self, indices: int[], dim)` -- split at the
+      given boundary indices; produces `len(indices) + 1` chunks.
+
+    Each output is a `slice` of the input along `dim`. Static-axis
+    only: the boundaries depend on `dim_size`, which we resolve at
+    trace time.
+    """
+    input_node, sections_node, axis_node = node.inputs
+    axis = pick_axis(input_node, axis_node.data)
+    _emit_axis_tensor_split(
+        g,
+        node,
+        name_to_tensor,
+        input_node=input_node,
+        sections_node=sections_node,
+        axis=axis,
+        op_label="tensor_split",
+    )
+
+
+def _emit_fixed_axis_split(g, node, name_to_tensor, axis, op_label):
+    """Shared body for `vsplit` / `hsplit` / `dsplit` (fixed axis 0/1/2)."""
+    input_node, sections_node = node.inputs
+    _emit_axis_tensor_split(
+        g,
+        node,
+        name_to_tensor,
+        input_node=input_node,
+        sections_node=sections_node,
+        axis=axis,
+        op_label=op_label,
+    )
+
+
+@OP_REGISTRY.register()
+def vsplit(g, node, name_to_tensor, **kwargs):
+    """Map PyTorch: 'aten:vsplit' (`tensor_split` along axis 0) to NNEF."""
+    _emit_fixed_axis_split(g, node, name_to_tensor, 0, "vsplit")
+
+
+@OP_REGISTRY.register()
+def hsplit(g, node, name_to_tensor, **kwargs):
+    """Map PyTorch: 'aten:hsplit' (`tensor_split` along axis 1) to NNEF."""
+    _emit_fixed_axis_split(g, node, name_to_tensor, 1, "hsplit")
+
+
+@OP_REGISTRY.register()
+def dsplit(g, node, name_to_tensor, **kwargs):
+    """Map PyTorch: 'aten:dsplit' (`tensor_split` along axis 2) to NNEF."""
+    _emit_fixed_axis_split(g, node, name_to_tensor, 2, "dsplit")


### PR DESCRIPTION
## Summary

Cleans up a chunk of the "looks unsupported on the support page but actually works" false negatives, plus a few real ops.

**Cosmetic registry-only (no behaviour change)**:
- `conv_transpose1d`, `conv_transpose2d`, `conv_transpose3d`, `convolution_overrideable`. PyTorch's `CompositeImplicitAutograd` dispatch decomposes these to `aten::_convolution(transposed=True)` before the trace reaches t2n, so they never fire in practice. Registering them anyway makes the support page reflect reality (every `nn.ConvTranspose*d` / `F.conv_transpose*d` form already works in practice). The `_emit_conv` helper is factored out of `_convolution` so a real `aten::conv_transpose{1,2,3}d` would still route correctly if it ever surfaces directly.

**New emitters**:
- **`dstack`**: alias of `cat(axis=2)`. Slots into the existing v/h-stack pattern in `concat.py` via a shared `_emit_axis_stack` helper.
- **`vsplit` / `hsplit` / `dsplit`**: aliases of `tensor_split` along axes 0 / 1 / 2. Boundary computation factored into `_emit_axis_tensor_split` shared with the existing `tensor_split`.
- **`count_nonzero(input, dim?)`**: decomposed as `ne(x, 0) -> tract_core_cast(i64) -> sum_reduce(axes) -> squeeze`.

## Why explicit intermediate NTensors for `count_nonzero`

The shared `add_single_output_op_from_nnef_tensors` inherits `node.outputs[0].shape` (the rank-0 final count) on every intermediate. That breaks `ne(rank_1_input, scalar_zero)`: the rank-align pass sees both operands as scalar-like and the declared output as rank-0, then squeezes the rank-1 input to scalar before evaluating. The downstream `sum_reduce` then panics with `index out of bounds: the len is 0 but the index is 0`. Building intermediates with their actual kept-dim shapes via `_intermediate` sidesteps that.

## Test plan

- [x] Smoke test 19 cases across the new ops -> all pass against `TractNNEF.latest()`
- [x] Proptest specs (6) added: `dstack`, `vsplit`, `hsplit`, `dsplit`, `count_nonzero-dim`, `count_nonzero-all`. `dstack` and the two `count_nonzero` specs opted into the dyn-axes variant -> 9 pass, 3 dyn-axes skip
- [x] `ruff check` / `ruff format` clean