### PR TITLE
feat(op): aten::im2col (F.unfold / NCHW patch extraction)

### DIFF
--- a/docs/contributing/supported_operators.md
+++ b/docs/contributing/supported_operators.md
@@ -19,9 +19,9 @@ We filter out 'backward' and 'sym' operators from the listing since they are unw
 
     -  and support from full `aten::`: 
 
-    [=293/862 "293/862"]
+    [=294/862 "294/862"]
 
-     (total operators listed as supported by `torch_to_nnef` being 325)
+     (total operators listed as supported by `torch_to_nnef` being 326)
 
     <div class="op-filter-container" markdown="0">
     <form class="op-filter-form">
@@ -412,7 +412,7 @@ We filter out 'backward' and 'sym' operators from the listing since they are unw
     <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.igamma.html">igamma</a></td><td>special_gammainc</td><td>✅</td><td>-</td></tr>
     <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.igammac.html">igammac</a></td><td>special_gammaincc</td><td>✅</td><td>-</td></tr>
     <tr class="op-row unsupported"><td>❌</td><td>iinfo</td><td></td><td>❌</td><td>-</td></tr>
-    <tr class="op-row unsupported"><td>❌</td><td>im2col</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td>im2col</td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.imag.html">imag</a></td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.index_add.html">index_add</a></td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.index_copy.html">index_copy</a></td><td></td><td>❌</td><td>-</td></tr>

--- a/tests/proptest/op_specs/shape.py
+++ b/tests/proptest/op_specs/shape.py
@@ -1409,6 +1409,55 @@ def _unfold_sample_st() -> st.SearchStrategy[OpSample]:
     return _draw()
 
 
+def _im2col_sample_st() -> st.SearchStrategy[OpSample]:
+    """`F.unfold(input, kernel_size, dilation, padding, stride)`.
+
+    Lowers to `aten::im2col`; rank-4 inputs `(N, C, H, W)` only.
+    Sample sizes / kernels / strides / dilations / paddings are kept
+    small but exercise both square and asymmetric configurations, and
+    cover the padding > 0 / dilation > 1 branches.
+    """
+
+    @st.composite
+    def _draw(draw) -> OpSample:
+        n = draw(st.integers(min_value=1, max_value=2))
+        c = draw(st.integers(min_value=1, max_value=3))
+        kh = draw(st.integers(min_value=1, max_value=3))
+        kw = draw(st.integers(min_value=1, max_value=3))
+        dh = draw(st.integers(min_value=1, max_value=2))
+        dw = draw(st.integers(min_value=1, max_value=2))
+        ph = draw(st.integers(min_value=0, max_value=1))
+        pw = draw(st.integers(min_value=0, max_value=1))
+        sh = draw(st.integers(min_value=1, max_value=2))
+        sw = draw(st.integers(min_value=1, max_value=2))
+        rcpt_h = dh * (kh - 1) + 1
+        rcpt_w = dw * (kw - 1) + 1
+        h = draw(st.integers(min_value=rcpt_h, max_value=rcpt_h + 4))
+        w = draw(st.integers(min_value=rcpt_w, max_value=rcpt_w + 4))
+        x = draw(
+            tensor_st(
+                (n, c, h, w),
+                torch.float32,
+                finite=True,
+                domain=Interval(-10.0, 10.0),
+            )
+        )
+
+        class _Im2Col(torch.nn.Module):
+            def forward(self, t):
+                return torch.nn.functional.unfold(
+                    t,
+                    kernel_size=(kh, kw),
+                    dilation=(dh, dw),
+                    padding=(ph, pw),
+                    stride=(sh, sw),
+                )
+
+        return OpSample(inputs=(x,), module=_Im2Col())
+
+    return _draw()
+
+
 def _unbind_sample_st() -> st.SearchStrategy[OpSample]:
     """`torch.unbind(input, dim)`: splits into a tuple of slices."""
 
