### PR TITLE
docs: collapsible exclusion appendix + softer pastel progress bars

### DIFF
--- a/docs/contributing/generate_support_page.py
+++ b/docs/contributing/generate_support_page.py
@@ -815,16 +815,36 @@ def build_markdown_header(fetcher) -> str:
         "\n\n"
         "We also exclude a long tail of identifiers that the `aten::*` "
         "source-grep picks up but that can never surface in an inference "
-        "JIT trace, grouped by reason:\n"
-        + "".join(
-            f"\n - **{label}** ({len(group)} names): "
-            f"`{', '.join(sorted(group))}`"
-            for label, group in NEVER_IN_INFERENCE_TRACE.items()
-        )
-        + "\n\nThis trims the unsupported column to the names where a "
-        "`torch_to_nnef` emitter (or a deliberate no-op map) would "
-        "actually be meaningful."
+        "JIT trace ([see the full list at the bottom of this "
+        "page](#excluded-aten-names)). This trims the unsupported column "
+        "to the names where a `torch_to_nnef` emitter (or a deliberate "
+        "no-op map) would actually be meaningful."
     )
+
+
+def build_excluded_appendix() -> str:
+    """Trailing collapsible appendix listing every excluded aten name.
+
+    Renders as a mkdocs-material collapsible admonition (`???`) so the
+    100+ identifiers don't drown the page; readers who want to audit
+    the exclusion sets can click to expand.
+    """
+    lines = [
+        '<h2 id="excluded-aten-names" style="margin-top:2rem;">',
+        "Appendix: identifiers excluded from this page",
+        "</h2>",
+        "",
+        "These names are filtered out of the support tables above because "
+        "they cannot surface in an inference JIT trace. Each group has a "
+        "documented rationale; click any to expand the full member list.",
+        "",
+    ]
+    for label, group in NEVER_IN_INFERENCE_TRACE.items():
+        lines.append(f'??? note "{label} ({len(group)} names)"')
+        members = ", ".join(f"`{n}`" for n in sorted(group))
+        lines.append(f"    {members}")
+        lines.append("")
+    return "\n".join(lines)
 
 
 def build_markdown_page(torch_version: str):
@@ -901,6 +921,7 @@ def build_markdown_page(torch_version: str):
                 support_n_ops_label="PyTorch's TorchScript ONNX exporter",
             )
         print(FILTER_SCRIPT, file=fh)
+        print(build_excluded_appendix(), file=fh)
     cache_url.save()
 
 

--- a/docs/contributing/supported_operators.md
+++ b/docs/contributing/supported_operators.md
@@ -9,17 +9,7 @@
 
 We filter out 'backward' and 'sym' operators from the listing since they are unwanted in an inference engine. In-place operations are merged with their non-inplace counterparts since that distinction is an inference implementation detail.
 
