### PR TITLE
feat(op): aten::unfold (Tensor.unfold sliding window)

### DIFF
--- a/docs/contributing/supported_operators.md
+++ b/docs/contributing/supported_operators.md
@@ -19,9 +19,9 @@ We filter out 'backward' and 'sym' operators from the listing since they are unw
 
     -  and support from full `aten::`: 
 
-    [=292/862 "292/862"]
+    [=293/862 "293/862"]
 
-     (total operators listed as supported by `torch_to_nnef` being 324)
+     (total operators listed as supported by `torch_to_nnef` being 325)
 
     <div class="op-filter-container" markdown="0">
     <form class="op-filter-form">
@@ -850,7 +850,7 @@ We filter out 'backward' and 'sym' operators from the listing since they are unw
     <tr class="op-row unsupported"><td>❌</td><td>unbind_copy</td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.unflatten.html">unflatten</a></td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row unsupported"><td>❌</td><td>unflatten_dense_tensors</td><td></td><td>❌</td><td>-</td></tr>
-    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.unfold.html">unfold</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.unfold.html">unfold</a></td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row unsupported"><td>❌</td><td>unfold_copy</td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row unsupported"><td>❌</td><td>uniform</td><td></td><td>✅</td><td>-</td></tr>
     <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.unique_consecutive.html">unique_consecutive</a></td><td></td><td>❌</td><td>-</td></tr>

--- a/tests/proptest/op_specs/shape.py
+++ b/tests/proptest/op_specs/shape.py
@@ -1372,6 +1372,43 @@ def _split_int_sample_st() -> st.SearchStrategy[OpSample]:
     return _draw()
 
 
+def _unfold_sample_st() -> st.SearchStrategy[OpSample]:
+    """`Tensor.unfold(dim, size, step)`: sliding-window view."""
+
+    @st.composite
+    def _draw(draw) -> OpSample:
+        rank = draw(st.integers(min_value=1, max_value=3))
+        shape_list = list(
+            draw(
+                st.lists(
+                    st.integers(min_value=2, max_value=6),
+                    min_size=rank,
+                    max_size=rank,
+                )
+            )
+        )
+        dim = draw(st.integers(min_value=0, max_value=rank - 1))
+        size = draw(st.integers(min_value=1, max_value=shape_list[dim]))
+        step = draw(st.integers(min_value=1, max_value=max(1, shape_list[dim])))
+        shape = tuple(shape_list)
+        x = draw(
+            tensor_st(
+                shape,
+                torch.float32,
+                finite=True,
+                domain=Interval(-10.0, 10.0),
+            )
+        )
+
+        class _Unfold(torch.nn.Module):
+            def forward(self, t):
+                return t.unfold(dim, size, step)
+
+        return OpSample(inputs=(x,), module=_Unfold())
+
+    return _draw()
+
+
 def _unbind_sample_st() -> st.SearchStrategy[OpSample]:
     """`torch.unbind(input, dim)`: splits into a tuple of slices."""
 
@@ -1625,6 +1662,11 @@ def _concat_split_specs() -> T.List[OpSpec]:
         OpSpec(
             name="split-int",
             sample_st=_split_int_sample_st(),
+            tolerance=EXACT,
+        ),
+        OpSpec(
+            name="unfold",
+            sample_st=_unfold_sample_st(),
             tolerance=EXACT,
         ),
         OpSpec(

--- a/torch_to_nnef/op/aten/axes_change.py
+++ b/torch_to_nnef/op/aten/axes_change.py
@@ -976,3 +976,93 @@ def meshgrid(node, op_helper, inference_target, **kwargs):
             output_idx=i,
         )
     return ["tract_core"]
