### PR TITLE
feat(op): thread dyn-axes through shape-derived op attrs

### DIFF
--- a/tests/proptest/op_specs/shape.py
+++ b/tests/proptest/op_specs/shape.py
@@ -2360,11 +2360,13 @@ def _index_pixel_specs() -> T.List[OpSpec]:
             ),
         ),
         # `take` uses `tract_core_gather`, no scatter reduction, so it
-        # passes on 0.22.1.
+        # passes on 0.22.1. The flatten reshape uses `[-1]` (deferred
+        # to tract / NNEF), so dyn-axes works without special-casing.
         OpSpec(
             name="take",
             sample_st=_take_sample_st(),
             tolerance=TractCheckTolerance.EXACT,
+            dynamic_axes_compatible=True,
         ),
         OpSpec(
             name="pixel_shuffle",
@@ -2497,27 +2499,20 @@ def _shape_utility_specs() -> T.List[OpSpec]:
             tolerance=TractCheckTolerance.EXACT,
             dynamic_axes_compatible=True,
         ),
-        # meshgrid emits a rank-changing reshape with a concrete numeric
-        # shape; under dyn-axes tract rejects the int-vs-symbolic mismatch
-        # ("A should be equal to N"). Threading dyn-axis symbols into
-        # `_make_ntensor_with_shape` is a follow-up.
+        # `resolve_attr_axis_size` threads each input's axis-0 dim
+        # through the reshape + broadcast attrs as a runtime
+        # identifier, so dyn-axes works.
         OpSpec(
             name="meshgrid_ij",
             sample_st=_meshgrid_sample_st("ij"),
             tolerance=TractCheckTolerance.EXACT,
-            dynamic_axes_skip_reason=(
-                "meshgrid reshape declares concrete shape; "
-                "symbolic-dim threading needs follow-up."
-            ),
+            dynamic_axes_compatible=True,
         ),
         OpSpec(
             name="meshgrid_xy",
             sample_st=_meshgrid_sample_st("xy"),
             tolerance=TractCheckTolerance.EXACT,
-            dynamic_axes_skip_reason=(
-                "meshgrid reshape declares concrete shape; "
-                "symbolic-dim threading needs follow-up."
-            ),
+            dynamic_axes_compatible=True,
         ),
         # tensor_split bakes slice boundaries from the trace-time
         # `dim_size`. Static-axes proptest passes; runtime correctness

--- a/tests/proptest/op_specs/specialty.py
+++ b/tests/proptest/op_specs/specialty.py
@@ -771,13 +771,10 @@ def _no_tract_change_specs() -> T.List[OpSpec]:
             name="affine_grid",
             sample_st=_affine_grid_sample_st(),
             tolerance=TractCheckTolerance.CLOSE,
