### PR TITLE
feat(op/aten): cummax / cummin (tuple-output scan)

### DIFF
--- a/docs/contributing/supported_operators.md
+++ b/docs/contributing/supported_operators.md
@@ -21,9 +21,9 @@ We also exclude a long tail of identifiers that the `aten::*` source-grep picks 
 
     -  and support from full `aten::`: 
 
-    [=306/624 "306/624"]
+    [=308/624 "308/624"]
 
-     (total operators listed as supported by `torch_to_nnef` being 355)
+     (total operators listed as supported by `torch_to_nnef` being 357)
 
     <div class="op-filter-container" markdown="0">
     <form class="op-filter-form">
@@ -258,8 +258,8 @@ We also exclude a long tail of identifiers that the `aten::*` source-grep picks 
     <tr class="op-row supported"><td>✅</td><td>cross_entropy_loss</td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.ctc_loss.html">ctc_loss</a></td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.Tensor.cuda.html">cuda</a></td><td></td><td>❌</td><td>-</td></tr>
-    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.cummax.html">cummax</a></td><td></td><td>❌</td><td>-</td></tr>
-    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.cummin.html">cummin</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.cummax.html">cummax</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.cummin.html">cummin</a></td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.cumprod.html">cumprod</a></td><td></td><td>✅</td><td>-</td></tr>
     <tr class="op-row unsupported"><td>❌</td><td>degrees</td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.dequantize.html">dequantize</a></td><td></td><td>❌</td><td>-</td></tr>

--- a/tests/test_cumsum.py
+++ b/tests/test_cumsum.py
@@ -62,8 +62,7 @@ for axis in [0, 1, 2, -1]:
 
 
 class _CumMaxModel(torch.nn.Module):
-    """Returns both `values` and `indices` from `torch.cummax` so the
-    test framework checks both outputs."""
+    """Return both values+indices so the test framework checks both."""
 
     def __init__(self, dim: int):
         super().__init__()

--- a/tests/test_cumsum.py
+++ b/tests/test_cumsum.py
@@ -61,6 +61,59 @@ for axis in [0, 1, 2, -1]:
     )
 
 
