### PR TITLE
feat(op): no-tract-change batch (bucketize / searchsorted / index_put / embedding_bag / affine_grid / linalg_cross / linalg_matrix_norm / conv_tbc)

### DIFF
--- a/tests/proptest/op_specs/shape.py
+++ b/tests/proptest/op_specs/shape.py
@@ -2703,6 +2703,190 @@ def _alias_specs() -> T.List[OpSpec]:
     ]
 
 
+def _index_put_sample_st(accumulate: bool) -> st.SearchStrategy[OpSample]:
+    """`out[idx] = src` (or `+=` when `accumulate=True`) along axis 0.
+
+    Only the single-axis form is exercised -- the t2n emitter rejects
+    multi-axis / mask indices with `NotImplementedError`. Indices are
+    drawn unique for the overwrite case (torch's `index_put_(...,
+    accumulate=False)` with duplicate indices has undefined ordering).
+    """
+
+    @st.composite
+    def _draw(draw) -> OpSample:
+        rank = draw(st.integers(min_value=1, max_value=3))
+        shape = tuple(
+            draw(
+                st.lists(
+                    st.integers(min_value=2, max_value=4),
+                    min_size=rank,
+                    max_size=rank,
+                )
+            )
+        )
+        idx_len = draw(st.integers(min_value=1, max_value=shape[0]))
+        idx = draw(
+            tensor_st(
+                (idx_len,),
+                torch.int64,
+                finite=True,
+                domain=Interval(0, shape[0] - 1),
+            )
+        )
+        idx_unique = torch.unique(idx)
+        if not accumulate and idx_unique.numel() != idx.numel():
+            idx = idx_unique
+            idx_len = int(idx.numel())
+        src_shape = list(shape)
+        src_shape[0] = idx_len
+        src = draw(
+            tensor_st(
+                tuple(src_shape),
+                torch.float32,
+                finite=True,
+                domain=Interval(-10.0, 10.0),
+            )
+        )
+        x = draw(
+            tensor_st(
+                shape,
+                torch.float32,
+                finite=True,
+                domain=Interval(-10.0, 10.0),
+            )
+        )
+        op_fn = (
+            lambda acc: (
+                lambda t, i, s: t.clone().index_put_((i,), s, accumulate=acc)
+            )
+        )(accumulate)
+        return OpSample(inputs=(x, idx, src), module=TernaryPrimitive(op_fn))
+
+    return _draw()
+
+
+def _bucketize_sample_st() -> st.SearchStrategy[OpSample]:
+    """`torch.bucketize(input, boundaries)` over a 1-D sorted boundary."""
+
+    @st.composite
+    def _draw(draw) -> OpSample:
+        rank = draw(st.integers(min_value=1, max_value=3))
+        shape = tuple(
+            draw(
+                st.lists(
+                    st.integers(min_value=1, max_value=4),
+                    min_size=rank,
+                    max_size=rank,
+                )
+            )
+        )
+        n_b = draw(st.integers(min_value=1, max_value=4))
+        x = draw(
+            tensor_st(
+                shape,
+                torch.float32,
+                finite=True,
+                domain=Interval(-5.0, 5.0),
+            )
+        )
+        # boundaries must be sorted
+        raw_b = draw(
+            tensor_st(
+                (n_b,),
+                torch.float32,
+                finite=True,
+                domain=Interval(-5.0, 5.0),
+            )
+        )
+        b, _ = torch.sort(raw_b)
+        right = draw(st.booleans())
+        op_fn = (lambda r: lambda xx, bb: torch.bucketize(xx, bb, right=r))(
+            right
+        )
+        return OpSample(inputs=(x, b), module=BinaryPrimitive(op_fn))
+
+    return _draw()
+
+
+def _searchsorted_sample_st() -> st.SearchStrategy[OpSample]:
+    """`torch.searchsorted(sorted_seq, values)`: args swapped vs bucketize."""
+
+    @st.composite
+    def _draw(draw) -> OpSample:
+        n_seq = draw(st.integers(min_value=1, max_value=4))
+        raw_seq = draw(
+            tensor_st(
+                (n_seq,),
+                torch.float32,
+                finite=True,
+                domain=Interval(-5.0, 5.0),
+            )
+        )
+        seq, _ = torch.sort(raw_seq)
+        rank = draw(st.integers(min_value=1, max_value=3))
+        vals_shape = tuple(
+            draw(
+                st.lists(
+                    st.integers(min_value=1, max_value=4),
+                    min_size=rank,
+                    max_size=rank,
+                )
+            )
+        )
+        vals = draw(
+            tensor_st(
+                vals_shape,
+                torch.float32,
+                finite=True,
+                domain=Interval(-5.0, 5.0),
+            )
+        )
+        right = draw(st.booleans())
+        op_fn = (lambda r: lambda s, v: torch.searchsorted(s, v, right=r))(
+            right
+        )
+        return OpSample(inputs=(seq, vals), module=BinaryPrimitive(op_fn))
+
+    return _draw()
+
+
+def _bucketize_searchsorted_specs() -> T.List[OpSpec]:
+    return [
+        OpSpec(
+            name="bucketize",
+            sample_st=_bucketize_sample_st(),
+            tolerance=TractCheckTolerance.EXACT,
+            dynamic_axes_compatible=True,
+        ),
+        OpSpec(
+            name="searchsorted",
+            sample_st=_searchsorted_sample_st(),
+            tolerance=TractCheckTolerance.EXACT,
+            dynamic_axes_compatible=True,
+        ),
+        # index_put(accumulate=False) just overwrites -- the
+        # `reduction` NNEF attr is ignored on tract 0.22.1 (default
+        # path is overwrite), so it works on stable.
+        OpSpec(
+            name="index_put",
+            sample_st=_index_put_sample_st(accumulate=False),
+            tolerance=TractCheckTolerance.EXACT,
+        ),
+        # accumulate=True needs the ScatterReduction support which
+        # landed in tract 0.23.0-dev.4; same xfail as the rest of the
+        # scatter family.
+        OpSpec(
+            name="index_put-accum-xfail",
+            sample_st=_index_put_sample_st(accumulate=True),
+            tolerance=TractCheckTolerance.APPROXIMATE,
+            xfail_reason=(
+                "tract 0.22.1 lacks ScatterReduction; t2n hard-errors "
+                "below 0.23.0-dev.4 when accumulate=True."
+            ),
+        ),
+    ]
+
+
 # 3D conv/pool + numerical helpers + classifiers
 
 SPECS = (
@@ -2714,4 +2898,5 @@ SPECS = (
     *_index_pixel_specs(),
     *_shape_utility_specs(),
     *_alias_specs(),
+    *_bucketize_searchsorted_specs(),
 )

--- a/tests/proptest/op_specs/specialty.py
+++ b/tests/proptest/op_specs/specialty.py
@@ -590,6 +590,209 @@ def _distance_specs() -> T.List[OpSpec]:
     ]
 
 
