### PR TITLE
feat(op): aten::col2im (F.fold / image patch accumulation)

### DIFF
--- a/docs/contributing/supported_operators.md
+++ b/docs/contributing/supported_operators.md
@@ -15,13 +15,13 @@ We filter out 'backward' and 'sym' operators from the listing since they are unw
 
     - core PyTorch opset:
 
-    [=127/138 "127/138"]
+    [=128/138 "128/138"]
 
     -  and support from full `aten::`: 
 
-    [=302/862 "302/862"]
+    [=303/862 "303/862"]
 
-     (total operators listed as supported by `torch_to_nnef` being 334)
+     (total operators listed as supported by `torch_to_nnef` being 335)
 
     <div class="op-filter-container" markdown="0">
     <form class="op-filter-form">
@@ -63,7 +63,7 @@ We filter out 'backward' and 'sym' operators from the listing since they are unw
     <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.ceil.html">ceil</a></td><td></td><td>✅</td><td>✅</td></tr>
     <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.clamp.html">clamp</a></td><td>clip</td><td>✅</td><td>✅</td></tr>
     <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.clone.html">clone</a></td><td></td><td>❌</td><td>✅</td></tr>
-    <tr class="op-row unsupported"><td>❌</td><td>col2im</td><td></td><td>❌</td><td>✅</td></tr>
+    <tr class="op-row supported"><td>✅</td><td>col2im</td><td></td><td>❌</td><td>✅</td></tr>
     <tr class="op-row supported"><td>✅</td><td>constant_pad_nd</td><td></td><td>❌</td><td>✅</td></tr>
     <tr class="op-row supported"><td>✅</td><td>convolution</td><td></td><td>❌</td><td>✅</td></tr>
     <tr class="op-row supported"><td>✅</td><td>copy</td><td></td><td>✅</td><td>✅</td></tr>

--- a/tests/proptest/op_specs/shape.py
+++ b/tests/proptest/op_specs/shape.py
@@ -1495,6 +1495,62 @@ def _im2col_sample_st() -> st.SearchStrategy[OpSample]:
     return _draw()
 
 
+def _col2im_sample_st() -> st.SearchStrategy[OpSample]:
+    """`F.fold(input, output_size, kernel_size, dilation, padding, stride)`.
+
+    Lowers to `aten::col2im`. Samples a rank-4 image `(N, C, H, W)`,
+    runs `F.unfold` to get the col representation, then `F.fold`
+    inverts it; the proptest checks that the t2n emitter reproduces
+    torch's output (which is the per-position sum of overlapping
+    kernel contributions, scaled by overlap count).
+    """
+
+    @st.composite
+    def _draw(draw) -> OpSample:
+        n = draw(st.integers(min_value=1, max_value=2))
+        c = draw(st.integers(min_value=1, max_value=3))
+        kh = draw(st.integers(min_value=1, max_value=3))
+        kw = draw(st.integers(min_value=1, max_value=3))
+        dh = draw(st.integers(min_value=1, max_value=2))
+        dw = draw(st.integers(min_value=1, max_value=2))
+        ph = draw(st.integers(min_value=0, max_value=1))
+        pw = draw(st.integers(min_value=0, max_value=1))
+        sh = draw(st.integers(min_value=1, max_value=2))
+        sw = draw(st.integers(min_value=1, max_value=2))
+        rcpt_h = dh * (kh - 1) + 1
+        rcpt_w = dw * (kw - 1) + 1
+        out_h = draw(st.integers(min_value=rcpt_h, max_value=rcpt_h + 4))
+        out_w = draw(st.integers(min_value=rcpt_w, max_value=rcpt_w + 4))
+        padded_h = out_h + 2 * ph
+        padded_w = out_w + 2 * pw
+        n_h = (padded_h - rcpt_h) // sh + 1
+        n_w = (padded_w - rcpt_w) // sw + 1
+        # F.fold input is (N, C*kH*kW, L).
+        x = draw(
+            tensor_st(
+                (n, c * kh * kw, n_h * n_w),
+                torch.float32,
+                finite=True,
+                domain=Interval(-10.0, 10.0),
+            )
+        )
+
+        class _Col2Im(torch.nn.Module):
+            def forward(self, t):
+                return torch.nn.functional.fold(
+                    t,
+                    output_size=(out_h, out_w),
+                    kernel_size=(kh, kw),
+                    dilation=(dh, dw),
+                    padding=(ph, pw),
+                    stride=(sh, sw),
+                )
+
+        return OpSample(inputs=(x,), module=_Col2Im())
+
+    return _draw()
+
+
 def _unbind_sample_st() -> st.SearchStrategy[OpSample]:
     """`torch.unbind(input, dim)`: splits into a tuple of slices."""
 