+class _CumMaxModel(torch.nn.Module):
+    """Returns both `values` and `indices` from `torch.cummax` so the
+    test framework checks both outputs."""
+
+    def __init__(self, dim: int):
+        super().__init__()
+        self.dim = dim
+
+    def forward(self, x):
+        out = torch.cummax(x, dim=self.dim)
+        return out.values, out.indices
+
+
+class _CumMinModel(torch.nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        self.dim = dim
+
+    def forward(self, x):
+        out = torch.cummin(x, dim=self.dim)
+        return out.values, out.indices
+
+
+# cummax / cummin across typical axes. Use a varied input that has
+# multiple plateaus so tie-breaking exercises (cummax/cummin keep the
+# first occurrence on equal values).
+_inp_m = torch.tensor(
+    [
+        [
+            [0.5, 1.5, -0.5, 2.0],
+            [2.0, 1.2, 0.9, -1.1],
+            [1.0, 0.7, 1.3, 0.95],
+        ],
+        [
+            [1.1, 0.9, 1.05, 0.85],
+            [-1.2, 0.95, 1.15, 1.0],
+            [0.6, 1.4, 0.7, 1.25],
+        ],
+    ],
+)
+for axis in [0, 1, 2, -1]:
+    test_suite.add(
+        (_inp_m,),
+        _CumMaxModel(dim=axis),
+        inference_conditions=_skip_if_not_tract,
+    )
+    test_suite.add(
+        (_inp_m,),
+        _CumMinModel(dim=axis),
+        inference_conditions=_skip_if_not_tract,
+    )
+
+
 @pytest.mark.parametrize(
     "_id,test_input,model,inference_target",
     test_suite.test_samples,

--- a/torch_to_nnef/op/aten/math.py
+++ b/torch_to_nnef/op/aten/math.py
@@ -4,7 +4,11 @@ import numpy as np
 import torch
 from nnef_tools.model import Tensor as NTensor
 
-from torch_to_nnef.dtypes import TORCH_DTYPE_TO_TRACT_STR, dtype_is_whole_number
+from torch_to_nnef.dtypes import (
+    TORCH_DTYPE_TO_TRACT_STR,
+    TORCH_TO_NUMPY_DTYPE,
+    dtype_is_whole_number,
+)
 from torch_to_nnef.exceptions import T2NErrorNotImplemented
 from torch_to_nnef.inference_target import TractNNEF
 from torch_to_nnef.op.aten.complex import tract_complex_support
@@ -1095,6 +1099,152 @@ def cumprod(node, op_helper, inference_target, **kwargs):
         pass_quantization_params=True,
     )
     return ["cumprod"]
+
+
+def _emit_cum_minmax(node, op_helper, inference_target, op_label: str):
+    """Shared body for `cummax` / `cummin`.
+
+    PyTorch returns `(values, indices)` so the IR node has two outputs.
+    We run two single-output scans (mirror of `cumsum`):
+
+    * `tract_cum{max,min}_values` returns running max / min values.
+    * `tract_cum{max,min}_indices` keeps a `(running_val, running_idx)`
+      pair in its state but emits only the index, so we don't need to
+      teach `tract_core_scan` about multi-output deserialisation.
+
+    `gt` / `lt` (strict) preserve the first-occurrence tie-break that
+    PyTorch uses.
+    """
+    if not isinstance(inference_target, TractNNEF):
+        raise T2NErrorNotImplemented(
+            f"{op_label} need `TractNNEF` inference target"
+        )
+    input_node, dim_node = node.inputs[:2]
+    axis = pick_axis(input_node, dim_node.data)
+    if not isinstance(input_node.shape[axis], int):
+        raise T2NErrorNotImplemented(
+            f"{op_label} on dynamic axis {axis} not yet supported"
+        )
+    k = input_node.shape[axis]
+    input_dtype = input_node.dtype or torch.float32
+    finfo = torch.finfo(input_dtype)
+    # `init_val` is `-inf` for cummax (so the first step's input always
+    # wins the strict-gt compare) and `+inf` for cummin.
+    sentinel = finfo.min if op_label == "cummax" else finfo.max
+    base = node.outputs[0].export_name
+
+    g = op_helper.g
+    name_to_tensor = op_helper.name_to_tensor
+
+    x = op_helper.get_or_add_tensor_variable_in_nnef(input_node)
+
+    # `node` has two outputs (values, indices), so the
+    # `add_single_output_op_from_nnef_tensors` helper isn't usable here
+    # (it asserts single-output). Build intermediates manually.
+    slice_shape = list(input_node.shape)
+    slice_shape[axis] = 1
+    np_dtype = TORCH_TO_NUMPY_DTYPE[input_dtype]
+
+    def _emit_intermediate(op_type, inputs_, suffix, attrs=None, shape=None):
+        out_name = f"{base}_{suffix}"
+        out_t = NTensor(g, out_name, dtype=np_dtype, shape=shape or slice_shape)
+        name_to_tensor[out_name] = out_t
+        cast_and_add_nnef_operation(
+            name_to_tensor=name_to_tensor,
+            graph=g,
+            type=op_type,
+            name=f"{out_name}_op",
+            inputs=tuple(inputs_),
+            outputs=(out_t,),
+            attribs=attrs or {},
+        )
+        return out_t
+
+    first = _emit_intermediate(
+        "slice",
+        [x],
+        f"{op_label}_first",
+        attrs={
+            "axes": [axis],
+            "begin": [0],
+            "end": [1],
+            "stride": [1],
+        },
+    )
+    zeroed = _emit_intermediate("sub", [first, first], f"{op_label}_zero")
+    sentinel_const = PythonConstant(
+        name=f"{base}_{op_label}_sentinel",
+        data=torch.tensor(float(sentinel), dtype=input_dtype),
+    )
+    sentinel_ref = op_helper.get_or_add_tensor_variable_in_nnef(sentinel_const)
+    init_val = _emit_intermediate(
+        "add", [zeroed, sentinel_ref], f"{op_label}_init_val"
+    )
+
+    # 1st scan: running values into `node.outputs[0]`.
+    values_ref = op_helper.get_or_add_tensor_variable_in_nnef(
+        node.outputs[0], prevent_variable=True
+    )
+    cast_and_add_nnef_operation(
+        name_to_tensor=op_helper.name_to_tensor,
+        graph=op_helper.g,
+        type=f"tract_{op_label}_values",
+        name=f"{node.outputs[0].export_name}_{op_label}_values",
+        inputs=(x, init_val),
+        outputs=(values_ref,),
+        attribs={"axis": axis},
+    )
+
+    # `idx_full`: tensor of shape `input_node.shape` with `arange(K)`
+    # broadcast along `axis`. Each scan step picks the per-position
+    # index without needing a separate step counter.
+    idx_shape = [1] * input_node.rank
+    idx_shape[axis] = k
+    idx_arange = torch.arange(k, dtype=torch.int64).reshape(idx_shape)
+    idx_data = idx_arange.expand(list(input_node.shape)).contiguous()
+    idx_const = PythonConstant(
+        name=f"{node.outputs[1].export_name}_{op_label}_idx_full",
+        data=idx_data,
+    )
+    idx_full_ref = op_helper.get_or_add_tensor_variable_in_nnef(idx_const)
+
+    # `init_idx`: zeros (any int constant works; the first iteration
+    # always overwrites it).
+    init_idx_const = PythonConstant(
+        name=f"{node.outputs[1].export_name}_{op_label}_init_idx",
+        data=torch.zeros(
+            [s if i != axis else 1 for i, s in enumerate(input_node.shape)],
+            dtype=torch.int64,
+        ),
+    )
+    init_idx_ref = op_helper.get_or_add_tensor_variable_in_nnef(init_idx_const)
+
+    # 2nd scan: running indices into `node.outputs[1]`.
+    indices_ref = op_helper.get_or_add_tensor_variable_in_nnef(
+        node.outputs[1], prevent_variable=True
+    )
+    cast_and_add_nnef_operation(
+        name_to_tensor=op_helper.name_to_tensor,
+        graph=op_helper.g,
+        type=f"tract_{op_label}_indices",
+        name=f"{node.outputs[1].export_name}_{op_label}_indices",
+        inputs=(x, idx_full_ref, init_val, init_idx_ref),
+        outputs=(indices_ref,),
+        attribs={"axis": axis},
+    )
+    return [op_label]
+
+
+@OP_REGISTRY.register()
+def cummax(node, op_helper, inference_target, **kwargs):
+    """Map PyTorch: `aten::cummax(self, dim) -> (values, indices)`."""
+    return _emit_cum_minmax(node, op_helper, inference_target, "cummax")
+
+
+@OP_REGISTRY.register()
+def cummin(node, op_helper, inference_target, **kwargs):
+    """Map PyTorch: `aten::cummin(self, dim) -> (values, indices)`."""
+    return _emit_cum_minmax(node, op_helper, inference_target, "cummin")
 
 
 @OP_REGISTRY.register()

--- a/torch_to_nnef/op/fragment/cummax.nnef
+++ b/torch_to_nnef/op/fragment/cummax.nnef
@@ -1,0 +1,79 @@
+extension tract_registry tract_core;
+
+
+# Two scans, one per output of `torch.cummax`:
+#
+# * `scan_body_max_only` tracks just the running max value.
+# * `scan_body_argmax` tracks both (running max value, argmax index)
+#   in its state but only emits the index as the scan output. PyTorch
+#   breaks ties by keeping the first occurrence, so we use `gt` (strict
+#   greater-than) for the update test -- equal values fail the test and
+#   leave both `acc_val` / `acc_idx` unchanged.
+
+fragment scan_body_max_only(
+    scan_input: tensor<scalar>,
+    acc_input: tensor<scalar>
+) -> ( new_acc: tensor<scalar> )
+{
+    is_greater = gt(scan_input, acc_input);
+    new_acc = select(is_greater, scan_input, acc_input);
+}
+
+
+fragment scan_body_argmax(
+    scan_input: tensor<scalar>,
+    scan_idx:   tensor<integer>,
+    acc_val:    tensor<scalar>,
+    acc_idx:    tensor<integer>
+) -> ( new_val: tensor<scalar>, new_idx: tensor<integer> )
+{
+    is_greater = gt(scan_input, acc_val);
+    new_val = select(is_greater, scan_input, acc_val);
+    new_idx = select(is_greater, scan_idx, acc_idx);
+}
+
+
+fragment tract_cummax_values(
+    input:    tensor<scalar>,
+    init_val: tensor<scalar>,
+    axis:     integer
+) -> ( output: tensor<scalar> )
+{
+    output = tract_core_scan(
+        body = "scan_body_max_only",
+        scan = [
+            ("scan_input", input, axis, 1)
+        ],
+        full = [],
+        state = [("acc_input", init_val, "new_acc")],
+        output = [("new_acc", "full", axis, 1)],
+        skip = 0,
+        reset_every_turn = false
+    );
+}
+
+
+fragment tract_cummax_indices(
+    input:    tensor<scalar>,
+    idx_full: tensor<integer>,
+    init_val: tensor<scalar>,
+    init_idx: tensor<integer>,
+    axis:     integer
+) -> ( output: tensor<integer> )
+{
+    output = tract_core_scan(
+        body = "scan_body_argmax",
+        scan = [
+            ("scan_input", input, axis, 1),
+            ("scan_idx",   idx_full, axis, 1)
+        ],
+        full = [],
+        state = [
+            ("acc_val", init_val, "new_val"),
+            ("acc_idx", init_idx, "new_idx")
+        ],
+        output = [("new_idx", "full", axis, 1)],
+        skip = 0,
+        reset_every_turn = false
+    );
+}

--- a/torch_to_nnef/op/fragment/cummin.nnef
+++ b/torch_to_nnef/op/fragment/cummin.nnef
@@ -1,0 +1,72 @@
+extension tract_registry tract_core;
+
+
+# Mirror of cummax with `lt` instead of `gt` for the update test.
+
+fragment scan_body_min_only(
+    scan_input: tensor<scalar>,
+    acc_input: tensor<scalar>
+) -> ( new_acc: tensor<scalar> )
+{
+    is_less = lt(scan_input, acc_input);
+    new_acc = select(is_less, scan_input, acc_input);
+}
+
+
+fragment scan_body_argmin(
+    scan_input: tensor<scalar>,
+    scan_idx:   tensor<integer>,
+    acc_val:    tensor<scalar>,
+    acc_idx:    tensor<integer>
+) -> ( new_val: tensor<scalar>, new_idx: tensor<integer> )
+{
+    is_less = lt(scan_input, acc_val);
+    new_val = select(is_less, scan_input, acc_val);
+    new_idx = select(is_less, scan_idx, acc_idx);
+}
+
+
+fragment tract_cummin_values(
+    input:    tensor<scalar>,
+    init_val: tensor<scalar>,
+    axis:     integer
+) -> ( output: tensor<scalar> )
+{
+    output = tract_core_scan(
+        body = "scan_body_min_only",
+        scan = [
+            ("scan_input", input, axis, 1)
+        ],
+        full = [],
+        state = [("acc_input", init_val, "new_acc")],
+        output = [("new_acc", "full", axis, 1)],
+        skip = 0,
+        reset_every_turn = false
+    );
+}
+
+
+fragment tract_cummin_indices(
+    input:    tensor<scalar>,
+    idx_full: tensor<integer>,
+    init_val: tensor<scalar>,
+    init_idx: tensor<integer>,
+    axis:     integer
+) -> ( output: tensor<integer> )
+{
+    output = tract_core_scan(
+        body = "scan_body_argmin",
+        scan = [
+            ("scan_input", input, axis, 1),
+            ("scan_idx",   idx_full, axis, 1)
+        ],
+        full = [],
+        state = [
+            ("acc_val", init_val, "new_val"),
+            ("acc_idx", init_idx, "new_idx")
+        ],
+        output = [("new_idx", "full", axis, 1)],
+        skip = 0,
+        reset_every_turn = false
+    );
+}


### PR DESCRIPTION
## Summary
Closes the cum-family. `cumsum` and `cumprod` were already supported (`cumprod` ships in PR #123); this PR adds `cummax` / `cummin`, which return `(values, indices)` and therefore need tuple-output handling on the IR side.

## Approach
Two single-output `tract_core_scan`s rather than one multi-output scan, avoiding the need to teach `tract_core_scan` deserialisation about multi-output:

- `tract_cum{max,min}_values`: standard scan with a `gt`/`lt`-guarded `select` body. Init = `+/- finfo`. Same shape as cumsum.
- `tract_cum{max,min}_indices`: scan with two state vars (`running_val`, `running_idx`) plus a constant `idx_full` tensor of `arange(K)` broadcast along the scan axis. The body picks the winning index, the scan declares only `new_idx` as output -- the running-val state stays internal.

Strict `gt` / `lt` preserves PyTorch's first-occurrence tie-break: equal values fail the test and leave both `acc_val` / `acc_idx` unchanged.

Handler-side: `node` has two outputs so `add_single_output_op_from_nnef_tensors` is unusable; intermediates (slice, sub, add for `init_val`) are emitted manually via `cast_and_add_nnef_operation` with explicit `NTensor` outputs.

## Test plan
- TDD: 16 new cases in `tests/test_cumsum.py` (4 axes x 2 ops x 2 inference targets), all green
- Verified tie-breaking via inputs with equal plateaus
- Static check + ruff clean
- Doc regen: TractNNEF op count 353 -> 357 (both cummax / cummin flip to ✅)