-We also exclude a long tail of identifiers that the `aten::*` source-grep picks up but that can never surface in an inference JIT trace, grouped by reason:
-
- - **Python builtin / scripting false positives** (52 names): `capitalize, center, chr, clear, dict, endswith, expandtabs, extend, find, format, get, getelem, hash, hex, isalnum, isalpha, isdecimal, isdigit, isidentifier, islower, isnumeric, isprintable, isspace, istitle, isupper, items, join, keys, ljust, lower, lstrip, oct, ord, partition, popitem, rfind, rindex, rjust, rpartition, rsplit, rstrip, setdefault, sorted, splitlines, startswith, strip, swapcase, title, update, upper, values, zfill`
- - **Test harness / placeholder identifiers** (13 names): `confirmed_by_owner, foo, mathremainder, percentFormat, pointwise_placeholder, symbolic_b, test, test_symbol, test_vartype, test_vartype2, unknown, view_expand_placeholder, your_op`
- - **Distributed / RPC primitives** (14 names): `all_gather_into_tensor, all_reduce, fork, get_gradients, is_owner, local_value, owner, owner_name, reduce_scatter_tensor, to_here, wait, wait_tensor, warn, warns`
- - **Backend-specific dispatch shims (cudnn / miopen / mkldnn / mps)** (26 names): `cudnn_affine_grid_generator, cudnn_batch_norm, cudnn_convolution, cudnn_convolution_add_relu, cudnn_convolution_relu, cudnn_convolution_transpose, cudnn_grid_sampler, cudnn_is_acceptable, miopen_batch_norm, miopen_convolution, miopen_convolution_add_relu, miopen_convolution_relu, miopen_convolution_transpose, miopen_ctc_loss, miopen_depthwise_convolution, miopen_rnn, mkldnn_adaptive_avg_pool2d, mkldnn_convolution, mkldnn_linear, mkldnn_max_pool2d, mkldnn_max_pool3d, mkldnn_reorder_conv2d_weight, mkldnn_reorder_conv3d_weight, mkldnn_rnn_layer, mps_linear, to_mkldnn`
- - **Tensor metadata accessors (return a Python value, not a tensor)** (60 names): `can_cast, data, dense_dim, device, dtype, element_size, enable_grad, get_autocast_dtype, get_device, get_pool_ceil_padding, grad, has_torch_function, iinfo, initial_seed, int_repr, is_autocast_cpu_enabled, is_autocast_enabled, is_coalesced, is_complex, is_conj, is_contiguous, is_cuda, is_grad_enabled, is_leaf, is_non_overlapping_and_dense, is_nonzero, is_pinned, is_same_size, is_scripting, is_set_to, is_signed, is_strides_like_format, manual_seed, node, op, op_name, output_nr, pin_memory, promote_types, q_per_channel_axis, q_per_channel_scales, q_per_channel_zero_points, q_scale, q_zero_point, qscheme, record_stream, refine_names, rename, requires_grad_, result_type, retain_grad, retains_grad, save, seed, set_data, set_grad_enabled, set_source_Tensor_storage_offset, sparse_dim, storage_offset, stride`
- - **Named-tensor API (names stripped before JIT trace)** (3 names): `align_as, align_tensors, align_to`
- - **Sparse-tensor machinery (NNEF / tract are dense-only)** (25 names): `ccol_indices, ccol_indices_copy, coalesce, col_indices, col_indices_copy, copy_sparse_to_sparse, crow_indices, crow_indices_copy, hspmm, indices, indices_copy, nested_to_padded_tensor, row_indices, row_indices_copy, smm, sparse_compressed_tensor, sparse_coo_tensor, sparse_mask, sparse_resize, sparse_resize_and_clear, sparse_sampled_addmm, sspaddmm, to_dense, to_padded_tensor, values_copy`
-
-This trims the unsupported column to the names where a `torch_to_nnef` emitter (or a deliberate no-op map) would actually be meaningful.
+We also exclude a long tail of identifiers that the `aten::*` source-grep picks up but that can never surface in an inference JIT trace ([see the full list at the bottom of this page](#excluded-aten-names)). This trims the unsupported column to the names where a `torch_to_nnef` emitter (or a deliberate no-op map) would actually be meaningful.
 === "TractNNEF"
 
 
@@ -1441,4 +1431,31 @@ This trims the unsupported column to the names where a `torch_to_nnef` emitter (
   });
 })();
 </script>