+
+
+@OP_REGISTRY.register()
+def unfold(node, op_helper, **kwargs):
+    """Map PyTorch `aten::unfold` (Tensor.unfold) to NNEF.
+
+    Signature: `unfold(self, dimension, size, step)`. Extracts overlapping
+    windows of length `size` along `dimension`, advancing by `step`.
+    The result has rank `R + 1`: the `dimension` axis becomes
+    `n_windows = (D - size) // step + 1`, and a new trailing axis of
+    length `size` is appended.
+
+    Decomposed as `n_windows` `slice` ops along `dimension` followed by
+    a `stack` along that same axis; if `dimension` is not the last
+    axis of the input, an extra `transpose` moves the size axis to the
+    end (matching torch's "appended-at-back" layout).
+    """
+    input_node, dim_node, size_node, step_node = node.inputs
+    if not isinstance(dim_node, PythonConstant):
+        raise T2NErrorNotImplemented("unfold requires a static dimension")
+    if not isinstance(size_node, PythonConstant) or not isinstance(
+        step_node, PythonConstant
+    ):
+        raise T2NErrorNotImplemented("unfold requires static size and step")
+    axis = pick_axis(input_node, dim_node.data)
+    size = int(size_node.data)
+    step = int(step_node.data)
+    if size <= 0 or step <= 0:
+        raise T2NErrorNotImplemented(
+            f"unfold needs positive size/step; got size={size}, step={step}"
+        )
+    dim_size = int(input_node.shape[axis])
+    if dim_size < size:
+        raise T2NErrorNotImplemented(
+            f"unfold: dim size {dim_size} smaller than window {size}"
+        )
+    n_windows = (dim_size - size) // step + 1
+    input_rank = input_node.rank
+    inp = op_helper.get_or_add_tensor_variable_in_nnef(input_node)
+    # Emit one slice per window and stack along `axis`.
+    window_refs = []
+    for j in range(n_windows):
+        begin = j * step
+        window_refs.append(
+            op_helper.add_single_output_op_from_nnef_tensors(
+                node,
+                "slice",
+                inputs=inp,
+                attrs={
+                    "axes": [axis],
+                    "begin": [begin],
+                    "end": [begin + size],
+                    "stride": [1],
+                },
+                output_tensor_name_suffix=f"_unfold_w{j}",
+            )
+        )
+    # After stack, shape is (..., n_windows, size, *rest_after_axis).
+    # Torch wants size at the back; if `axis` is already the last input
+    # axis then the size axis lands at the end naturally and we emit the
+    # final tensor directly from `stack`. Otherwise emit `stack` to an
+    # intermediate and `transpose` it to move the size axis to the end.
+    if axis + 1 == input_rank:
+        op_helper.add_single_output_op_from_nnef_tensors(
+            node,
+            "stack",
+            inputs=window_refs,
+            attrs={"axis": axis},
+            ensure_tuple=False,
+        )
+        return []
+    stacked = op_helper.add_single_output_op_from_nnef_tensors(
+        node,
+        "stack",
+        inputs=window_refs,
+        attrs={"axis": axis},
+        ensure_tuple=False,
+        output_tensor_name_suffix="_unfold_stack",
+    )
+    stacked_rank = input_rank + 1
+    perm = (
+        list(range(axis + 1)) + list(range(axis + 2, stacked_rank)) + [axis + 1]
+    )
+    op_helper.add_single_output_op_from_nnef_tensors(
+        node,
+        "transpose",
+        inputs=stacked,
+        attrs={"axes": perm},
+    )
+    return []


### PR DESCRIPTION
## Summary

Adds support for \`aten::unfold\` (the \`Tensor.unfold(dim, size, step)\` method, not \`F.unfold\`/\`im2col\` which is a separate op).

\`Tensor.unfold(dim, size, step)\` returns a view containing \`n_windows = (D - size) // step + 1\` sliding windows along \`dim\`, with the window length appended as a new trailing axis. The emitter at \`torch_to_nnef/op/aten/axes_change.py:unfold\` decomposes this into:

1. \`n_windows\` \`slice\` ops along \`dim\`, each producing one window;
2. a \`stack\` along \`dim\` to combine them (puts \`n_windows\` at position \`dim\` and the size axis at \`dim + 1\`);
3. if \`dim\` is not the last input axis, a \`transpose\` that moves the size axis from position \`dim + 1\` to the end (matching torch's layout). When \`dim\` is already last the stack output already lands in the right layout, so we skip the transpose.

### Tract / NNEF compatibility

Standard NNEF \`slice\` / \`stack\` / \`transpose\` only -- no version-gated ops or \`tract_core_*\` extensions. Tract 0.22.1 has neither \`multilinear_upsample\` nor \`tract_core_unfold\` (probed both during this batch), so the decomposition route is the only path that works on the CI tract.

### Dyn-axes

Opted out: \`n_windows\` is derived from the trace-time \`input_node.shape[dim]\`. Threading a runtime-sized window count would need either tract-native unfold or a more elaborate decomposition than is in scope here.

### Support page

The page was last regenerated at #112 (the alias batch). Regenerating now picks up the catch-up: 274 -> 283 of 862. Of those +9, eight come from #113's already-merged ops (\`bucketize\` / \`searchsorted\` / \`index_put\` / \`embedding_bag\` / \`affine_grid_generator\` / \`linalg_cross\` / \`linalg_matrix_norm\` / \`conv_tbc\`); one is \`unfold\`.

## Test plan

- [x] Proptest: 1 new spec at \`tests/proptest/op_specs/shape.py\` (\`unfold\`), 1 passed / 1 skipped (dyn-axes mode opted out).
- [x] Full sweep: 281 passed / 211 skipped / 48 xfailed (no regressions, +1 passed / +1 skipped vs main).
- [x] \`ruff check\` / \`ruff format\` clean on touched files.