+def _embedding_bag_static_offsets_sample_st(
+    mode: str,
+) -> st.SearchStrategy[OpSample]:
+    """`F.embedding_bag(idx, weight, offsets, mode=...)`: static offsets.
+
+    Offsets are baked into the traced module via a `torch.tensor`
+    constant, so they appear as a constant in the t2n IR (the
+    typical case in real models is either this or the 2-D-input
+    flattening, which produces the same effect upstream).
+    """
+
+    @st.composite
+    def _draw(draw) -> OpSample:
+        num_emb = draw(st.integers(min_value=2, max_value=6))
+        emb_dim = draw(st.integers(min_value=2, max_value=4))
+        n_bags = draw(st.integers(min_value=1, max_value=3))
+        # Each bag size in [1, 3]; total `k` is sum of sizes.
+        sizes = [
+            draw(st.integers(min_value=1, max_value=3)) for _ in range(n_bags)
+        ]
+        k = sum(sizes)
+        idx = draw(
+            tensor_st(
+                (k,),
+                torch.int64,
+                finite=True,
+                domain=Interval(0, num_emb - 1),
+            )
+        )
+        weights = draw(
+            tensor_st(
+                (num_emb, emb_dim),
+                torch.float32,
+                finite=True,
+                domain=Interval(-5.0, 5.0),
+            )
+        )
+        offsets_list = [0]
+        for s in sizes[:-1]:
+            offsets_list.append(offsets_list[-1] + s)
+        offsets_t = torch.tensor(offsets_list, dtype=torch.int64)
+
+        class _EB(nn.Module):
+            def __init__(self, off, m):
+                super().__init__()
+                self.register_buffer("off", off)
+                self.m = m
+
+            def forward(self, w, ix):
+                return F.embedding_bag(ix, w, self.off, mode=self.m)
+
+        return OpSample(inputs=(weights, idx), module=_EB(offsets_t, mode))
+
+    return _draw()
+
+
+def _affine_grid_sample_st() -> st.SearchStrategy[OpSample]:
+    """`F.affine_grid(theta, (N, C, H, W), align_corners)` -- 2-D only."""
+
+    @st.composite
+    def _draw(draw) -> OpSample:
+        n = draw(st.integers(min_value=1, max_value=2))
+        c = draw(st.integers(min_value=1, max_value=3))
+        h = draw(st.integers(min_value=2, max_value=5))
+        w = draw(st.integers(min_value=2, max_value=5))
+        align_corners = draw(st.booleans())
+        theta = draw(
+            tensor_st(
+                (n, 2, 3),
+                torch.float32,
+                finite=True,
+                domain=Interval(-2.0, 2.0),
+            )
+        )
+
+        class _AG(nn.Module):
+            def __init__(self, nn_, cc, hh, ww, ac):
+                super().__init__()
+                self.size = (nn_, cc, hh, ww)
+                self.ac = ac
+
+            def forward(self, th):
+                return F.affine_grid(th, self.size, align_corners=self.ac)
+
+        return OpSample(inputs=(theta,), module=_AG(n, c, h, w, align_corners))
+
+    return _draw()
+
+
+def _conv_tbc_sample_st() -> st.SearchStrategy[OpSample]:
+    """`torch.conv_tbc(x, w, b, pad)` with baked weight/bias."""
+
+    @st.composite
+    def _draw(draw) -> OpSample:
+        kernel = draw(st.integers(min_value=1, max_value=3))
+        c_in = draw(st.integers(min_value=1, max_value=3))
+        c_out = draw(st.integers(min_value=1, max_value=3))
+        b = draw(st.integers(min_value=1, max_value=2))
+        t = draw(st.integers(min_value=kernel + 1, max_value=8))
+        pad = draw(st.integers(min_value=0, max_value=kernel // 2))
+        x = draw(
+            tensor_st(
+                (t, b, c_in),
+                torch.float32,
+                finite=True,
+                domain=Interval(-2.0, 2.0),
+            )
+        )
+
+        class _CTBC(nn.Module):
+            def __init__(self, kk, ci, co, pp):
+                super().__init__()
+                self.w = nn.Parameter(torch.randn(kk, ci, co))
+                self.bias = nn.Parameter(torch.randn(co))
+                self.pad = pp
+
+            def forward(self, xx):
+                return torch.conv_tbc(xx, self.w, self.bias, pad=self.pad)
+
+        return OpSample(
+            inputs=(x,), module=_CTBC(kernel, c_in, c_out, pad).eval()
+        )
+
+    return _draw()
+
+
+def _linalg_matrix_norm_sample_st() -> st.SearchStrategy[OpSample]:
+    """`torch.linalg.matrix_norm(x, 'fro', dim, keepdim)`."""
+
+    @st.composite
+    def _draw(draw) -> OpSample:
+        rank = draw(st.integers(min_value=2, max_value=4))
+        shape = tuple(
+            draw(
+                st.lists(
+                    st.integers(min_value=2, max_value=5),
+                    min_size=rank,
+                    max_size=rank,
+                )
+            )
+        )
+        keepdim = draw(st.booleans())
+        x = draw(
+            tensor_st(
+                shape,
+                torch.float32,
+                finite=True,
+                domain=Interval(-5.0, 5.0),
+            )
+        )
+        op_fn = (
+            lambda kd: (
+                lambda t: torch.linalg.matrix_norm(t, ord="fro", keepdim=kd)
+            )
+        )(keepdim)
+        return OpSample(inputs=(x,), module=UnaryPrimitive(op_fn))
+
+    return _draw()
+
+
+def _no_tract_change_specs() -> T.List[OpSpec]:
+    return [
+        OpSpec(
+            name="embedding_bag-sum",
+            sample_st=_embedding_bag_static_offsets_sample_st("sum"),
+            tolerance=TractCheckTolerance.CLOSE,
+        ),
+        OpSpec(
+            name="embedding_bag-mean",
+            sample_st=_embedding_bag_static_offsets_sample_st("mean"),
+            tolerance=TractCheckTolerance.CLOSE,
+        ),
+        OpSpec(
+            name="embedding_bag-max",
+            sample_st=_embedding_bag_static_offsets_sample_st("max"),
+            tolerance=TractCheckTolerance.EXACT,
+        ),
+        OpSpec(
+            name="affine_grid",
+            sample_st=_affine_grid_sample_st(),
+            tolerance=TractCheckTolerance.CLOSE,
+            # Final reshape declares `(N, H, W, 2)` with a concrete
+            # `N` that clashes with the dyn-axis symbol -- same
+            # pattern as meshgrid / tensor_split.
+            dynamic_axes_skip_reason=(
+                "affine_grid_generator's final reshape declares "
+                "concrete N; symbolic-dim threading needs follow-up."
+            ),
+        ),
+        OpSpec(
+            name="conv_tbc",
+            sample_st=_conv_tbc_sample_st(),
+            tolerance=TractCheckTolerance.CLOSE,
+        ),
+        OpSpec(
+            name="linalg_matrix_norm_fro",
+            sample_st=_linalg_matrix_norm_sample_st(),
+            tolerance=TractCheckTolerance.CLOSE,
+            dynamic_axes_compatible=True,
+        ),
+    ]
+
+
 # Constructors (input-less in PyTorch, wrapped with a shape-coupled input)
 # + advanced index + SDPA
 
@@ -598,4 +801,5 @@ SPECS = (
     *_prelu_glu_einsum_specs(),
     *_max_pool_dropout_specs(),
     *_distance_specs(),
+    *_no_tract_change_specs(),
 )

--- a/torch_to_nnef/op/aten/math.py
+++ b/torch_to_nnef/op/aten/math.py
@@ -960,7 +960,7 @@ def cdist(node, op_helper, **kwargs):
     return ["cdist"]
 
 
-@OP_REGISTRY.register()
+@OP_REGISTRY.register(torch_op_ids=["cross", "linalg_cross"])
 def cross(node, op_helper, **kwargs):
     """Map PyTorch: 'aten:cross' to NNEF via a fragment.
 

--- a/torch_to_nnef/op/aten/matmul.py
+++ b/torch_to_nnef/op/aten/matmul.py
@@ -298,6 +298,81 @@ def conv_transpose_nd(
 
 
 @OP_REGISTRY.register()
+def conv_tbc(
+    g, node, name_to_tensor, null_ref, op_helper, inference_target, **kwargs
+):
+    """Map PyTorch: 'aten:conv_tbc' to NNEF.
+
+    `conv_tbc(input, weight, bias, pad)` is a 1-D convolution over a
+    `(T, B, C)` input -- time-batch-channel layout -- with weight
+    `(kernel, C_in, C_out)`. Equivalent semantically to
+    `conv1d(input.permute(1, 2, 0), weight.permute(2, 1, 0), bias,
+    padding=pad).permute(2, 0, 1)`, which is exactly the
+    `permute -> conv -> permute` chain we emit.
+    """
+    if not isinstance(inference_target, TractNNEF):
+        raise T2NErrorNotImplemented(inference_target)
+    input_node, weight_node, bias_node, pad_node = node.inputs
+    pad = int(pad_node.data)
+    # Repack weight from (kernel, C_in, C_out) to (C_out, C_in, kernel).
+    if weight_node.data is None:
+        raise T2NErrorNotImplemented(
+            "conv_tbc needs static weight (got graph-input weight)"
+        )
+    weight_node.set_data(
+        weight_node.data.permute(2, 1, 0).contiguous(), force_shape=True
+    )
+    # Permute input from (T, B, C) to (B, C, T).
+    inp_ref = op_helper.get_or_add_tensor_variable_in_nnef(input_node)
+    inp_bct = op_helper.add_single_output_op_from_nnef_tensors(
+        node,
+        "transpose",
+        inputs=inp_ref,
+        attrs={"axes": [1, 2, 0]},
+        output_tensor_name_suffix="ctbc_pre",
+    )
+    weight_ref = op_helper.get_or_add_tensor_variable_in_nnef(weight_node)
+    bias_ref = (
+        op_helper.get_or_add_tensor_variable_in_nnef(bias_node)
+        if bias_node.data is not None
+        else null_ref
+    )
+    # 1-D conv: output (B, C_out, T_out).
+    onode = node.outputs[0]
+    t_out, b_out, c_out = onode.shape
+    conv_out = NTensor(
+        g,
+        f"{onode.export_name}_ctbc_conv",
+        dtype=onode.np_dtype,
+        shape=(b_out, c_out, t_out),
+    )
+    name_to_tensor[conv_out.name] = conv_out
+    cast_and_add_nnef_operation(
+        name_to_tensor=name_to_tensor,
+        graph=g,
+        type="conv",
+        name=f"{conv_out.name}_op",
+        inputs=(inp_bct, weight_ref, bias_ref),
+        outputs=(conv_out,),
+        attribs={
+            "dilation": [1],
+            "padding": [(pad, pad)],
+            "stride": [1],
+            "groups": 1,
+            "border": "constant",
+        },
+        force_consistent_inputs_shapes=False,
+    )
+    # Permute back to (T, B, C_out).
+    op_helper.add_single_output_op_from_nnef_tensors(
+        node,
+        "transpose",
+        inputs=conv_out,
+        attrs={"axes": [2, 0, 1]},
+    )
+
+
+@OP_REGISTRY.register()
 def linear(g, node, name_to_tensor, null_ref, inference_target, **kwargs):
     """Map PyTorch: 'aten:linear' to NNEF."""
     (

--- a/torch_to_nnef/op/aten/norm.py
+++ b/torch_to_nnef/op/aten/norm.py
@@ -230,13 +230,32 @@ def instance_norm(node, op_helper, **kwargs):
 
 
 @OP_REGISTRY.register(
-    ["norm", "linalg_vector_norm", "linalg_norm", "frobenius_norm"]
+    [
+        "norm",
+        "linalg_vector_norm",
+        "linalg_norm",
+        "linalg_matrix_norm",
+        "frobenius_norm",
+    ]
 )
 def norm(g, node, name_to_tensor, inference_target, **kwargs):
     """NOTE this is only the normed vector."""
     if node.kind in ["aten::linalg_vector_norm", "aten::linalg_norm"]:
         # new in PyTorch 2.0
         input_node, p_node, axes_node, keep_dim_node, _ = node.inputs
+    elif node.kind == "aten::linalg_matrix_norm":
+        # signature: (input, ord_str, dims, keepdim, dtype)
+        # Only the Frobenius norm is supported here; nuclear / spectral
+        # need SVD which tract doesn't expose.
+        input_node, ord_node, axes_node, keep_dim_node, _dtype_node = (
+            node.inputs
+        )
+        if ord_node.data != "fro":
+            raise T2NErrorNotImplemented(
+                f"linalg_matrix_norm with ord={ord_node.data!r} not "
+                "supported (only 'fro' currently)"
+            )
+        p_node = PythonConstant(name=f"{node.outputs[0].name}_p_node", data=2)
     elif node.kind == "aten::frobenius_norm":
         input_node, axes_node, keep_dim_node = node.inputs
         p_node = PythonConstant(name=f"{node.outputs[0].name}_p_node", data=2)

--- a/torch_to_nnef/op/aten/selector.py
+++ b/torch_to_nnef/op/aten/selector.py
@@ -4,6 +4,7 @@ from copy import copy
 import nnef
 import numpy as np
 import torch
+from nnef_tools.model import Tensor as NTensor
 
 from torch_to_nnef.dtypes import TORCH_DTYPE_TO_TRACT_STR, TORCH_TO_NUMPY_DTYPE
 from torch_to_nnef.exceptions import T2NErrorNotImplemented
@@ -587,6 +588,235 @@ def embedding(node, op_helper, inference_target, **kwargs):
             attrs={"axes": [0]},
         )
     return custom_fragments
+
+
+_EMBEDDING_BAG_MODE_TO_REDUCE = {
+    0: "sum_reduce",
+    1: "mean_reduce",
+    2: "max_reduce",
+}
+
+
+@OP_REGISTRY.register()
+def embedding_bag(
+    g, node, name_to_tensor, op_helper, inference_target, **kwargs
+):
+    """Map PyTorch: 'aten:embedding_bag' to NNEF.
+
+    `embedding_bag(weight, indices, offsets, scale_grad, mode, sparse,
+    per_sample_weights, include_last_offset, padding_idx)` returns a
+    4-tuple in torch (`output, offset2bag, bag_size, max_indices`); we
+    only emit the first output (the bag-reduced embeddings). The
+    other three are gradient bookkeeping and typically aren't
+    consumed in inference traces.
+
+    Decomposition (statically-known offsets):
+
+      emb = tract_core_gather(weight, indices, axis=0)  # (K, D)
+      for each bag b: bag_out_b = reduce(emb[offsets[b]:end_b], axis=0)
+      output = concat(bag_outs, axis=0)  # (B, D)
+
+    When all bag sizes are equal (e.g. from a 2-D input flattened
+    upstream), the slow per-bag slice path collapses to a single
+    `reshape + reduce + squeeze` shortcut.
+
+    Limitations: mode in {sum, mean, max}; `per_sample_weights`,
+    `padding_idx`, and `include_last_offset=True` not yet supported.
+    """
+    if not isinstance(inference_target, TractNNEF):
+        raise T2NErrorNotImplemented(inference_target)
+    if len(node.inputs) < 5:
+        raise T2NErrorNotImplemented(
+            f"embedding_bag with {len(node.inputs)} inputs"
+        )
+    weight_node = node.inputs[0]
+    indices_node = node.inputs[1]
+    offsets_node = node.inputs[2]
+    mode_node = node.inputs[4]
+    per_sample_weights_node = node.inputs[6] if len(node.inputs) > 6 else None
+    include_last_offset_node = node.inputs[7] if len(node.inputs) > 7 else None
+    padding_idx_node = node.inputs[8] if len(node.inputs) > 8 else None
+
+    mode = int(mode_node.data)
+    if mode not in _EMBEDDING_BAG_MODE_TO_REDUCE:
+        raise T2NErrorNotImplemented(f"embedding_bag mode={mode}")
+    if per_sample_weights_node is not None and not (
+        isinstance(per_sample_weights_node, PythonConstant)
+        and per_sample_weights_node.data is None
+    ):
+        raise T2NErrorNotImplemented(
+            "embedding_bag with per_sample_weights not supported"
+        )
+    if (
+        include_last_offset_node is not None
+        and isinstance(include_last_offset_node, PythonConstant)
+        and bool(include_last_offset_node.data)
+    ):
+        raise T2NErrorNotImplemented(
+            "embedding_bag with include_last_offset=True not supported"
+        )
+    if padding_idx_node is not None and not (
+        isinstance(padding_idx_node, PythonConstant)
+        and padding_idx_node.data in (None, -1)
+    ):
+        raise T2NErrorNotImplemented(
+            "embedding_bag with explicit padding_idx not supported"
+        )
+
+    offsets_data = offsets_node.data
+    if offsets_data is None:
+        raise T2NErrorNotImplemented(
+            "embedding_bag requires statically-known offsets"
+        )
+    if hasattr(offsets_data, "tolist"):
+        offsets_data = offsets_data.tolist()
+    offsets_list = [int(x) for x in offsets_data]
+    k = int(indices_node.shape[0])
+    boundaries = [*offsets_list, k]
+    bag_sizes = [
+        boundaries[i + 1] - boundaries[i] for i in range(len(offsets_list))
+    ]
+    n_bags = len(bag_sizes)
+    d_dim = int(weight_node.shape[1])
+
+    onode = node.outputs[0]
+    base = onode.export_name
+    np_dtype = onode.np_dtype
+    reduce_op = _EMBEDDING_BAG_MODE_TO_REDUCE[mode]
+
+    # Gather emb = weight[indices]  -- shape (k, D)
+    emb = NTensor(g, f"{base}_eb_emb", dtype=np_dtype, shape=(k, d_dim))
+    name_to_tensor[f"{base}_eb_emb"] = emb
+    weight_ref = get_or_add_tensor_variable_in_nnef(
+        g, weight_node, name_to_tensor
+    )
+    indices_ref = get_or_add_tensor_variable_in_nnef(
+        g, indices_node, name_to_tensor
+    )
+    cast_and_add_nnef_operation(
+        name_to_tensor=name_to_tensor,
+        graph=g,
+        type="tract_core_gather",
+        name=f"{emb.name}_op",
+        inputs=(weight_ref, indices_ref),
+        outputs=(emb,),
+        attribs={"axis": 0},
+        force_consistent_inputs_shapes=False,
+    )
+
+    out_ref = op_helper.get_or_add_tensor_variable_in_nnef(
+        onode, prevent_variable=True
+    )
+
+    # Fast path: all bag sizes equal -> reshape + reduce + squeeze.
+    if len(set(bag_sizes)) == 1 and bag_sizes[0] > 0:
+        bag_size = bag_sizes[0]
+        reshaped = NTensor(
+            g,
+            f"{base}_eb_reshape",
+            dtype=np_dtype,
+            shape=(n_bags, bag_size, d_dim),
+        )
+        name_to_tensor[reshaped.name] = reshaped
+        cast_and_add_nnef_operation(
+            name_to_tensor=name_to_tensor,
+            graph=g,
+            type="reshape",
+            name=f"{reshaped.name}_op",
+            inputs=(emb,),
+            outputs=(reshaped,),
+            attribs={"shape": [n_bags, bag_size, d_dim]},
+        )
+        kd = NTensor(
+            g,
+            f"{base}_eb_kd",
+            dtype=np_dtype,
+            shape=(n_bags, 1, d_dim),
+        )
+        name_to_tensor[kd.name] = kd
+        cast_and_add_nnef_operation(
+            name_to_tensor=name_to_tensor,
+            graph=g,
+            type=reduce_op,
+            name=f"{kd.name}_op",
+            inputs=(reshaped,),
+            outputs=(kd,),
+            attribs={"axes": [1]},
+        )
+        cast_and_add_nnef_operation(
+            name_to_tensor=name_to_tensor,
+            graph=g,
+            type="squeeze",
+            name=f"{base}_eb_squeeze",
+            inputs=(kd,),
+            outputs=(out_ref,),
+            attribs={"axes": [1]},
+        )
+        return ["tract_core"]
+
+    # General path: per-bag slice + reduce, then concat. Variable bag
+    # sizes are supported as long as no bag is empty.
+    if any(s <= 0 for s in bag_sizes):
+        raise T2NErrorNotImplemented(
+            f"embedding_bag with empty bag (sizes={bag_sizes}); torch "
+            "fills empty bags with zeros which would need a different "
+            "emit path"
+        )
+    per_bag = []
+    for b, (start, size) in enumerate(
+        zip(boundaries[:-1], bag_sizes, strict=True)
+    ):
+        slc = NTensor(
+            g,
+            f"{base}_eb_b{b}_slice",
+            dtype=np_dtype,
+            shape=(size, d_dim),
+        )
+        name_to_tensor[slc.name] = slc
+        cast_and_add_nnef_operation(
+            name_to_tensor=name_to_tensor,
+            graph=g,
+            type="slice",
+            name=f"{slc.name}_op",
+            inputs=(emb,),
+            outputs=(slc,),
+            attribs={
+                "axes": [0],
+                "begin": [start],
+                "end": [start + size],
+                "stride": [1],
+            },
+        )
+        reduced = NTensor(
+            g,
+            f"{base}_eb_b{b}_kd",
+            dtype=np_dtype,
+            shape=(1, d_dim),
+        )
+        name_to_tensor[reduced.name] = reduced
+        cast_and_add_nnef_operation(
+            name_to_tensor=name_to_tensor,
+            graph=g,
+            type=reduce_op,
+            name=f"{reduced.name}_op",
+            inputs=(slc,),
+            outputs=(reduced,),
+            attribs={"axes": [0]},
+        )
+        per_bag.append(reduced)
+    # `concat` takes a list-typed `values` arg in NNEF -- pass as a
+    # Python list (not tuple) so the serializer writes `[...]`.
+    cast_and_add_nnef_operation(
+        name_to_tensor=name_to_tensor,
+        graph=g,
+        type="concat",
+        name=f"{base}_eb_concat",
+        inputs=list(per_bag),
+        outputs=(out_ref,),
+        attribs={"axis": 0},
+        force_consistent_inputs_shapes=False,
+    )
+    return ["tract_core"]
 
 
 @OP_REGISTRY.register()
@@ -1440,6 +1670,66 @@ def index_add(g, node, name_to_tensor, op_helper, inference_target, **kwargs):
 
 
 @OP_REGISTRY.register()
+def index_put(g, node, name_to_tensor, op_helper, inference_target, **kwargs):
+    """Map PyTorch: 'aten:index_put' (and `_`) to NNEF.
+
+    `index_put(self, indices: Tensor?[], values, accumulate)` writes
+    `values` into `self` at the positions indexed by `indices`. Only
+    the `len(indices) == 1` case with a single 1-D int index along
+    axis 0 is supported -- that's the `out[idx] = values` pattern that
+    covers most realistic usage. Lowered to
+    `tract_core_scatter_elements` with reduction `'add'` (when
+    `accumulate=True`) or `'none'` (overwrite).
+    """
+    if not isinstance(inference_target, TractNNEF):
+        raise T2NErrorNotImplemented(inference_target)
+    # pylint: disable-next=import-outside-toplevel
+    from torch_to_nnef.torch_graph import FixedTensorList
+
+    input_node, indices_node, values_node, accumulate_node = node.inputs
+    if bool(accumulate_node.data):
+        # Only the accumulate=True path needs the `reduction` NNEF attr
+        # (which landed in tract 0.23.0-dev.4). Overwrite (=False) is the
+        # default scatter_elements behaviour, available since at least
+        # 0.21.x.
+        _check_scatter_reduction_supported(inference_target)
+    if not isinstance(indices_node, FixedTensorList):
+        raise T2NErrorNotImplemented(
+            f"index_put indices must be a FixedTensorList, got {indices_node!r}"
+        )
+    real_indices = [
+        idx
+        for idx in indices_node.data
+        if not (isinstance(idx, PythonConstant) and idx.data is None)
+    ]
+    if len(real_indices) != 1:
+        raise T2NErrorNotImplemented(
+            f"index_put with {len(real_indices)} non-None indices "
+            "not supported (only single-axis form covered)"
+        )
+    (index_node,) = real_indices
+    if index_node.dtype not in (torch.int32, torch.int64):
+        raise T2NErrorNotImplemented(
+            f"index_put with bool / mask index not supported "
+            f"(got dtype {index_node.dtype}); use scatter or "
+            "masked_fill for the mask form"
+        )
+    accumulate = bool(accumulate_node.data)
+    src_ref = op_helper.get_or_add_tensor_variable_in_nnef(values_node)
+    return _emit_index_family_scatter(
+        g,
+        name_to_tensor,
+        op_helper,
+        node,
+        input_node,
+        dim=0,
+        index_node=index_node,
+        src_ref=src_ref,
+        reduction="add" if accumulate else "none",
+    )
+
+
+@OP_REGISTRY.register()
 def take(node, op_helper, inference_target, **kwargs):
     """Map PyTorch: 'aten:take' to NNEF.
 
@@ -1477,3 +1767,173 @@ def take(node, op_helper, inference_target, **kwargs):
         force_consistent_inputs_shapes=False,
     )
     return ["tract_core"]
+
+
+def _emit_bucketize(node, op_helper, *, input_node, boundaries_node, right):
+    """Shared body for `bucketize` / `searchsorted`.
+
+    For each value `v` in `input_node`, count the number of
+    `boundaries` that satisfy the comparison: `<` for `right=False`
+    (default; lower-bound search) or `<=` for `right=True`
+    (upper-bound search). The count is the inserted-position index.
+
+    Decomposition (1-D `boundaries` -- the typical case):
+
+        x_exp     = unsqueeze(input, axes=[input.rank])  # (..., 1)
+        cmp_mask  = (lt | le)(boundaries, x_exp)         # (..., N) bool
+        cmp_int   = tract_core_cast(cmp_mask, to='i64')
+        kept_dim  = sum_reduce(cmp_int, axes=[input.rank])
+        output    = squeeze(kept_dim, axes=[input.rank])
+    """
+    if boundaries_node.rank != 1:
+        raise T2NErrorNotImplemented(
+            "bucketize/searchsorted with N-D boundaries (per-row) "
+            "not supported; only 1-D boundaries shared across input"
+        )
+    g = op_helper.g
+    name_to_tensor = op_helper.name_to_tensor
+    onode = node.outputs[0]
+    base = onode.export_name
+    rank = input_node.rank
+    last_axis = rank  # axis we add for broadcast and reduce over
+
+    inp_ref = op_helper.get_or_add_tensor_variable_in_nnef(input_node)
+    bnd_ref = op_helper.get_or_add_tensor_variable_in_nnef(boundaries_node)
+
+    inp_shape = list(input_node.shape)
+    n_b = boundaries_node.shape[0]
+    bcast_shape = inp_shape + [int(n_b) if isinstance(n_b, int) else n_b]
+    np_dtype = onode.np_dtype
+
+    def _intermediate(name, shape):
+        t = NTensor(g, name, dtype=np_dtype, shape=tuple(shape))
+        name_to_tensor[name] = t
+        return t
+
+    # Unsqueeze input on the trailing axis.
+    x_exp = _intermediate(f"{base}_bk_x_exp", inp_shape + [1])
+    cast_and_add_nnef_operation(
+        name_to_tensor=name_to_tensor,
+        graph=g,
+        type="unsqueeze",
+        name=f"{x_exp.name}_op",
+        inputs=(inp_ref,),
+        outputs=(x_exp,),
+        attribs={"axes": [last_axis]},
+    )
+    cmp_op = "le" if right else "lt"
+    mask = _intermediate(f"{base}_bk_mask", bcast_shape)
+    cast_and_add_nnef_operation(
+        name_to_tensor=name_to_tensor,
+        graph=g,
+        type=cmp_op,
+        name=f"{mask.name}_op",
+        inputs=(bnd_ref, x_exp),
+        outputs=(mask,),
+        attribs={},
+    )
+    int_t = _intermediate(f"{base}_bk_int", bcast_shape)
+    cast_and_add_nnef_operation(
+        name_to_tensor=name_to_tensor,
+        graph=g,
+        type="tract_core_cast",
+        name=f"{int_t.name}_op",
+        inputs=(mask,),
+        outputs=(int_t,),
+        attribs={"to": TORCH_DTYPE_TO_TRACT_STR[torch.int64]},
+    )
+    kd_shape = inp_shape + [1]
+    kd = _intermediate(f"{base}_bk_kd", kd_shape)
+    cast_and_add_nnef_operation(
+        name_to_tensor=name_to_tensor,
+        graph=g,
+        type="sum_reduce",
+        name=f"{kd.name}_op",
+        inputs=(int_t,),
+        outputs=(kd,),
+        attribs={"axes": [last_axis]},
+    )
+    out_ref = op_helper.get_or_add_tensor_variable_in_nnef(
+        onode, prevent_variable=True
+    )
+    cast_and_add_nnef_operation(
+        name_to_tensor=name_to_tensor,
+        graph=g,
+        type="squeeze",
+        name=f"{base}_bk_squeeze",
+        inputs=(kd,),
+        outputs=(out_ref,),
+        attribs={"axes": [last_axis]},
+    )
+    return ["tract_core"]
+
+
+@OP_REGISTRY.register()
+def bucketize(node, op_helper, inference_target, **kwargs):
+    """Map PyTorch: 'aten:bucketize' to NNEF.
+
+    `bucketize(input, boundaries, out_int32, right)` returns the index
+    in `boundaries` (1-D, sorted) for each value in `input`. Decomposed
+    via broadcast-compare + sum_reduce of the comparison mask.
+    """
+    if not isinstance(inference_target, TractNNEF):
+        raise T2NErrorNotImplemented(inference_target)
+    input_node, boundaries_node, _out_int32_node, right_node = node.inputs
+    return _emit_bucketize(
+        node,
+        op_helper,
+        input_node=input_node,
+        boundaries_node=boundaries_node,
+        right=bool(right_node.data),
+    )
+
+
+@OP_REGISTRY.register()
+def searchsorted(node, op_helper, inference_target, **kwargs):
+    """Map PyTorch: 'aten:searchsorted' to NNEF.
+
+    `searchsorted(sorted_seq, values, out_int32, right, side, sorter)`
+    is `bucketize` with the args swapped (`sorted_seq` plays the role
+    of `boundaries`, `values` plays the role of `input`). The `side`
+    string overload supersedes `right` when present.
+    """
+    if not isinstance(inference_target, TractNNEF):
+        raise T2NErrorNotImplemented(inference_target)
+    sorted_seq_node = node.inputs[0]
+    values_node = node.inputs[1]
+    right_node = node.inputs[3] if len(node.inputs) > 3 else None
+    side_node = node.inputs[4] if len(node.inputs) > 4 else None
+    if (
+        side_node is not None
+        and not isinstance(side_node, PythonConstant)
+        and side_node.data not in (None, "left", "right")
+    ):
+        raise T2NErrorNotImplemented(
+            f"searchsorted side={side_node.data!r} not supported"
+        )
+    if (
+        side_node is not None
+        and isinstance(side_node, PythonConstant)
+        and side_node.data == "right"
+    ):
+        right = True
+    elif right_node is not None:
+        right = bool(right_node.data) if right_node.data is not None else False
+    else:
+        right = False
+    sorter_node = node.inputs[5] if len(node.inputs) > 5 else None
+    if (
+        sorter_node is not None
+        and not isinstance(sorter_node, PythonConstant)
+        and sorter_node.data is not None
+    ):
+        raise T2NErrorNotImplemented(
+            "searchsorted with explicit `sorter` not supported"
+        )
+    return _emit_bucketize(
+        node,
+        op_helper,
+        input_node=values_node,
+        boundaries_node=sorted_seq_node,
+        right=right,
+    )

--- a/torch_to_nnef/op/aten/selector.py
+++ b/torch_to_nnef/op/aten/selector.py
@@ -682,9 +682,7 @@ def _embedding_bag_uniform_path(
         outputs=(reshaped,),
         attribs={"shape": [n_bags, bag_size, d_dim]},
     )
-    kd = NTensor(
-        g, f"{base}_eb_kd", dtype=np_dtype, shape=(n_bags, 1, d_dim)
-    )
+    kd = NTensor(g, f"{base}_eb_kd", dtype=np_dtype, shape=(n_bags, 1, d_dim))
     name_to_tensor[kd.name] = kd
     cast_and_add_nnef_operation(
         name_to_tensor=name_to_tensor,

--- a/torch_to_nnef/op/aten/selector.py
+++ b/torch_to_nnef/op/aten/selector.py
@@ -597,34 +597,14 @@ _EMBEDDING_BAG_MODE_TO_REDUCE = {
 }
 
 
-@OP_REGISTRY.register()
-def embedding_bag(
-    g, node, name_to_tensor, op_helper, inference_target, **kwargs
-):
-    """Map PyTorch: 'aten:embedding_bag' to NNEF.
+def _embedding_bag_validate(node):
+    """Validate `aten::embedding_bag` inputs and pull out the args.
 
-    `embedding_bag(weight, indices, offsets, scale_grad, mode, sparse,
-    per_sample_weights, include_last_offset, padding_idx)` returns a
-    4-tuple in torch (`output, offset2bag, bag_size, max_indices`); we
-    only emit the first output (the bag-reduced embeddings). The
-    other three are gradient bookkeeping and typically aren't
-    consumed in inference traces.
-
-    Decomposition (statically-known offsets):
-
-      emb = tract_core_gather(weight, indices, axis=0)  # (K, D)
-      for each bag b: bag_out_b = reduce(emb[offsets[b]:end_b], axis=0)
-      output = concat(bag_outs, axis=0)  # (B, D)
-
-    When all bag sizes are equal (e.g. from a 2-D input flattened
-    upstream), the slow per-bag slice path collapses to a single
-    `reshape + reduce + squeeze` shortcut.
-
-    Limitations: mode in {sum, mean, max}; `per_sample_weights`,
-    `padding_idx`, and `include_last_offset=True` not yet supported.
+    Raises `T2NErrorNotImplemented` for the cases the current emitter
+    can't handle (mode out of {sum, mean, max}, `per_sample_weights`,
+    `include_last_offset`, explicit `padding_idx`, dynamic offsets).
+    Returns `(weight_node, indices_node, offsets_list, mode)`.
     """
-    if not isinstance(inference_target, TractNNEF):
-        raise T2NErrorNotImplemented(inference_target)
     if len(node.inputs) < 5:
         raise T2NErrorNotImplemented(
             f"embedding_bag with {len(node.inputs)} inputs"
@@ -670,92 +650,75 @@ def embedding_bag(
         )
     if hasattr(offsets_data, "tolist"):
         offsets_data = offsets_data.tolist()
-    offsets_list = [int(x) for x in offsets_data]
-    k = int(indices_node.shape[0])
-    boundaries = [*offsets_list, k]
-    bag_sizes = [
-        boundaries[i + 1] - boundaries[i] for i in range(len(offsets_list))
-    ]
-    n_bags = len(bag_sizes)
-    d_dim = int(weight_node.shape[1])
+    return weight_node, indices_node, [int(x) for x in offsets_data], mode
 
-    onode = node.outputs[0]
-    base = onode.export_name
-    np_dtype = onode.np_dtype
-    reduce_op = _EMBEDDING_BAG_MODE_TO_REDUCE[mode]
 
-    # Gather emb = weight[indices]  -- shape (k, D)
-    emb = NTensor(g, f"{base}_eb_emb", dtype=np_dtype, shape=(k, d_dim))
-    name_to_tensor[f"{base}_eb_emb"] = emb
-    weight_ref = get_or_add_tensor_variable_in_nnef(
-        g, weight_node, name_to_tensor
+def _embedding_bag_uniform_path(
+    g,
+    name_to_tensor,
+    base,
+    np_dtype,
+    emb,
+    out_ref,
+    n_bags,
+    bag_size,
+    d_dim,
+    reduce_op,
+):
+    """Equal-bag-size shortcut: reshape + reduce on axis 1 + squeeze."""
+    reshaped = NTensor(
+        g,
+        f"{base}_eb_reshape",
+        dtype=np_dtype,
+        shape=(n_bags, bag_size, d_dim),
     )
-    indices_ref = get_or_add_tensor_variable_in_nnef(
-        g, indices_node, name_to_tensor
+    name_to_tensor[reshaped.name] = reshaped
+    cast_and_add_nnef_operation(
+        name_to_tensor=name_to_tensor,
+        graph=g,
+        type="reshape",
+        name=f"{reshaped.name}_op",
+        inputs=(emb,),
+        outputs=(reshaped,),
+        attribs={"shape": [n_bags, bag_size, d_dim]},
+    )
+    kd = NTensor(
+        g, f"{base}_eb_kd", dtype=np_dtype, shape=(n_bags, 1, d_dim)
+    )
+    name_to_tensor[kd.name] = kd
+    cast_and_add_nnef_operation(
+        name_to_tensor=name_to_tensor,
+        graph=g,
+        type=reduce_op,
+        name=f"{kd.name}_op",
+        inputs=(reshaped,),
+        outputs=(kd,),
+        attribs={"axes": [1]},
     )
     cast_and_add_nnef_operation(
         name_to_tensor=name_to_tensor,
         graph=g,
-        type="tract_core_gather",
-        name=f"{emb.name}_op",
-        inputs=(weight_ref, indices_ref),
-        outputs=(emb,),
-        attribs={"axis": 0},
-        force_consistent_inputs_shapes=False,
+        type="squeeze",
+        name=f"{base}_eb_squeeze",
+        inputs=(kd,),
+        outputs=(out_ref,),
+        attribs={"axes": [1]},
     )
 
-    out_ref = op_helper.get_or_add_tensor_variable_in_nnef(
-        onode, prevent_variable=True
-    )
 
-    # Fast path: all bag sizes equal -> reshape + reduce + squeeze.
-    if len(set(bag_sizes)) == 1 and bag_sizes[0] > 0:
-        bag_size = bag_sizes[0]
-        reshaped = NTensor(
-            g,
-            f"{base}_eb_reshape",
-            dtype=np_dtype,
-            shape=(n_bags, bag_size, d_dim),
-        )
-        name_to_tensor[reshaped.name] = reshaped
-        cast_and_add_nnef_operation(
-            name_to_tensor=name_to_tensor,
-            graph=g,
-            type="reshape",
-            name=f"{reshaped.name}_op",
-            inputs=(emb,),
-            outputs=(reshaped,),
-            attribs={"shape": [n_bags, bag_size, d_dim]},
-        )
-        kd = NTensor(
-            g,
-            f"{base}_eb_kd",
-            dtype=np_dtype,
-            shape=(n_bags, 1, d_dim),
-        )
-        name_to_tensor[kd.name] = kd
-        cast_and_add_nnef_operation(
-            name_to_tensor=name_to_tensor,
-            graph=g,
-            type=reduce_op,
-            name=f"{kd.name}_op",
-            inputs=(reshaped,),
-            outputs=(kd,),
-            attribs={"axes": [1]},
-        )
-        cast_and_add_nnef_operation(
-            name_to_tensor=name_to_tensor,
-            graph=g,
-            type="squeeze",
-            name=f"{base}_eb_squeeze",
-            inputs=(kd,),
-            outputs=(out_ref,),
-            attribs={"axes": [1]},
-        )
-        return ["tract_core"]
-
-    # General path: per-bag slice + reduce, then concat. Variable bag
-    # sizes are supported as long as no bag is empty.
+def _embedding_bag_variable_path(
+    g,
+    name_to_tensor,
+    base,
+    np_dtype,
+    emb,
+    out_ref,
+    boundaries,
+    bag_sizes,
+    d_dim,
+    reduce_op,
+):
+    """Variable-bag-size path: per-bag slice + reduce + concat."""
     if any(s <= 0 for s in bag_sizes):
         raise T2NErrorNotImplemented(
             f"embedding_bag with empty bag (sizes={bag_sizes}); torch "
@@ -767,10 +730,7 @@ def embedding_bag(
         zip(boundaries[:-1], bag_sizes, strict=True)
     ):
         slc = NTensor(
-            g,
-            f"{base}_eb_b{b}_slice",
-            dtype=np_dtype,
-            shape=(size, d_dim),
+            g, f"{base}_eb_b{b}_slice", dtype=np_dtype, shape=(size, d_dim)
         )
         name_to_tensor[slc.name] = slc
         cast_and_add_nnef_operation(
@@ -788,10 +748,7 @@ def embedding_bag(
             },
         )
         reduced = NTensor(
-            g,
-            f"{base}_eb_b{b}_kd",
-            dtype=np_dtype,
-            shape=(1, d_dim),
+            g, f"{base}_eb_b{b}_kd", dtype=np_dtype, shape=(1, d_dim)
         )
         name_to_tensor[reduced.name] = reduced
         cast_and_add_nnef_operation(
@@ -816,6 +773,96 @@ def embedding_bag(
         attribs={"axis": 0},
         force_consistent_inputs_shapes=False,
     )
+
+
+@OP_REGISTRY.register()
+def embedding_bag(
+    g, node, name_to_tensor, op_helper, inference_target, **kwargs
+):
+    """Map PyTorch: 'aten:embedding_bag' to NNEF.
+
+    `embedding_bag(weight, indices, offsets, scale_grad, mode, sparse,
+    per_sample_weights, include_last_offset, padding_idx)` returns a
+    4-tuple in torch (`output, offset2bag, bag_size, max_indices`); we
+    only emit the first output (the bag-reduced embeddings). The
+    other three are gradient bookkeeping and typically aren't
+    consumed in inference traces.
+
+    Decomposition (statically-known offsets):
+
+      emb = tract_core_gather(weight, indices, axis=0)  # (K, D)
+      for each bag b: bag_out_b = reduce(emb[offsets[b]:end_b], axis=0)
+      output = concat(bag_outs, axis=0)  # (B, D)
+
+    Equal bag sizes collapse to a single `reshape + reduce + squeeze`.
+    """
+    if not isinstance(inference_target, TractNNEF):
+        raise T2NErrorNotImplemented(inference_target)
+    weight_node, indices_node, offsets_list, mode = _embedding_bag_validate(
+        node
+    )
+    k = int(indices_node.shape[0])
+    boundaries = [*offsets_list, k]
+    bag_sizes = [
+        boundaries[i + 1] - boundaries[i] for i in range(len(offsets_list))
+    ]
+    n_bags = len(bag_sizes)
+    d_dim = int(weight_node.shape[1])
+
+    onode = node.outputs[0]
+    base = onode.export_name
+    np_dtype = onode.np_dtype
+    reduce_op = _EMBEDDING_BAG_MODE_TO_REDUCE[mode]
+
+    emb = NTensor(g, f"{base}_eb_emb", dtype=np_dtype, shape=(k, d_dim))
+    name_to_tensor[f"{base}_eb_emb"] = emb
+    weight_ref = get_or_add_tensor_variable_in_nnef(
+        g, weight_node, name_to_tensor
+    )
+    indices_ref = get_or_add_tensor_variable_in_nnef(
+        g, indices_node, name_to_tensor
+    )
+    cast_and_add_nnef_operation(
+        name_to_tensor=name_to_tensor,
+        graph=g,
+        type="tract_core_gather",
+        name=f"{emb.name}_op",
+        inputs=(weight_ref, indices_ref),
+        outputs=(emb,),
+        attribs={"axis": 0},
+        force_consistent_inputs_shapes=False,
+    )
+
+    out_ref = op_helper.get_or_add_tensor_variable_in_nnef(
+        onode, prevent_variable=True
+    )
+
+    if len(set(bag_sizes)) == 1 and bag_sizes[0] > 0:
+        _embedding_bag_uniform_path(
+            g,
+            name_to_tensor,
+            base,
+            np_dtype,
+            emb,
+            out_ref,
+            n_bags,
+            bag_sizes[0],
+            d_dim,
+            reduce_op,
+        )
+    else:
+        _embedding_bag_variable_path(
+            g,
+            name_to_tensor,
+            base,
+            np_dtype,
+            emb,
+            out_ref,
+            boundaries,
+            bag_sizes,
+            d_dim,
+            reduce_op,
+        )
     return ["tract_core"]
 
 

--- a/torch_to_nnef/op/aten/tensor_build.py
+++ b/torch_to_nnef/op/aten/tensor_build.py
@@ -866,3 +866,84 @@ def hann_window(g, node, name_to_tensor, **kwargs):
         force_shape=True,
     )
     add_tensor_variable_node_as_nnef_tensor(g, onode, name_to_tensor)
+
+
+@OP_REGISTRY.register()
+def affine_grid_generator(
+    g, node, name_to_tensor, op_helper, inference_target, **kwargs
+):
+    """Map PyTorch: 'aten:affine_grid_generator' to NNEF.
+
+    `affine_grid_generator(theta, size, align_corners)` builds a
+    sampling grid for `F.grid_sample`. The base grid -- a fixed set
+    of normalized coordinates in `[-1, 1]` (or pixel-centered for
+    `align_corners=False`) -- depends only on the output spatial
+    shape, so we bake it as a constant tensor at trace time. The
+    only runtime cost is a single matmul against `theta`.
+
+    Currently 2-D only (theta shape `(N, 2, 3)`, output `(N, H, W,
+    2)`). 3-D affine_grid would need a `(D*H*W, 4)` base grid +
+    reshape to `(N, D, H, W, 3)`.
+    """
+    if not isinstance(inference_target, TractNNEF):
+        raise T2NErrorNotImplemented(inference_target)
+    theta_node, size_node, align_corners_node = node.inputs
+    size_data = size_node.data
+    if hasattr(size_data, "tolist"):
+        size_data = size_data.tolist()
+    size = [int(x) for x in size_data]
+    align_corners = bool(align_corners_node.data)
+    if len(size) != 4:
+        raise T2NErrorNotImplemented(
+            f"affine_grid_generator: only 2-D (rank-4 size) supported; "
+            f"got size={size}"
+        )
+    n, _c, h, w = size
+    if tuple(theta_node.shape) != (n, 2, 3):
+        raise T2NErrorNotImplemented(
+            f"affine_grid_generator: theta shape must be (N, 2, 3); "
+            f"got {theta_node.shape}"
+        )
+
+    if align_corners:
+        ys = torch.linspace(-1.0, 1.0, h)
+        xs = torch.linspace(-1.0, 1.0, w)
+    else:
+        ys = torch.linspace(-1.0 + 1.0 / h, 1.0 - 1.0 / h, h)
+        xs = torch.linspace(-1.0 + 1.0 / w, 1.0 - 1.0 / w, w)
+    grid_y, grid_x = torch.meshgrid(ys, xs, indexing="ij")
+    base = torch.stack(
+        [grid_x.reshape(-1), grid_y.reshape(-1), torch.ones(h * w)],
+        dim=1,
+    )
+    # Bake base as (1, 3, H*W) so it matches theta's rank-3 shape for
+    # NNEF matmul (same-rank requirement).
+    base_t = base.t().contiguous().unsqueeze(0).to(theta_node.dtype)
+    onode = node.outputs[0]
+    base_const = PythonConstant(
+        name=f"{onode.name}_ag_base",
+        data=base_t,
+    )
+    base_ref = op_helper.get_or_add_tensor_variable_in_nnef(base_const)
+    theta_ref = op_helper.get_or_add_tensor_variable_in_nnef(theta_node)
+    mm_out = op_helper.add_single_output_op_from_nnef_tensors(
+        node,
+        "matmul",
+        inputs=[theta_ref, base_ref],
+        attrs={"transposeA": False, "transposeB": False},
+        output_tensor_name_suffix="ag_mm",
+        force_consistent_inputs_shapes=False,
+    )
+    transposed = op_helper.add_single_output_op_from_nnef_tensors(
+        node,
+        "transpose",
+        inputs=mm_out,
+        attrs={"axes": [0, 2, 1]},
+        output_tensor_name_suffix="ag_t",
+    )
+    op_helper.add_single_output_op_from_nnef_tensors(
+        node,
+        "reshape",
+        inputs=transposed,
+        attrs={"shape": [n, h, w, 2]},
+    )

--- a/torch_to_nnef/torch_graph/ir_op.py
+++ b/torch_to_nnef/torch_graph/ir_op.py
@@ -433,6 +433,18 @@ INFER_RULES = {
     "aten::index_add": InferRule(None, 1, identity=True),
     "aten::index_copy": InferRule(None, 1, identity=True),
     "aten::index_fill": InferRule(None, 1, identity=True),
+    # `aten::bucketize` / `aten::searchsorted`: torch's overload
+    # resolver fails on the shape-inference re-execution when the
+    # tracer hands all-zero placeholder tensors (the dispatcher
+    # picks an overload it can't satisfy). Output shape matches the
+    # input argument (`input` for bucketize, `values` for
+    # searchsorted) -- short-circuit instead of calling op_ref.
+    "aten::bucketize": InferRule(
+        lambda inp, *_: inp.shape, 1, require_dtype=False
+    ),
+    "aten::searchsorted": InferRule(
+        lambda _seq, vals, *_: vals.shape, 2, require_dtype=False
+    ),
     ATEN_EMBEDDING: InferRule(_infer_shape_embedding_output, 2),
     ATEN_MATMUL: InferRule(_infer_trace_result_matmul, 2),
     ATEN_LINEAR: InferRule(_infer_shape_linear_output, 2),


### PR DESCRIPTION
## Summary

Seven ops, all decomposed against existing NNEF stdlib + `tract_core_*` primitives -- zero tract-side changes needed.

- **`bucketize`** / **`searchsorted`** -> broadcast-compare against the sorted boundary axis (`lt` for `right=False`, `le` for `right=True`) + `tract_core_cast(i64)` + `sum_reduce` + `squeeze`.
- **`index_put`** -> `tract_core_scatter_elements` on the single-1-D-axis form (`out[idx] = values`). Reuses the `_emit_index_family_scatter` backbone. **`accumulate=False` works on stable tract 0.22.1**; `accumulate=True` keeps the same 0.23+ requirement as the rest of the scatter family.
- **`embedding_bag`** (`sum` / `mean` / `max`) -> `tract_core_gather` + per-bag slice + reduce + concat. Detects equal bag sizes and shortcuts to a single `reshape + reduce + squeeze`. Static offsets only (the typical case in real models, including the 2-D-input form which flattens upstream).
- **`affine_grid_generator`** (2-D) -> bake the (`H*W`, 3) homogeneous base grid as a constant at trace time, then `theta @ base.T -> transpose -> reshape` at runtime. The heavy lifting is at trace time; runtime cost is one matmul.
- **`linalg_cross`** -> straight alias of the existing `cross` emitter.
- **`linalg_matrix_norm`** (`ord='fro'`) -> joins the existing `norm` / `frobenius_norm` registration. Nuclear / spectral norms need SVD and stay unsupported.
- **`conv_tbc`** -> `transpose (T,B,C) -> (B,C,T)` + `conv1d` + `transpose back`. Weight repack from `(K, C_in, C_out)` to `(C_out, C_in, K)`.

## IR changes

Two new `InferRule` entries in `torch_to_nnef/torch_graph/ir_op.py` for `bucketize` and `searchsorted`: torch's overload resolver chokes on the shape-inference re-execution (all-zero placeholders pick an overload that can't be satisfied). Short-circuited with custom shape functions instead of calling `op_ref`.

## Test plan

- [x] Smoke-test 26 cases across the seven ops -> all pass against `TractNNEF.latest()` (0.22.1) except the `index_put-accum-xfail` case which expectedly needs tract 0.23.
- [x] Proptest specs (12 new): `bucketize`, `searchsorted`, `index_put`, `index_put-accum-xfail`, `embedding_bag-{sum,mean,max}`, `affine_grid`, `conv_tbc`, `linalg_matrix_norm_fro`. The existing `cross` spec covers `linalg_cross` (same emitter). `bucketize` / `searchsorted` / `linalg_matrix_norm_fro` opted into dyn-axes. -> 14 pass, 2 xfail, 6 skip.
- [x] `ruff check` / `ruff format` clean.