@@ -1758,6 +1814,11 @@ def _concat_split_specs() -> T.List[OpSpec]:
         OpSpec(
             name="im2col",
             sample_st=_im2col_sample_st(),
+            tolerance=EXACT,
+        ),
+        OpSpec(
+            name="col2im",
+            sample_st=_col2im_sample_st(),
             tolerance=EXACT,
         ),
         OpSpec(

--- a/torch_to_nnef/op/aten/axes_change.py
+++ b/torch_to_nnef/op/aten/axes_change.py
@@ -1098,7 +1098,7 @@ def _as_pair(node_value, name: str):
         node_value = node_value.tolist()
     if not isinstance(node_value, (list, tuple)) or len(node_value) != 2:
         raise T2NErrorNotImplemented(
-            f"im2col: {name} must be a 2-element list; got {node_value!r}"
+            f"{name} must be a 2-element list; got {node_value!r}"
         )
     return int(node_value[0]), int(node_value[1])
 
@@ -1202,5 +1202,213 @@ def im2col(node, op_helper, **kwargs):
         "reshape",
         inputs=stacked,
         attrs={"shape": [n, c * kh * kw, o_h * o_w]},
+    )
+    return []
+
+
+@OP_REGISTRY.register()
+def col2im(node, op_helper, **kwargs):
+    """Map PyTorch `aten::col2im` (a.k.a. `F.fold`) to NNEF.
+
+    Signature: `col2im(self, output_size, kernel_size, dilation, padding,
+    stride)` for a rank-3 input `(N, C * kH * kW, L)`. Inverse of
+    `im2col`: places each of the `kH * kW` "kernel offsets" of the input
+    at strided positions inside a `(N, C, output_H + 2*pH, output_W +
+    2*pW)` canvas, summing overlaps, then crops the canvas to
+    `(N, C, output_H, output_W)`.
+
+    Tract has no NNEF-level `col2im` / `scatter_add-with-reduction` on
+    the version we target, so we decompose per kernel offset:
+
+    1. reshape input `(N, C*kH*kW, n_h*n_w)` -> `(N, C, kH, kW, n_h, n_w)`;
+    2. for every `(di, dj)`:
+       a. slice the per-offset feature map `(N, C, n_h, n_w)`;
+       b. spread it to `(N, C, n_h*sH, n_w*sW)` -- reshape with two
+          size-1 axes then `pad` axis 3 by `(0, sH-1)` and axis 5 by
+          `(0, sW-1)` to insert zeros between elements -- then reshape
+          to flatten the spread axes; trim trailing zeros by slicing to
+          `((n_h-1)*sH + 1, (n_w-1)*sW + 1)`;
+       c. pad to the canvas size `(padded_H, padded_W)` with left/top
+          offsets `(di*dH, dj*dW)`;
+    3. sum the `kH * kW` placed contributions (`add` chain);
+    4. crop the leading / trailing `(pH, pW)` rows / cols of the
+       canvas to land on `(N, C, output_H, output_W)`.
+
+    A future tract release that exposes a native col2im (or scatter-add
+    with sum reduction) lets us replace this chain with a single op
+    behind a version gate.
+    """
+    (
+        input_node,
+        output_size_node,
+        kernel_node,
+        dilation_node,
+        padding_node,
+        stride_node,
+    ) = node.inputs
+    if input_node.rank != 3:
+        raise T2NErrorNotImplemented(
+            f"col2im expects rank-3 input (N, C*kH*kW, L); got rank "
+            f"{input_node.rank}"
+        )
+    out_h, out_w = _as_pair(output_size_node, "output_size")
+    kh, kw = _as_pair(kernel_node, "kernel_size")
+    dh, dw = _as_pair(dilation_node, "dilation")
+    ph, pw = _as_pair(padding_node, "padding")
+    sh, sw = _as_pair(stride_node, "stride")
+    n = int(input_node.shape[0])
+    channels_packed = int(input_node.shape[1])
+    if channels_packed % (kh * kw) != 0:
+        raise T2NErrorNotImplemented(
+            f"col2im: input channel dim {channels_packed} not divisible "
+            f"by kH*kW={kh * kw}"
+        )
+    c = channels_packed // (kh * kw)
+    padded_h = out_h + 2 * ph
+    padded_w = out_w + 2 * pw
+    rcpt_h = dh * (kh - 1) + 1
+    rcpt_w = dw * (kw - 1) + 1
+    if padded_h < rcpt_h or padded_w < rcpt_w:
+        raise T2NErrorNotImplemented(
+            f"col2im: padded output ({padded_h}, {padded_w}) too small "
+            f"for receptive field ({rcpt_h}, {rcpt_w})"
+        )
+    n_h = (padded_h - rcpt_h) // sh + 1
+    n_w = (padded_w - rcpt_w) // sw + 1
+    if int(input_node.shape[2]) != n_h * n_w:
+        raise T2NErrorNotImplemented(
+            f"col2im: input L={input_node.shape[2]} != n_h*n_w={n_h * n_w}"
+        )
+
+    inp = op_helper.get_or_add_tensor_variable_in_nnef(input_node)
+    # Step 1: (N, C*kH*kW, L) -> (N, C, kH, kW, n_h, n_w).
+    reshaped = op_helper.add_single_output_op_from_nnef_tensors(
+        node,
+        "reshape",
+        inputs=inp,
+        attrs={"shape": [n, c, kh, kw, n_h, n_w]},
+        output_tensor_name_suffix="_col2im_reshape",
+    )
+
+    # Compactly-named helper for the trim length of the spread block.
+    spread_h_trim = (n_h - 1) * sh + 1
+    spread_w_trim = (n_w - 1) * sw + 1
+
+    contribution_refs = []
+    for di in range(kh):
+        for dj in range(kw):
+            slc = op_helper.add_single_output_op_from_nnef_tensors(
+                node,
+                "slice",
+                inputs=reshaped,
+                attrs={
+                    "axes": [2, 3],
+                    "begin": [di, dj],
+                    "end": [di + 1, dj + 1],
+                    "stride": [1, 1],
+                },
+                output_tensor_name_suffix=f"_c2i_sl{di}_{dj}",
+            )
+            # Drop the now-singleton (kH, kW) axes -> (N, C, n_h, n_w).
+            slc = op_helper.add_single_output_op_from_nnef_tensors(
+                node,
+                "squeeze",
+                inputs=slc,
+                attrs={"axes": [2, 3]},
+                output_tensor_name_suffix=f"_c2i_sq{di}_{dj}",
+            )
+            # Spread with stride: (n_h, n_w) -> (n_h*sH, n_w*sW) with
+            # zeros between elements. Only needed when stride > 1.
+            if sh > 1 or sw > 1:
+                slc = op_helper.add_single_output_op_from_nnef_tensors(
+                    node,
+                    "reshape",
+                    inputs=slc,
+                    attrs={"shape": [n, c, n_h, 1, n_w, 1]},
+                    output_tensor_name_suffix=f"_c2i_rs{di}_{dj}",
+                )
+                slc = op_helper.add_single_output_op_from_nnef_tensors(
+                    node,
+                    "pad",
+                    inputs=slc,
+                    attrs={
+                        "padding": [
+                            (0, 0),
+                            (0, 0),
+                            (0, 0),
+                            (0, sh - 1),
+                            (0, 0),
+                            (0, sw - 1),
+                        ],
+                        "value": 0.0,
+                    },
+                    output_tensor_name_suffix=f"_c2i_pd{di}_{dj}",
+                )
+                slc = op_helper.add_single_output_op_from_nnef_tensors(
+                    node,
+                    "reshape",
+                    inputs=slc,
+                    attrs={"shape": [n, c, n_h * sh, n_w * sw]},
+                    output_tensor_name_suffix=f"_c2i_fl{di}_{dj}",
+                )
+                # Trim trailing zero rows / cols.
+                slc = op_helper.add_single_output_op_from_nnef_tensors(
+                    node,
+                    "slice",
+                    inputs=slc,
+                    attrs={
+                        "axes": [2, 3],
+                        "begin": [0, 0],
+                        "end": [spread_h_trim, spread_w_trim],
+                        "stride": [1, 1],
+                    },
+                    output_tensor_name_suffix=f"_c2i_tr{di}_{dj}",
+                )
+            # Pad into the canvas at offset (di*dH, dj*dW).
+            pad_top = di * dh
+            pad_bottom = padded_h - pad_top - spread_h_trim
+            pad_left = dj * dw
+            pad_right = padded_w - pad_left - spread_w_trim
+            slc = op_helper.add_single_output_op_from_nnef_tensors(
+                node,
+                "pad",
+                inputs=slc,
+                attrs={
+                    "padding": [
+                        (0, 0),
+                        (0, 0),
+                        (pad_top, pad_bottom),
+                        (pad_left, pad_right),
+                    ],
+                    "value": 0.0,
+                },
+                output_tensor_name_suffix=f"_c2i_cv{di}_{dj}",
+            )
+            contribution_refs.append(slc)
+
+    # Step 3: sum kH*kW contributions via a chain of binary `add` ops.
+    accumulated = contribution_refs[0]
+    n_contribs = len(contribution_refs)
+    for idx in range(1, n_contribs):
+        accumulated = op_helper.add_single_output_op_from_nnef_tensors(
+            node,
+            "add",
+            inputs=(accumulated, contribution_refs[idx]),
+            output_tensor_name_suffix=f"_c2i_acc{idx}",
+        )
+    # Step 4: crop the (pH, pW) padding. We always emit the final
+    # `slice` (even when `pH == pW == 0` it just runs as a whole-tensor
+    # slice) so the canvas accumulator never needs to double as the
+    # named final output.
+    op_helper.add_single_output_op_from_nnef_tensors(
+        node,
+        "slice",
+        inputs=accumulated,
+        attrs={
+            "axes": [2, 3],
+            "begin": [ph, pw],
+            "end": [ph + out_h, pw + out_w],
+            "stride": [1, 1],
+        },
     )
     return []


