### PR TITLE
feat(op): matrix-transpose + flip aliases (5 ops)

### DIFF
--- a/docs/contributing/supported_operators.md
+++ b/docs/contributing/supported_operators.md
@@ -31,9 +31,9 @@ This trims the unsupported column to the names where a `torch_to_nnef` emitter (
 
     -  and support from full `aten::`: 
 
-    [=303/673 "303/673"]
+    [=308/673 "308/673"]
 
-     (total operators listed as supported by `torch_to_nnef` being 335)
+     (total operators listed as supported by `torch_to_nnef` being 340)
 
     <div class="op-filter-container" markdown="0">
     <form class="op-filter-form">
@@ -329,8 +329,8 @@ This trims the unsupported column to the names where a `torch_to_nnef` emitter (
     <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.Tensor.fill_diagonal_.html">fill_diagonal_</a></td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.flatten.html">flatten</a></td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row unsupported"><td>❌</td><td>flatten_dense_tensors</td><td></td><td>❌</td><td>-</td></tr>
-    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.fliplr.html">fliplr</a></td><td></td><td>❌</td><td>-</td></tr>
-    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.flipud.html">flipud</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.fliplr.html">fliplr</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.flipud.html">flipud</a></td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.float_power.html">float_power</a></td><td></td><td>✅</td><td>-</td></tr>
     <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.floor_divide.html">floor_divide</a></td><td></td><td>✅</td><td>-</td></tr>
     <tr class="op-row unsupported"><td>❌</td><td>floordiv</td><td></td><td>❌</td><td>-</td></tr>
@@ -458,8 +458,8 @@ This trims the unsupported column to the names where a `torch_to_nnef` emitter (
     <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.linalg.lstsq.html">lstsq</a></td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.lu_solve.html">lu_solve</a></td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.lu_unpack.html">lu_unpack</a></td><td></td><td>❌</td><td>-</td></tr>
-    <tr class="op-row unsupported"><td>❌</td><td>mH</td><td>adjoint</td><td>❌</td><td>-</td></tr>
-    <tr class="op-row unsupported"><td>❌</td><td>mT</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td>mH</td><td>adjoint</td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td>mT</td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.margin_ranking_loss.html">margin_ranking_loss</a></td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.Tensor.masked_fill.html">masked_fill</a></td><td></td><td>✅</td><td>-</td></tr>
     <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.masked_select.html">masked_select</a></td><td></td><td>❌</td><td>-</td></tr>
@@ -581,7 +581,7 @@ This trims the unsupported column to the names where a `torch_to_nnef` emitter (
     <tr class="op-row supported"><td>✅</td><td>rnn_tanh</td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row unsupported"><td>❌</td><td>rnn_tanh_cell</td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.roll.html">roll</a></td><td></td><td>❌</td><td>-</td></tr>
-    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.rot90.html">rot90</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.rot90.html">rot90</a></td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row unsupported"><td>❌</td><td>rowwise_prune</td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.rrelu.html">rrelu</a></td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row unsupported"><td>❌</td><td>rrelu_with_noise</td><td></td><td>✅</td><td>-</td></tr>

--- a/tests/proptest/op_specs/shape.py
+++ b/tests/proptest/op_specs/shape.py
@@ -1693,6 +1693,126 @@ def _triangular_sample_st(
     return _draw()
 
 
+def _matrix_transpose_sample_st(
+    op_fn,
+) -> st.SearchStrategy[OpSample]:
+    """`Tensor.mT` / `Tensor.mH` -- swap the last two axes (rank >= 2)."""
+
+    @st.composite
+    def _draw(draw) -> OpSample:
+        rank = draw(st.integers(min_value=2, max_value=4))
+        shape = tuple(
+            draw(
+                st.lists(
+                    st.integers(min_value=1, max_value=4),
+                    min_size=rank,
+                    max_size=rank,
+                )
+            )
+        )
+        x = draw(
+            tensor_st(
+                shape,
+                torch.float32,
+                finite=True,
+                domain=Interval(-10.0, 10.0),
+            )
+        )
+        return OpSample(inputs=(x,), module=UnaryPrimitive(op_fn))
+
+    return _draw()
+
+
+def _fliplr_sample_st() -> st.SearchStrategy[OpSample]:
+    @st.composite
+    def _draw(draw) -> OpSample:
+        rank = draw(st.integers(min_value=2, max_value=4))
+        shape = tuple(
+            draw(
+                st.lists(
+                    st.integers(min_value=1, max_value=4),
+                    min_size=rank,
+                    max_size=rank,
+                )
+            )
+        )
+        x = draw(
+            tensor_st(
+                shape,
+                torch.float32,
+                finite=True,
+                domain=Interval(-10.0, 10.0),
+            )
+        )
+        return OpSample(inputs=(x,), module=UnaryPrimitive(torch.fliplr))
+
+    return _draw()
+
+
+def _flipud_sample_st() -> st.SearchStrategy[OpSample]:
+    @st.composite
+    def _draw(draw) -> OpSample:
+        rank = draw(st.integers(min_value=1, max_value=4))
+        shape = tuple(
+            draw(
+                st.lists(
+                    st.integers(min_value=1, max_value=4),
+                    min_size=rank,
+                    max_size=rank,
+                )
+            )
+        )
+        x = draw(
+            tensor_st(
+                shape,
+                torch.float32,
+                finite=True,
+                domain=Interval(-10.0, 10.0),
+            )
+        )
+        return OpSample(inputs=(x,), module=UnaryPrimitive(torch.flipud))
+
+    return _draw()
+
+
+def _rot90_sample_st() -> st.SearchStrategy[OpSample]:
+    """`torch.rot90(input, k, dims)`: rotate by 90 * k degrees."""
+
+    @st.composite
+    def _draw(draw) -> OpSample:
+        rank = draw(st.integers(min_value=2, max_value=4))
+        shape = tuple(
+            draw(
+                st.lists(
+                    st.integers(min_value=1, max_value=4),
+                    min_size=rank,
+                    max_size=rank,
+                )
+            )
+        )
+        k = draw(st.integers(min_value=0, max_value=3))
+        d0 = draw(st.integers(min_value=0, max_value=rank - 1))
+        d1 = draw(
+            st.integers(min_value=0, max_value=rank - 1).filter(
+                lambda v: v != d0
+            )
+        )
+        x = draw(
+            tensor_st(
+                shape,
+                torch.float32,
+                finite=True,
+                domain=Interval(-10.0, 10.0),
+            )
+        )
+        return OpSample(
+            inputs=(x,),
+            module=UnaryPrimitive(partial(torch.rot90, k=k, dims=(d0, d1))),
+        )
+
+    return _draw()
+
+
 def _flip_sample_st() -> st.SearchStrategy[OpSample]:
     """`torch.flip(input, dims)`: reverse along a unique subset of dims."""
 
@@ -1849,6 +1969,33 @@ def _concat_split_specs() -> T.List[OpSpec]:
         OpSpec(
             name="flip",
             sample_st=_flip_sample_st(),
+            tolerance=EXACT,
+        ),
+        OpSpec(
+            name="mT",
+            sample_st=_matrix_transpose_sample_st(lambda x: x.mT),
+            tolerance=EXACT,
+            dynamic_axes_compatible=True,
+        ),
+        OpSpec(
+            name="mH",
+            sample_st=_matrix_transpose_sample_st(lambda x: x.mH),
+            tolerance=EXACT,
+            dynamic_axes_compatible=True,
+        ),
+        OpSpec(
+            name="fliplr",
+            sample_st=_fliplr_sample_st(),
+            tolerance=EXACT,
+        ),
+        OpSpec(
+            name="flipud",
+            sample_st=_flipud_sample_st(),
+            tolerance=EXACT,
+        ),
+        OpSpec(
+            name="rot90",
+            sample_st=_rot90_sample_st(),
             tolerance=EXACT,
         ),
         OpSpec(

--- a/torch_to_nnef/op/aten/axes_change.py
+++ b/torch_to_nnef/op/aten/axes_change.py
@@ -135,6 +135,35 @@ def numpy_t(g, node, name_to_tensor, **kwargs):
     )
 
 
+@OP_REGISTRY.register(torch_op_ids=["mT", "mH"])
+def matrix_transpose(g, node, name_to_tensor, **kwargs):
+    """Map `aten::mT` and `aten::mH` (`Tensor.mT` / `Tensor.mH`) to NNEF.
+
+    Both ops swap the last two axes of a rank-`>=` 2 tensor. `mH` is the
+    conjugate-transpose; for real-valued tensors (the only ones NNEF /
+    tract carry without the complex feature flag) it is identical to
+    `mT`, so a single emitter handles both.
+    """
+    (input_node,) = node.inputs
+    if input_node.rank < 2:
+        raise T2NErrorNotImplemented(
+            f"mT / mH require rank >= 2; got {input_node.rank}"
+        )
+    perm = list(range(input_node.rank))
+    perm[-2], perm[-1] = perm[-1], perm[-2]
+    add_single_output_op(
+        g,
+        node,
+        name_to_tensor,
+        "transpose",
+        inputs=get_or_add_tensor_variable_in_nnef(
+            g, input_node, name_to_tensor
+        ),
+        attrs={"axes": perm},
+        pass_quantization_params=True,
+    )
+
+
 @OP_REGISTRY.register()
 def transpose(g, node, name_to_tensor, inference_target, **kwargs):
     """Map PyTorch: 'aten:transpose' to NNEF."""
@@ -310,23 +339,30 @@ def reshape(
     )
 
 
-@OP_REGISTRY.register()
-def flip(g, node, name_to_tensor, inference_target, **kwargs):
-    """Map PyTorch: 'aten:flip' to NNEF.
+def _emit_flip_chain(
+    g,
+    node,
+    name_to_tensor,
+    inference_target,
+    input_node,
+    raw_dims,
+    op_label: str,
+):
+    """Emit a per-axis `tract_core_gather` chain.
 
-    Decomposes to a chain of `tract_core_gather` calls, one per axis,
-    with a constant reversed-index tensor `[N-1, ..., 0]`. Static-shape
-    only: a dynamic axis size raises `T2NErrorNotImplemented` (would
-    require building the index at runtime via `tract_core_range` over
-    `tract_core_shape_of(input)[axis]`).
+    Shared by `flip` / `fliplr` / `flipud` / `rot90`. Each axis becomes
+    one `tract_core_gather` with a constant reversed-index tensor
+    `[N-1, ..., 0]`. Static-shape only: a dynamic axis size raises
+    `T2NErrorNotImplemented` (would require building the index at
+    runtime via `tract_core_range` over
+    `tract_core_shape_of(input)[axis]`). The last gather lands in
+    `node.outputs[0]` so the caller doesn't need to thread an output
+    name through.
     """
     if not isinstance(inference_target, TractNNEF):
         raise T2NErrorNotImplemented(
-            "flip requires `tract_core_gather` (TractNNEF target)"
+            f"{op_label} requires `tract_core_gather` (TractNNEF target)"
         )
-    input_node, dims_node = node.inputs
-    raw_dims = list(dims_node.data) if dims_node.data is not None else []
-
     seen = set()
     axes = []
     for d in raw_dims:
@@ -346,18 +382,18 @@ def flip(g, node, name_to_tensor, inference_target, **kwargs):
             inputs=cur_ref,
             attrs={"shape": list(input_node.shape)},
         )
-        return []
+        return ["tract_core"]
 
     for axis in axes:
         if not isinstance(input_node.shape[axis], int):
             raise T2NErrorNotImplemented(
-                f"flip on dynamic axis {axis} not yet supported"
+                f"{op_label} on dynamic axis {axis} not yet supported"
             )
 
     for i, axis in enumerate(axes):
         n = input_node.shape[axis]
         idx_const = PythonConstant(
-            name=f"{node.outputs[0].export_name}_flip_idx_{axis}",
+            name=f"{node.outputs[0].export_name}_{op_label}_idx_{axis}",
             data=torch.arange(n - 1, -1, -1, dtype=torch.int64),
         )
         idx_ref = get_or_add_tensor_variable_in_nnef(
@@ -372,8 +408,189 @@ def flip(g, node, name_to_tensor, inference_target, **kwargs):
             inputs=[cur_ref, idx_ref],
             attrs={"axis": axis},
             force_consistent_inputs_shapes=False,
-            output_tensor_name_suffix=("" if is_last else f"_flip_axis{axis}"),
+            output_tensor_name_suffix=(
+                "" if is_last else f"_{op_label}_axis{axis}"
+            ),
         )
+    return ["tract_core"]
+
+
+@OP_REGISTRY.register()
+def flip(g, node, name_to_tensor, inference_target, **kwargs):
+    """Map PyTorch `aten::flip(input, dims)` to NNEF."""
+    input_node, dims_node = node.inputs
+    raw_dims = list(dims_node.data) if dims_node.data is not None else []
+    return _emit_flip_chain(
+        g,
+        node,
+        name_to_tensor,
+        inference_target,
+        input_node,
+        raw_dims,
+        op_label="flip",
+    )
+
+
+@OP_REGISTRY.register()
+def fliplr(g, node, name_to_tensor, inference_target, **kwargs):
+    """Map `aten::fliplr` (`torch.fliplr`) to NNEF.
+
+    Reverses elements along axis 1 (per torch's rank>=2 convention).
+    """
+    (input_node,) = node.inputs
+    if input_node.rank < 2:
+        raise T2NErrorNotImplemented(
+            f"fliplr requires rank >= 2; got {input_node.rank}"
+        )
+    return _emit_flip_chain(
+        g,
+        node,
+        name_to_tensor,
+        inference_target,
+        input_node,
+        raw_dims=[1],
+        op_label="fliplr",
+    )
+
+
+@OP_REGISTRY.register()
+def flipud(g, node, name_to_tensor, inference_target, **kwargs):
+    """Map `aten::flipud` (`torch.flipud`) to NNEF.
+
+    Reverses elements along axis 0 (per torch's rank>=1 convention).
+    """
+    (input_node,) = node.inputs
+    if input_node.rank < 1:
+        raise T2NErrorNotImplemented(
+            f"flipud requires rank >= 1; got {input_node.rank}"
+        )
+    return _emit_flip_chain(
+        g,
+        node,
+        name_to_tensor,
+        inference_target,
+        input_node,
+        raw_dims=[0],
+        op_label="flipud",
+    )
+
+
+@OP_REGISTRY.register()
+def rot90(g, node, name_to_tensor, inference_target, op_helper, **kwargs):
+    """Map `aten::rot90(input, k, dims)` to NNEF.
+
+    Rotates by `90 * k` degrees in the plane `(dims[0], dims[1])`.
+    The rotation direction is from `dims[0]` toward `dims[1]`, matching
+    torch's convention. Decomposed per the standard `flip + transpose`
+    identity:
+
+    * `k % 4 == 0`: identity (single `reshape` with the same shape so
+      the named output tensor is materialised).
+    * `k % 4 == 1`: `flip(dims[1]) -> transpose(dims[0], dims[1])`.
+    * `k % 4 == 2`: `flip([dims[0], dims[1]])`.
+    * `k % 4 == 3`: `transpose(dims[0], dims[1]) -> flip(dims[1])`.
+    """
+    input_node, k_node, dims_node = node.inputs
+    if not isinstance(k_node, PythonConstant):
+        raise T2NErrorNotImplemented("rot90: k must be statically known")
+    raw_dims = list(dims_node.data) if dims_node.data is not None else [0, 1]
+    if len(raw_dims) != 2:
+        raise T2NErrorNotImplemented(
+            f"rot90: dims must be 2-element list; got {raw_dims!r}"
+        )
+    d0 = pick_axis(input_node, raw_dims[0])
+    d1 = pick_axis(input_node, raw_dims[1])
+    if d0 == d1:
+        raise T2NErrorNotImplemented(
+            f"rot90: dims must be distinct; got [{d0}, {d1}]"
+        )
+    k = int(k_node.data) % 4
+    if k == 0:
+        add_single_output_op(
+            g,
+            node,
+            name_to_tensor,
+            "reshape",
+            inputs=get_or_add_tensor_variable_in_nnef(
+                g, input_node, name_to_tensor
+            ),
+            attrs={"shape": list(input_node.shape)},
+        )
+        return []
+    if k == 2:
+        return _emit_flip_chain(
+            g,
+            node,
+            name_to_tensor,
+            inference_target,
+            input_node,
+            raw_dims=[d0, d1],
+            op_label="rot90",
+        )
+
+    # k in {1, 3}: one flip + one transpose, ordering swaps with k.
+    if not isinstance(input_node.shape[d1], int):
+        raise T2NErrorNotImplemented(
+            f"rot90 on dynamic axis {d1} not yet supported"
+        )
+    perm = list(range(input_node.rank))
+    perm[d0], perm[d1] = perm[d1], perm[d0]
+
+    if k == 1:
+        # flip(d1) first, then transpose.
+        flip_axis_n = input_node.shape[d1]
+        idx_const = PythonConstant(
+            name=f"{node.outputs[0].export_name}_rot90_idx_{d1}",
+            data=torch.arange(flip_axis_n - 1, -1, -1, dtype=torch.int64),
+        )
+        idx_ref = get_or_add_tensor_variable_in_nnef(
+            g, idx_const, name_to_tensor
+        )
+        flipped = op_helper.add_single_output_op_from_nnef_tensors(
+            node,
+            "tract_core_gather",
+            inputs=[
+                get_or_add_tensor_variable_in_nnef(
+                    g, input_node, name_to_tensor
+                ),
+                idx_ref,
+            ],
+            attrs={"axis": d1},
+            force_consistent_inputs_shapes=False,
+            output_tensor_name_suffix="_rot90_flip",
+        )
+        op_helper.add_single_output_op_from_nnef_tensors(
+            node,
+            "transpose",
+            inputs=flipped,
+            attrs={"axes": perm},
+        )
+        return ["tract_core"]
+
+    # k == 3: transpose first, then flip.
+    transposed = op_helper.add_single_output_op_from_nnef_tensors(
+        node,
+        "transpose",
+        inputs=get_or_add_tensor_variable_in_nnef(
+            g, input_node, name_to_tensor
+        ),
+        attrs={"axes": perm},
+        output_tensor_name_suffix="_rot90_t",
+    )
+    # After transpose, dim d1 still holds the previous d0's size.
+    flip_axis_n = input_node.shape[d0]
+    idx_const = PythonConstant(
+        name=f"{node.outputs[0].export_name}_rot90_idx_{d1}",
+        data=torch.arange(flip_axis_n - 1, -1, -1, dtype=torch.int64),
+    )
+    idx_ref = get_or_add_tensor_variable_in_nnef(g, idx_const, name_to_tensor)
+    op_helper.add_single_output_op_from_nnef_tensors(
+        node,
+        "tract_core_gather",
+        inputs=[transposed, idx_ref],
+        attrs={"axis": d1},
+        force_consistent_inputs_shapes=False,
+    )
     return ["tract_core"]
 
 


### PR DESCRIPTION
## Summary

Five aten ops added as thin wrappers / compositions over existing infrastructure.

| Op | How | Dyn-axes |
|---|---|---|
| `mT` (`Tensor.mT`) | last-two-axis `transpose` (constant permutation) | ✅ |
| `mH` (`Tensor.mH`) | same as `mT` for real-valued tensors (conjugate is identity); single emitter handles both via `torch_op_ids=["mT", "mH"]` | ✅ |
| `fliplr` | `_emit_flip_chain` with `raw_dims=[1]` | -- |
| `flipud` | `_emit_flip_chain` with `raw_dims=[0]` | -- |
| `rot90(input, k, dims)` | k%4 == 0 → identity reshape; k%4 == 1 → `flip(d1) -> transpose(d0,d1)`; k%4 == 2 → `flip([d0,d1])`; k%4 == 3 → `transpose(d0,d1) -> flip(d1)` | -- |

The existing `flip` emitter was refactored to extract its per-axis `tract_core_gather` chain into a private `_emit_flip_chain` helper so the three flip-family aliases can share it without duplication.

## Coverage

`docs/contributing/supported_operators.md`: 303 -> 308 of 673 (post-#120 denominator).

## Test plan

- [x] Verify spec fails without impl: 7 fail with `T2NErrorNotImplemented`.
- [x] Verify spec passes with impl: 7 passed / 3 skipped.
- [x] Full proptest sweep: 309 / 220 / 48 → 314 / 224 / 48 (no regressions).
- [x] `ruff check` / `ruff format` clean on touched files.