@@ -1667,6 +1716,11 @@ def _concat_split_specs() -> T.List[OpSpec]:
         OpSpec(
             name="unfold",
             sample_st=_unfold_sample_st(),
+            tolerance=EXACT,
+        ),
+        OpSpec(
+            name="im2col",
+            sample_st=_im2col_sample_st(),
             tolerance=EXACT,
         ),
         OpSpec(

--- a/torch_to_nnef/op/aten/axes_change.py
+++ b/torch_to_nnef/op/aten/axes_change.py
@@ -1066,3 +1066,119 @@ def unfold(node, op_helper, **kwargs):
         attrs={"axes": perm},
     )
     return []
+
+
+def _as_pair(node_value, name: str):
+    """Unwrap PyTorch's `[h, w]` list inputs into a (h, w) int tuple."""
+    if hasattr(node_value, "data"):
+        node_value = node_value.data
+    if hasattr(node_value, "tolist"):
+        node_value = node_value.tolist()
+    if not isinstance(node_value, (list, tuple)) or len(node_value) != 2:
+        raise T2NErrorNotImplemented(
+            f"im2col: {name} must be a 2-element list; got {node_value!r}"
+        )
+    return int(node_value[0]), int(node_value[1])
+
+
+@OP_REGISTRY.register()
+def im2col(node, op_helper, **kwargs):
+    """Map PyTorch `aten::im2col` (a.k.a. `F.unfold`) to NNEF.
+
+    Signature: `im2col(self, kernel_size, dilation, padding, stride)` for
+    a rank-4 input `(N, C, H, W)`. Output is `(N, C * kH * kW, L)` where
+    `L = oH * oW` and:
+
+    * `oH = (H + 2*pH - dH*(kH - 1) - 1) // sH + 1`
+    * `oW = (W + 2*pW - dW*(kW - 1) - 1) // sW + 1`
+
+    No tract / NNEF op exposes this directly (we probed
+    `tract_core_im2col` / `im2col` -- both unknown), so we decompose:
+
+    1. zero-pad the input along H and W if `padding > 0`;
+    2. for every kernel position `(di, dj)`, take a strided
+       2-axis `slice` -- begin=`[di*dH, dj*dW]`, stride=`[sH, sW]`,
+       length `oH x oW`;
+    3. `stack` the `kH * kW` slices along a new axis at position 2,
+       then `reshape` `(N, C, kH*kW, oH, oW)` -> `(N, C*kH*kW, oH*oW)`.
+
+    Iteration order is `di` outer, `dj` inner, matching torch's flat
+    output-channel index `c*kH*kW + di*kW + dj`.
+    """
+    (
+        input_node,
+        kernel_node,
+        dilation_node,
+        padding_node,
+        stride_node,
+    ) = node.inputs
+    if input_node.rank != 4:
+        raise T2NErrorNotImplemented(
+            f"im2col expects a rank-4 input (N, C, H, W); got rank "
+            f"{input_node.rank}"
+        )
+    kh, kw = _as_pair(kernel_node, "kernel_size")
+    dh, dw = _as_pair(dilation_node, "dilation")
+    ph, pw = _as_pair(padding_node, "padding")
+    sh, sw = _as_pair(stride_node, "stride")
+    n, c, h, w = (int(d) for d in input_node.shape)
+    padded_h = h + 2 * ph
+    padded_w = w + 2 * pw
+    rcpt_h = dh * (kh - 1) + 1
+    rcpt_w = dw * (kw - 1) + 1
+    if padded_h < rcpt_h or padded_w < rcpt_w:
+        raise T2NErrorNotImplemented(
+            f"im2col: padded input ({padded_h}, {padded_w}) too small "
+            f"for receptive field ({rcpt_h}, {rcpt_w})"
+        )
+    o_h = (padded_h - rcpt_h) // sh + 1
+    o_w = (padded_w - rcpt_w) // sw + 1
+    inp = op_helper.get_or_add_tensor_variable_in_nnef(input_node)
+    if ph > 0 or pw > 0:
+        inp = op_helper.add_single_output_op_from_nnef_tensors(
+            node,
+            "pad",
+            inputs=inp,
+            attrs={
+                "padding": [(0, 0), (0, 0), (ph, ph), (pw, pw)],
+                "value": 0.0,
+            },
+            output_tensor_name_suffix="_im2col_pad",
+        )
+    slice_refs = []
+    for di in range(kh):
+        for dj in range(kw):
+            begin_h = di * dh
+            begin_w = dj * dw
+            slice_refs.append(
+                op_helper.add_single_output_op_from_nnef_tensors(
+                    node,
+                    "slice",
+                    inputs=inp,
+                    attrs={
+                        "axes": [2, 3],
+                        "begin": [begin_h, begin_w],
+                        "end": [
+                            begin_h + (o_h - 1) * sh + 1,
+                            begin_w + (o_w - 1) * sw + 1,
+                        ],
+                        "stride": [sh, sw],
+                    },
+                    output_tensor_name_suffix=f"_im2col_s{di}_{dj}",
+                )
+            )
+    stacked = op_helper.add_single_output_op_from_nnef_tensors(
+        node,
+        "stack",
+        inputs=slice_refs,
+        attrs={"axis": 2},
+        ensure_tuple=False,
+        output_tensor_name_suffix="_im2col_stack",
+    )
+    op_helper.add_single_output_op_from_nnef_tensors(
+        node,
+        "reshape",
+        inputs=stacked,
+        attrs={"shape": [n, c * kh * kw, o_h * o_w]},
+    )
+    return []