+
+<h2 id="excluded-aten-names" style="margin-top:2rem;">
+Appendix: identifiers excluded from this page
+</h2>
+
+These names are filtered out of the support tables above because they cannot surface in an inference JIT trace. Each group has a documented rationale; click any to expand the full member list.
+
+??? note "Python builtin / scripting false positives (52 names)"
+    `capitalize`, `center`, `chr`, `clear`, `dict`, `endswith`, `expandtabs`, `extend`, `find`, `format`, `get`, `getelem`, `hash`, `hex`, `isalnum`, `isalpha`, `isdecimal`, `isdigit`, `isidentifier`, `islower`, `isnumeric`, `isprintable`, `isspace`, `istitle`, `isupper`, `items`, `join`, `keys`, `ljust`, `lower`, `lstrip`, `oct`, `ord`, `partition`, `popitem`, `rfind`, `rindex`, `rjust`, `rpartition`, `rsplit`, `rstrip`, `setdefault`, `sorted`, `splitlines`, `startswith`, `strip`, `swapcase`, `title`, `update`, `upper`, `values`, `zfill`
+
+??? note "Test harness / placeholder identifiers (13 names)"
+    `confirmed_by_owner`, `foo`, `mathremainder`, `percentFormat`, `pointwise_placeholder`, `symbolic_b`, `test`, `test_symbol`, `test_vartype`, `test_vartype2`, `unknown`, `view_expand_placeholder`, `your_op`
+
+??? note "Distributed / RPC primitives (14 names)"
+    `all_gather_into_tensor`, `all_reduce`, `fork`, `get_gradients`, `is_owner`, `local_value`, `owner`, `owner_name`, `reduce_scatter_tensor`, `to_here`, `wait`, `wait_tensor`, `warn`, `warns`
+
+??? note "Backend-specific dispatch shims (cudnn / miopen / mkldnn / mps) (26 names)"
+    `cudnn_affine_grid_generator`, `cudnn_batch_norm`, `cudnn_convolution`, `cudnn_convolution_add_relu`, `cudnn_convolution_relu`, `cudnn_convolution_transpose`, `cudnn_grid_sampler`, `cudnn_is_acceptable`, `miopen_batch_norm`, `miopen_convolution`, `miopen_convolution_add_relu`, `miopen_convolution_relu`, `miopen_convolution_transpose`, `miopen_ctc_loss`, `miopen_depthwise_convolution`, `miopen_rnn`, `mkldnn_adaptive_avg_pool2d`, `mkldnn_convolution`, `mkldnn_linear`, `mkldnn_max_pool2d`, `mkldnn_max_pool3d`, `mkldnn_reorder_conv2d_weight`, `mkldnn_reorder_conv3d_weight`, `mkldnn_rnn_layer`, `mps_linear`, `to_mkldnn`
+
+??? note "Tensor metadata accessors (return a Python value, not a tensor) (60 names)"
+    `can_cast`, `data`, `dense_dim`, `device`, `dtype`, `element_size`, `enable_grad`, `get_autocast_dtype`, `get_device`, `get_pool_ceil_padding`, `grad`, `has_torch_function`, `iinfo`, `initial_seed`, `int_repr`, `is_autocast_cpu_enabled`, `is_autocast_enabled`, `is_coalesced`, `is_complex`, `is_conj`, `is_contiguous`, `is_cuda`, `is_grad_enabled`, `is_leaf`, `is_non_overlapping_and_dense`, `is_nonzero`, `is_pinned`, `is_same_size`, `is_scripting`, `is_set_to`, `is_signed`, `is_strides_like_format`, `manual_seed`, `node`, `op`, `op_name`, `output_nr`, `pin_memory`, `promote_types`, `q_per_channel_axis`, `q_per_channel_scales`, `q_per_channel_zero_points`, `q_scale`, `q_zero_point`, `qscheme`, `record_stream`, `refine_names`, `rename`, `requires_grad_`, `result_type`, `retain_grad`, `retains_grad`, `save`, `seed`, `set_data`, `set_grad_enabled`, `set_source_Tensor_storage_offset`, `sparse_dim`, `storage_offset`, `stride`
+
+??? note "Named-tensor API (names stripped before JIT trace) (3 names)"
+    `align_as`, `align_tensors`, `align_to`
+
+??? note "Sparse-tensor machinery (NNEF / tract are dense-only) (25 names)"
+    `ccol_indices`, `ccol_indices_copy`, `coalesce`, `col_indices`, `col_indices_copy`, `copy_sparse_to_sparse`, `crow_indices`, `crow_indices_copy`, `hspmm`, `indices`, `indices_copy`, `nested_to_padded_tensor`, `row_indices`, `row_indices_copy`, `smm`, `sparse_compressed_tensor`, `sparse_coo_tensor`, `sparse_mask`, `sparse_resize`, `sparse_resize_and_clear`, `sparse_sampled_addmm`, `sspaddmm`, `to_dense`, `to_padded_tensor`, `values_copy`
 

--- a/docs/style.css
+++ b/docs/style.css
@@ -54,15 +54,17 @@
 }
 
 .progress-40plus .progress-bar {
-  background-color: #ff5252;
+  /* Pastel coral; the saturated #ff5252 felt visually loud against the
+     pastel-green progress states above. */
+  background-color: #f5b5b5;
 }
 
 .progress-20plus .progress-bar {
-  background-color: #ffa7aa;
+  background-color: #f0a0a3;
 }
 
 .progress-0plus .progress-bar {
-  background-color: #f50057;
+  background-color: #e8838c;
 }
 
 


### PR DESCRIPTION
## Summary

Two presentation tweaks on the support page surfaced in feedback after #120.

### 1. Move the 193-name exclusion list to a collapsible appendix

The exclusion listing introduced in #120 lived at the very top of the page, drowning the actual support tables. Move it to a trailing appendix anchored at `#excluded-aten-names`, with one collapsible admonition (`??? note`) per group so each group can be expanded on demand without dominating the page. The top-of-page reference now links into the appendix.

Generator-side: extract `build_excluded_appendix()` (rendered after the per-target tabs are written via `print(build_excluded_appendix(), file=fh)`). No data change vs #120 -- same seven groups, same names, same totals.

### 2. Pastel coral / rose for lower-coverage progress bars

The 40+ / 20+ / 0+ progress states were using saturated reds (`#ff5252` / `#f50057`) that read as alarm rather than information, especially next to the pastel green (`#aad6aa`) used by the 80+ state. Replace with pastel coral / rose:

| State | Old | New |
|---|---|---|
| 40+ | `#ff5252` | `#f5b5b5` |
| 20+ | `#ffa7aa` | `#f0a0a3` |
| 0+ | `#f50057` | `#e8838c` |

`#aad6aa` for 80+ stays as the visual reference for "this is the pastel scale".

## Test plan

- [x] Regenerated the support page; eyeballed:
  - Top-of-page mention is short + links to anchor.
  - Each group renders as `??? note "<label> (<N> names)"` -- click expands to a comma-separated, code-formatted name list.
  - Anchor `#excluded-aten-names` resolves to the `<h2>` heading.
- [x] Inspected `docs/style.css` diff: only the three progress-bar colours changed; everything else is identical.
- [x] No coverage or count change vs #120 (this is pure presentation).