-            # Final reshape declares `(N, H, W, 2)` with a concrete
-            # `N` that clashes with the dyn-axis symbol -- same
-            # pattern as meshgrid / tensor_split.
-            dynamic_axes_skip_reason=(
-                "affine_grid_generator's final reshape declares "
-                "concrete N; symbolic-dim threading needs follow-up."
-            ),
+            # `resolve_attr_axis_size` threads theta's dynamic batch
+            # dim through the final reshape; H/W still need to be
+            # statically known (we bake the base grid as a constant).
+            dynamic_axes_compatible=True,
         ),
         OpSpec(
             name="conv_tbc",

--- a/torch_to_nnef/op/aten/axes_change.py
+++ b/torch_to_nnef/op/aten/axes_change.py
@@ -17,6 +17,7 @@ from torch_to_nnef.op.helper import (
     get_or_add_tensor_variable_in_nnef,
     get_tract_dyn_axis_size_soc,
     pick_axis,
+    resolve_attr_axis_size,
 )
 from torch_to_nnef.torch_graph import FixedTensorList
 from torch_to_nnef.torch_graph.ir_data import PythonConstant
@@ -818,6 +819,10 @@ def _emit_broadcast_to(op_helper, node, src_ref, target_shape, output_idx):
     exactly torch's `broadcast_tensors` semantics: take an input that's
     already broadcast-compatible with `target_shape` and replicate the
     size-1 axes up to the target size.
+
+    `target_shape` entries may be plain `int` (static) or
+    `nnef.Identifier` (resolved at runtime from a `tract_core_shape_of`
+    chain emitted upstream).
     """
     g = op_helper.g
     name_to_tensor = op_helper.name_to_tensor
@@ -825,10 +830,6 @@ def _emit_broadcast_to(op_helper, node, src_ref, target_shape, output_idx):
     out_ref = op_helper.get_or_add_tensor_variable_in_nnef(
         onode, prevent_variable=True
     )
-    if not all(isinstance(d, int) for d in target_shape):
-        raise T2NErrorNotImplemented(
-            "broadcast with dynamic target shape not yet supported"
-        )
     cast_and_add_nnef_operation(
         name_to_tensor=name_to_tensor,
         graph=g,
@@ -877,28 +878,39 @@ def broadcast_tensors(node, op_helper, inference_target, **kwargs):
 
 
 def _emit_meshgrid_one_axis(
-    op_helper, node, src_ref, target_shape, axis, output_idx
+    op_helper, node, in_data, target_shape_attr, axis, output_idx
 ):
     """Emit one meshgrid output: reshape + broadcast to target shape.
 
-    Reshape `src_ref` (rank 1) to `(1, .., size, .., 1)` at `axis`,
-    then broadcast to `target_shape` and write to
-    `node.outputs[output_idx]`. The reshape step is rank-changing, so
-    we build the intermediate NTensor explicitly (the shared
-    `add_single_output_op...` helpers inherit `node.outputs[0].shape`
-    and assert single-output, both wrong for a multi-output meshgrid).
+    Reshape `in_data` (rank 1) to `(1, .., size, .., 1)` at `axis`,
+    then broadcast to `target_shape_attr` and write to
+    `node.outputs[output_idx]`. `target_shape_attr` is a list of
+    op-attr values (`int` or `nnef.Identifier`), allowing the
+    runtime-extracted symbolic size for dynamic axes.
     """
     g = op_helper.g
     name_to_tensor = op_helper.name_to_tensor
-    rank = len(target_shape)
+    rank = len(target_shape_attr)
+    # Use the 1-D input's axis-0 size for the inserted axis (resolved
+    # symbolically when that axis is dynamic).
+    axis_size = resolve_attr_axis_size(op_helper, in_data, axis=0)
     reshape_shape = [1] * rank
-    reshape_shape[axis] = int(target_shape[axis])
+    reshape_shape[axis] = axis_size
+    # The intermediate NTensor's `.shape` is metadata used by t2n's
+    # rank-align pass; tract reads the actual size from the reshape
+    # op attribute. For dynamic axes we just write 1 there -- the
+    # reshape result is rank-correct and tract will derive the actual
+    # size from the symbolic attribute at runtime.
     onode = node.outputs[output_idx]
+    declared_shape = [1] * rank
+    if isinstance(axis_size, int):
+        declared_shape[axis] = axis_size
+    src_ref = op_helper.get_or_add_tensor_variable_in_nnef(in_data)
     intermediate = _make_ntensor_with_shape(
         g,
         name_to_tensor,
         f"{onode.export_name}_mg_reshape",
-        reshape_shape,
+        declared_shape,
         onode.np_dtype,
     )
     cast_and_add_nnef_operation(
@@ -910,7 +922,9 @@ def _emit_meshgrid_one_axis(
         outputs=intermediate,
         attribs={"shape": reshape_shape},
     )
-    _emit_broadcast_to(op_helper, node, intermediate, target_shape, output_idx)
+    _emit_broadcast_to(
+        op_helper, node, intermediate, target_shape_attr, output_idx
+    )
 
 
 @OP_REGISTRY.register()
@@ -934,7 +948,6 @@ def meshgrid(node, op_helper, inference_target, **kwargs):
     assert isinstance(input_list_node, FixedTensorList)
     assert len(input_list_node.data) == len(node.outputs)
     n = len(input_list_node.data)
-    target_shape = list(node.outputs[0].shape)
 
     def axis_for_input(i: int) -> int:
         if indexing == "xy" and n >= 2:
@@ -944,13 +957,21 @@ def meshgrid(node, op_helper, inference_target, **kwargs):
                 return 0
         return i
 
+    # Build the broadcast target shape from each input's axis-0 size.
+    # The size resolver emits a `tract_core_shape_of` chain and returns
+    # an `nnef.Identifier` for dynamic inputs; otherwise it's a plain int.
+    target_shape_attr = [None] * n
     for i, in_data in enumerate(input_list_node.data):
-        src_ref = op_helper.get_or_add_tensor_variable_in_nnef(in_data)
+        target_shape_attr[axis_for_input(i)] = resolve_attr_axis_size(
+            op_helper, in_data, axis=0
+        )
+
+    for i, in_data in enumerate(input_list_node.data):
         _emit_meshgrid_one_axis(
             op_helper,
             node,
-            src_ref,
-            target_shape,
+            in_data,
+            target_shape_attr,
             axis=axis_for_input(i),
             output_idx=i,
         )

--- a/torch_to_nnef/op/aten/selector.py
+++ b/torch_to_nnef/op/aten/selector.py
@@ -16,6 +16,7 @@ from torch_to_nnef.op.helper import (
     get_tract_dyn_axis_size_soc,
     pick_axis,
     pick_index_in_axis,
+    resolve_attr_axis_size,
 )
 from torch_to_nnef.tensor import OpaqueTensorRef
 from torch_to_nnef.torch_graph.ir_data import PythonConstant, TensorVariable
@@ -1527,6 +1528,10 @@ def _broadcast_index_to_input_shape(
     have the same shape as the iteration domain. Torch's index_* family
     ships a rank-1 `index`, so we unsqueeze it to the input rank and
     tile it across every non-`dim` axis.
+
+    Tile repeats for dynamic non-`dim` axes are resolved at runtime via
+    `resolve_attr_axis_size`; the broadcast shape returned to the
+    caller mixes ints and `nnef.Identifier` for the same reason.
     """
     rank = input_node.rank
     if not isinstance(index_node.shape[0], int):
@@ -1538,12 +1543,12 @@ def _broadcast_index_to_input_shape(
     if rank == 1:
         return idx_ref, [k]
 
-    repeats = list(input_node.shape)
-    if not all(isinstance(d, int) for d in repeats):
-        raise T2NErrorNotImplemented(
-            "index_* with dynamic non-`dim` axes not supported"
-        )
-    repeats[dim] = 1
+    repeats = []
+    for axis in range(rank):
+        if axis == dim:
+            repeats.append(1)
+        else:
+            repeats.append(resolve_attr_axis_size(op_helper, input_node, axis))
 
     axes_to_add = [i for i in range(rank) if i != dim]
     idx_unsq = op_helper.add_single_output_op_from_nnef_tensors(
@@ -1779,26 +1784,21 @@ def take(node, op_helper, inference_target, **kwargs):
     """Map PyTorch: 'aten:take' to NNEF.
 
     `take(self, index)` flattens `self` to 1-D and gathers along axis
-    0. Lowered to a static `reshape` (to `(numel,)`) followed by
-    `tract_core_gather` on axis 0.
+    0. Lowered to a `reshape(input, shape=[-1])` followed by
+    `tract_core_gather` on axis 0. The `-1` lets NNEF / tract derive
+    the flat size at runtime from the input shape, so dynamic input
+    axes work without any special-casing.
     """
     if not isinstance(inference_target, TractNNEF):
         raise T2NErrorNotImplemented(inference_target)
     input_node, index_node = node.inputs
-    if not all(isinstance(d, int) for d in input_node.shape):
-        raise T2NErrorNotImplemented(
-            "take with dynamic input shape not supported"
-        )
-    flat_size = 1
-    for d in input_node.shape:
-        flat_size *= int(d)
 
     inp_ref = op_helper.get_or_add_tensor_variable_in_nnef(input_node)
     flat = op_helper.add_single_output_op_from_nnef_tensors(
         node,
         "reshape",
         inputs=inp_ref,
-        attrs={"shape": [flat_size]},
+        attrs={"shape": [-1]},
         output_tensor_name_suffix="_take_flat",
     )
     op_helper.add_single_output_op_from_nnef_tensors(

--- a/torch_to_nnef/op/aten/tensor_build.py
+++ b/torch_to_nnef/op/aten/tensor_build.py
@@ -18,6 +18,7 @@ from torch_to_nnef.op.helper import (
     get_list_of_int,
     get_or_add_tensor_variable_in_nnef,
     get_tract_dyn_axis_size_soc,
+    resolve_attr_axis_size,
     unary_output_op_without_attr,
 )
 from torch_to_nnef.torch_graph import (
@@ -891,15 +892,28 @@ def affine_grid_generator(
     size_data = size_node.data
     if hasattr(size_data, "tolist"):
         size_data = size_data.tolist()
-    size = [int(x) for x in size_data]
-    align_corners = bool(align_corners_node.data)
-    if len(size) != 4:
+    if len(size_data) != 4:
         raise T2NErrorNotImplemented(
             f"affine_grid_generator: only 2-D (rank-4 size) supported; "
-            f"got size={size}"
+            f"got size={size_data}"
         )
-    n, _c, h, w = size
-    if tuple(theta_node.shape) != (n, 2, 3):
+    # H / W must be static (we bake the base grid as a constant); the
+    # batch dim N can be dynamic (resolved via `resolve_attr_axis_size`
+    # below).
+
+    def _as_static_int(v, name):
+        if isinstance(v, int):
+            return v
+        if hasattr(v, "data") and isinstance(v.data, int):
+            return v.data
+        raise T2NErrorNotImplemented(
+            f"affine_grid_generator: {name} must be statically known; got {v!r}"
+        )
+
+    h = _as_static_int(size_data[2], "H")
+    w = _as_static_int(size_data[3], "W")
+    align_corners = bool(align_corners_node.data)
+    if theta_node.rank != 3 or tuple(theta_node.shape[1:]) != (2, 3):
         raise T2NErrorNotImplemented(
             f"affine_grid_generator: theta shape must be (N, 2, 3); "
             f"got {theta_node.shape}"
@@ -941,9 +955,13 @@ def affine_grid_generator(
         attrs={"axes": [0, 2, 1]},
         output_tensor_name_suffix="ag_t",
     )
+    # Resolve N from theta's runtime shape so the reshape works with a
+    # dynamic batch axis (otherwise tract refuses to unify a concrete
+    # N against the symbolic axis-0 dim).
+    n_attr = resolve_attr_axis_size(op_helper, theta_node, axis=0)
     op_helper.add_single_output_op_from_nnef_tensors(
         node,
         "reshape",
         inputs=transposed,
-        attrs={"shape": [n, h, w, 2]},
+        attrs={"shape": [n_attr, h, w, 2]},
     )

--- a/torch_to_nnef/op/helper.py
+++ b/torch_to_nnef/op/helper.py
@@ -1121,6 +1121,25 @@ class SimpleOpChainer:
         return SimpleOpChainer(self.op_helper, new_data)
 
 
+def resolve_attr_axis_size(op_helper, input_node, axis: int):
+    """Resolve `input_node.shape[axis]` for use in a NNEF op attribute.
+
+    When `inference_target.has_dynamic_axes`, emit (and cache) a
+    `tract_core_shape_of -> slice -> squeeze` chain to extract the
+    runtime size of `axis` and return an `nnef.Identifier` referencing
+    that scalar. Otherwise, return the static `int(input_node.shape[axis])`.
+
+    Use this anywhere a shape-derived value lands in an op attribute
+    (e.g. `reshape(shape=[...])`, `tile(repeats=[...])`, `slice(end=...)`)
+    so the same emitter works in both static and dyn-axes modes
+    without baking the trace-time size into the exported graph.
+    """
+    if not op_helper.inference_target.has_dynamic_axes:
+        return int(input_node.shape[axis])
+    get_tract_dyn_axis_size_soc(op_helper, input_node, axis)
+    return nnef.Identifier(f"{input_node.export_name}_dim{axis}")
+
+
 def get_tract_dyn_axis_size_soc(
     op_helper, input_node, axis: int
 ) -> SimpleOpChainer:


### PR DESCRIPTION
## Summary

Adds a small helper that lets ops keep working when an input axis is
marked dynamic, instead of opting out via `dynamic_axes_skip_reason`.

### The helper

`resolve_attr_axis_size(op_helper, input_node, axis)` in
`op/helper.py`:

- Under static-axes export: returns `int(input_node.shape[axis])`.
- Under dyn-axes export: emits (and caches) a
  `tract_core_shape_of -> slice -> squeeze` chain, then returns an
  `nnef.Identifier(\"{input_name}_dim{axis}\")` pointing at that
  scalar.

The identifier is valid wherever a NNEF op attribute accepts an int
(reshape `shape`, tile `repeats`, slice `end`, ...). Tract reads the
runtime size from the attribute instead of unifying against a
baked-in trace-time constant.

### Ops opted in

| Op | What changed |
|---|---|
| `affine_grid_generator` | N threaded through the final `(N, H, W, 2)` reshape. H / W still must be static (base grid is baked as a constant). |
| `meshgrid` | Each input's axis-0 dim threaded through the per-axis reshape + the broadcast target shape. `_emit_broadcast_to` accepts mixed int / Identifier shapes. |
| `_broadcast_index_to_input_shape` (index_fill / index_copy / index_add) | Tile repeats for non-`dim` axes resolved per-axis. (Proptest still xfails on tract 0.22.1 due to ScatterReduction; the dyn-axes plumbing is independent.) |
| `take` | `reshape(shape=[numel])` -> `reshape(shape=[-1])`; NNEF / tract derive the flat size. |

### Proptest specs flipped to opt-in

- `affine_grid`
- `meshgrid_ij`
- `meshgrid_xy`
- `take`

## Test plan

- [x] Targeted: `uv run pytest tests/test_primitive_proptest.py::test_op_property -k 'meshgrid or affine_grid or take or broadcast_tensors or index_'` -- 12 passed, 8 xfailed (pre-existing tract 0.22.1 ScatterReduction xfails).
- [x] Targeted dyn-axes: `uv run pytest tests/test_primitive_proptest.py::test_op_property_dynamic -k 'meshgrid or affine_grid or take or broadcast_tensors or index_'` -- 5 passed, 4 xfailed.
- [x] Full proptest sweep: 280 passed, 210 skipped, 48 xfailed (matches baseline).
- [x] `ruff check` / `ruff format` clean on touched files.