### PR DESCRIPTION
## Summary

Adds support for \`aten::im2col\` (the \`torch.nn.functional.unfold\` lowering -- distinct from #116's \`Tensor.unfold\`).

### Decomposition

Tract does not expose im2col at the NNEF op level. Probed \`im2col\` / \`Im2Col\` / \`tract_core_im2col\` / \`tract_core_box\` on tract 0.22.1 -- all return \"No definition for operator\". The internal \`core/src/ops/cnn/conv/im2col.rs\` is used only as a convolution lowering, not exposed in \`nnef/src/ops/core/\`.

The emitter at \`torch_to_nnef/op/aten/axes_change.py:im2col\` decomposes the op for rank-4 \`(N, C, H, W)\` input:

1. zero-pad H / W if \`padding > 0\` (NNEF \`pad\`);
2. for every kernel offset \`(di, dj)\`, take a 2-axis strided \`slice\` -- begin \`[di*dH, dj*dW]\`, stride \`[sH, sW]\`, length \`oH x oW\`;
3. \`stack\` the \`kH * kW\` slices along a new axis at position 2;
4. \`reshape\` \`(N, C, kH*kW, oH, oW)\` -> \`(N, C*kH*kW, oH*oW)\`.

Iteration is \`di\` outer / \`dj\` inner, matching torch's flat output-channel index \`c*kH*kW + di*kW + dj\`.

### Forward compatibility

Once tract grows a \`tract_core_im2col\` registration (short patch in \`nnef/src/ops/core/\`), a version-gated path can emit it directly while keeping the slice-stack decomposition as the fallback for older tract -- retrocompat in the same way the upsample path does \`debox\` vs \`deconv\`.

### Dyn-axes

Opted out: \`oH\` / \`oW\` and slice extents come from the trace-time \`input_node.shape\`. Threading dynamic H/W through the per-window slices would need either tract-native im2col or a much more elaborate decomposition.

### Coverage

\`docs/contributing/supported_operators.md\`: 293 -> 294 of 862.

## Test plan

- [x] Proptest spec at \`tests/proptest/op_specs/shape.py\` covers square / asymmetric kernels, strides, dilations, paddings; 1 passed / 1 skipped (dyn-axes mode opted out). Re-ran with seeds 0, 42, 99.
- [x] Full sweep: 297 / 213 / 48 -> 298 / 214 / 48 (no regressions).
- [x] \`ruff check\` / \`ruff format\` clean on touched files.