### PR DESCRIPTION
## Summary

Adds support for \`aten::col2im\` -- the inverse of \`im2col\` (a.k.a. \`F.fold\`), the natural pair to #117.

### Decomposition

Tract 0.22.1 has no NNEF-level col2im and no scatter-add-with-\`sum\`-reduction (the reduction landed in 0.23). The emitter at \`torch_to_nnef/op/aten/axes_change.py:col2im\` builds the output as a sum of \`kH * kW\` \"placed contributions\". Per offset \`(di, dj)\`:

1. slice the per-offset feature map \`(N, C, n_h, n_w)\` out of the reshaped \`(N, C, kH, kW, n_h, n_w)\` tensor;
2. **spread with stride** -- reshape to \`(N, C, n_h, 1, n_w, 1)\`, \`pad\` axes 3 / 5 by \`(0, sH - 1)\` / \`(0, sW - 1)\` to insert zeros between elements, reshape to \`(N, C, n_h*sH, n_w*sW)\`, and \`slice\` to trim the trailing zeros (skipped entirely when \`sH == sW == 1\`);
3. **place into canvas** -- \`pad\` axes 2 / 3 to canvas size \`(padded_H, padded_W)\` with left/top offsets \`(di*dH, dj*dW)\`.

The \`kH * kW\` contributions are summed via an \`add\` chain, then a final \`slice\` strips the \`(pH, pW)\` border to land on \`(N, C, output_H, output_W)\`. The final slice is emitted unconditionally so the accumulator never has to double as the named output tensor (the path generalises cleanly to the degenerate \`kH * kW == 1\` case).

### Forward compatibility

Once tract grows a native col2im op (or \`tract_core_scatter_nd\` with \`sum\` reduction) at the NNEF op level, a version-gated path can replace this chain -- same pattern as the im2col fast-path described in #117.

### Dyn-axes

Opted out: \`n_h\` / \`n_w\` and per-axis pad amounts are derived from trace-time shape / attribute math.

### Coverage

\`docs/contributing/supported_operators.md\`: 294 -> 295 of 862; core PyTorch IR coverage 127 -> 128 / 138.

## Test plan

- [x] Proptest spec at \`tests/proptest/op_specs/shape.py\` covers square / asymmetric kernels, strides 1 / 2, dilations 1 / 2, paddings 0 / 1. Tolerance: \`EXACT\` (operand-order of the \`add\` chain matches torch's accumulation order).
- [x] Re-ran seeds 0, 1, 7, 13, 42, 99, 100, 500 -- all green.
- [x] Full sweep: 298 / 214 / 48 -> 299 / 215 / 48 (no regressions).
- [x] \`ruff check\` / \`ruff format\` clean on touched files.