### PR TITLE
feat(op/aten): complex constructor + conj/conj_physical fix + 6 elementwise

### DIFF
--- a/docs/contributing/supported_operators.md
+++ b/docs/contributing/supported_operators.md
@@ -21,9 +21,9 @@ We also exclude a long tail of identifiers that the `aten::*` source-grep picks 
 
     -  and support from full `aten::`: 
 
-    [=308/624 "308/624"]
+    [=316/624 "316/624"]
 
-     (total operators listed as supported by `torch_to_nnef` being 357)
+     (total operators listed as supported by `torch_to_nnef` being 366)
 
     <div class="op-filter-container" markdown="0">
     <form class="op-filter-form">
@@ -233,8 +233,8 @@ We also exclude a long tail of identifiers that the `aten::*` source-grep picks 
     <tr class="op-row supported"><td>✅</td><td>clamp_max</td><td></td><td>✅</td><td>-</td></tr>
     <tr class="op-row supported"><td>✅</td><td>clamp_min</td><td></td><td>✅</td><td>-</td></tr>
     <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.column_stack.html">column_stack</a></td><td></td><td>❌</td><td>-</td></tr>
-    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.complex.html">complex</a></td><td></td><td>❌</td><td>-</td></tr>
-    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.conj.html">conj</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.complex.html">complex</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.conj.html">conj</a></td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.conj_physical.html">conj_physical</a></td><td></td><td>✅</td><td>-</td></tr>
     <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.Tensor.contiguous.html">contiguous</a></td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row unsupported"><td>❌</td><td>conv</td><td></td><td>❌</td><td>-</td></tr>
@@ -286,7 +286,7 @@ We also exclude a long tail of identifiers that the `aten::*` source-grep picks 
     <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.equal.html">equal</a></td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.erfc.html">erfc</a></td><td>special_erfc</td><td>✅</td><td>-</td></tr>
     <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.erfinv.html">erfinv</a></td><td>special_erfinv</td><td>✅</td><td>-</td></tr>
-    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.exp2.html">exp2</a></td><td>special_exp2</td><td>✅</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.exp2.html">exp2</a></td><td>special_exp2</td><td>✅</td><td>-</td></tr>
     <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.Tensor.expand_as.html">expand_as</a></td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row unsupported"><td>❌</td><td>exponential</td><td></td><td>✅</td><td>-</td></tr>
     <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.eye.html">eye</a></td><td></td><td>❌</td><td>-</td></tr>
@@ -308,8 +308,8 @@ We also exclude a long tail of identifiers that the `aten::*` source-grep picks 
     <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.Tensor.float_power_.html">float_power_</a></td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.floor_divide.html">floor_divide</a></td><td></td><td>✅</td><td>-</td></tr>
     <tr class="op-row unsupported"><td>❌</td><td>floordiv</td><td></td><td>❌</td><td>-</td></tr>
-    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.fmax.html">fmax</a></td><td></td><td>❌</td><td>-</td></tr>
-    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.fmin.html">fmin</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.fmax.html">fmax</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.fmin.html">fmin</a></td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.frac.html">frac</a></td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.fractional_max_pool2d.html">fractional_max_pool2d</a></td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.fractional_max_pool3d.html">fractional_max_pool3d</a></td><td></td><td>❌</td><td>-</td></tr>
@@ -334,13 +334,13 @@ We also exclude a long tail of identifiers that the `aten::*` source-grep picks 
     <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.hardsigmoid.html">hardsigmoid</a></td><td></td><td>✅</td><td>-</td></tr>
     <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.hardswish.html">hardswish</a></td><td></td><td>✅</td><td>-</td></tr>
     <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.hash_tensor.html">hash_tensor</a></td><td></td><td>❌</td><td>-</td></tr>
-    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.heaviside.html">heaviside</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.heaviside.html">heaviside</a></td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.hinge_embedding_loss.html">hinge_embedding_loss</a></td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.histc.html">histc</a></td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.histogram.html">histogram</a></td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.histogramdd.html">histogramdd</a></td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.hstack.html">hstack</a></td><td></td><td>❌</td><td>-</td></tr>
-    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.hypot.html">hypot</a></td><td></td><td>✅</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.hypot.html">hypot</a></td><td></td><td>✅</td><td>-</td></tr>
     <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.i0.html">i0</a></td><td>special_i0</td><td>✅</td><td>-</td></tr>
     <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.igamma.html">igamma</a></td><td>special_gammainc</td><td>✅</td><td>-</td></tr>
     <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.igammac.html">igammac</a></td><td>special_gammaincc</td><td>✅</td><td>-</td></tr>
@@ -654,7 +654,7 @@ We also exclude a long tail of identifiers that the `aten::*` source-grep picks 
     <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.vstack.html">vstack</a></td><td>row_stack</td><td>❌</td><td>-</td></tr>
     <tr class="op-row unsupported"><td>❌</td><td>wrapped_linear_prepack</td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row unsupported"><td>❌</td><td>wrapped_quantized_linear_prepacked</td><td></td><td>❌</td><td>-</td></tr>
-    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.xlogy.html">xlogy</a></td><td>special_xlogy</td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.xlogy.html">xlogy</a></td><td>special_xlogy</td><td>❌</td><td>-</td></tr>
     <tr class="op-row supported"><td>✅</td><td>zero</td><td></td><td>✅</td><td>-</td></tr>
     <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.zeros.html">zeros</a></td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.zeros_like.html">zeros_like</a></td><td></td><td>❌</td><td>-</td></tr>

--- a/tests/test_fft.py
+++ b/tests/test_fft.py
@@ -175,6 +175,46 @@ add_test(torch.arange(24.0).reshape(2, 3, 4), MyIFFTN(dims=[1, 2]))
 add_test(torch.arange(8.0), MyHammingWindowScaled(8, "hamming"))
 add_test(torch.arange(8.0), MyHammingWindowScaled(8, "blackman"))
 add_test(torch.arange(8.0), MyHammingWindowScaled(8, "kaiser"))
+
+
+class MyComplex(nn.Module):
+    """Build a complex tensor and unfold to real for comparison."""
+
+    def forward(self, real, imag):
+        return torch.view_as_real(torch.complex(real, imag))
+
+
+class MyConj(nn.Module):
+    """Conjugate a complex tensor (with `resolve_conj` to materialise)."""
+
+    def forward(self, x):
+        c = torch.view_as_complex(x)
+        return torch.view_as_real(torch.conj(c).resolve_conj())
+
+
+class MyConjPhysical(nn.Module):
+    """`torch.conj_physical(complex)` -> conjugate (materialised)."""
+
+    def forward(self, x):
+        c = torch.view_as_complex(x)
+        return torch.view_as_real(torch.conj_physical(c))
+
+
+add_test(
+    (
+        torch.tensor([[1.0, 2.0], [3.0, 4.0]]),
+        torch.tensor([[0.5, -1.0], [-2.0, 1.5]]),
+    ),
+    MyComplex(),
+)
+add_test(
+    torch.tensor([[[1.0, 2.0], [3.0, -1.5]], [[-0.5, 0.7], [2.0, -2.0]]]),
+    MyConj(),
+)
+add_test(
+    torch.tensor([[[1.0, 2.0], [3.0, -1.5]], [[-0.5, 0.7], [2.0, -2.0]]]),
+    MyConjPhysical(),
+)
 add_test(
     torch.arange(12).float(),
     MySTFT(window=torch.tensor([0.1, 0.5, 0.5, 0.1, 0.1, 0.1])),

--- a/tests/test_primitive.py
+++ b/tests/test_primitive.py
@@ -1197,6 +1197,59 @@ test_suite.add(
     inference_conditions=skip_khronos_interpreter,
 )
 
+
+# Elementwise math: exp2, hypot, xlogy, heaviside, fmax, fmin.
+test_suite.add(
+    (torch.tensor([-2.0, -1.0, 0.0, 0.5, 1.0, 2.5]),),
+    UnaryPrimitive(torch.exp2),
+    inference_conditions=skip_khronos_interpreter,
+)
+test_suite.add(
+    (
+        torch.tensor([[3.0, -4.0, 5.0], [0.0, 1.5, -2.5]]),
+        torch.tensor([[4.0, 3.0, 12.0], [0.0, -2.0, 6.0]]),
+    ),
+    BinaryPrimitive(torch.hypot),
+    inference_conditions=skip_khronos_interpreter,
+)
+# xlogy: include `x==0` so the special-case branch fires (PyTorch
+# returns 0 there even when `log(y)` is nan/-inf).
+test_suite.add(
+    (
+        torch.tensor([0.0, 1.0, 2.0, 0.5, 0.0]),
+        torch.tensor([0.0, 2.0, 1.0, 4.0, 5.0]),
+    ),
+    BinaryPrimitive(torch.xlogy),
+    inference_conditions=skip_khronos_interpreter,
+)
+test_suite.add(
+    (
+        torch.tensor([-1.0, 0.0, 2.0, -3.0, 0.0]),
+        torch.tensor([0.5, 0.5, 0.5, 0.5, 0.5]),
+    ),
+    BinaryPrimitive(torch.heaviside),
+    inference_conditions=skip_khronos_interpreter,
+)
+# fmax / fmin propagate NaN from the *non*-NaN operand: torch.fmax(NaN, x)
+# returns x, unlike torch.max which returns NaN. Test with both finite
+# and NaN inputs.
+test_suite.add(
+    (
+        torch.tensor([1.0, float("nan"), 3.0, float("nan")]),
+        torch.tensor([2.0, 5.0, float("nan"), float("nan")]),
+    ),
+    BinaryPrimitive(torch.fmax),
+    inference_conditions=skip_khronos_interpreter,
+)
+test_suite.add(
+    (
+        torch.tensor([1.0, float("nan"), 3.0, float("nan")]),
+        torch.tensor([2.0, 5.0, float("nan"), float("nan")]),
+    ),
+    BinaryPrimitive(torch.fmin),
+    inference_conditions=skip_khronos_interpreter,
+)
+
 test_suite.add(
     (torch.rand(6, 2)),
     UnaryPrimitive(torch.expm1),

--- a/torch_to_nnef/op/aten/complex.py
+++ b/torch_to_nnef/op/aten/complex.py
@@ -86,6 +86,89 @@ def angle(node, op_helper, inference_target, **kwargs):
 
 
 @OP_REGISTRY.register()
+def complex(  # pylint: disable=redefined-builtin
+    node, op_helper, inference_target, **kwargs
+):
+    """Map PyTorch: 'aten:complex(real, imag)' to NNEF.
+
+    Stacks `real` / `imag` on a new trailing axis via the `complex`
+    fragment so the result matches t2n's `(..., 2)` layout (mirror of
+    `polar` without the `cos` / `sin`).
+    """
+    if tract_complex_support(inference_target):
+        raise T2NErrorNotImplemented("Complex not supported in vanilla spec")
+    real_node, imag_node = node.inputs
+    # Clear the trace's complex64 marker on the IR output: we actually
+    # emit a real `(..., 2)` tensor, and downstream implicit-cast logic
+    # otherwise tries to coerce the real inputs to `complexf64`.
+    node.outputs[0].dtype = torch.float32
+    node.outputs[0].shape = list(real_node.shape) + [2]
+    real_ref = op_helper.get_or_add_tensor_variable_in_nnef(real_node)
+    imag_ref = op_helper.get_or_add_tensor_variable_in_nnef(imag_node)
+    op_helper.add_single_output_op_from_nnef_tensors(
+        node,
+        "complex",
+        inputs=[real_ref, imag_ref],
+        attrs={"axis": real_node.rank},
+    )
+    return ["complex"]
+
+
+def _emit_conjugate(node, op_helper, inference_target, torch_graph, op_label):
+    """Shared body for `aten::conj` / `aten::conj_physical`.
+
+    On a real input we leave the trace untouched (the conjugate of a
+    real is itself). On a complex input we route through the
+    `conjugate` NNEF fragment which flips the sign of the imag slice
+    on the trailing-2 axis.
+    """
+    if tract_complex_support(inference_target):
+        raise T2NErrorNotImplemented("Complex not supported in vanilla spec")
+    (input_node,) = node.inputs
+    if input_node.dtype not in (torch.complex64, torch.complex128):
+        torch_graph.remap_node(node.outputs[0], input_node)
+        return []
+    inp = op_helper.get_or_add_tensor_variable_in_nnef(input_node)
+    # On a complex input the trailing-2 axis is already part of the
+    # t2n IR rank (`view_as_complex` re-tagged the input's dtype to
+    # `complex64` without changing its shape), so the complex axis
+    # sits at `rank - 1`, not `rank`.
+    op_helper.add_single_output_op_from_nnef_tensors(
+        node,
+        "conjugate",
+        inputs=[inp],
+        attrs={"axis": input_node.rank - 1},
+    )
+    return ["conjugate"]
+
+
+@OP_REGISTRY.register(["conj", "_conj"])
+def conj(node, op_helper, inference_target, torch_graph, **kwargs):
+    """Map PyTorch: 'aten:conj' / 'aten::_conj' to NNEF.
+
+    The trace usually pairs `conj` with `resolve_conj` (which stays in
+    `identity_remap` as a no-op); we put the actual sign flip here.
+    """
+    return _emit_conjugate(
+        node, op_helper, inference_target, torch_graph, "conj"
+    )
+
+
+@OP_REGISTRY.register()
+def conj_physical(node, op_helper, inference_target, torch_graph, **kwargs):
+    """Map PyTorch: 'aten:conj_physical' to NNEF.
+
+    Standalone version of `conj`; same code path. Previously routed to
+    `identity_remap`, which silently produced the wrong answer for
+    complex inputs (returned the input unchanged instead of
+    conjugating it).
+    """
+    return _emit_conjugate(
+        node, op_helper, inference_target, torch_graph, "conj_physical"
+    )
+
+
+@OP_REGISTRY.register()
 def polar(node, op_helper, inference_target, **kwargs):
     """Map PyTorch: 'aten:polar(abs, angle)' to NNEF.
 

--- a/torch_to_nnef/op/aten/math.py
+++ b/torch_to_nnef/op/aten/math.py
@@ -1248,6 +1248,69 @@ def cummin(node, op_helper, inference_target, **kwargs):
 
 
 @OP_REGISTRY.register()
+def exp2(node, op_helper, **kwargs):
+    """aten::exp2 -> `exp2` fragment (`exp(x * ln 2)`)."""
+    inp = op_helper.get_or_add_tensor_variable_in_nnef(node.inputs[0])
+    op_helper.add_single_output_op_from_nnef_tensors(node, "exp2", inputs=inp)
+    return ["exp2"]
+
+
+@OP_REGISTRY.register()
+def hypot(node, op_helper, **kwargs):
+    """aten::hypot -> `hypot` fragment (`sqrt(a^2 + b^2)`)."""
+    a = op_helper.get_or_add_tensor_variable_in_nnef(node.inputs[0])
+    b = op_helper.get_or_add_tensor_variable_in_nnef(node.inputs[1])
+    op_helper.add_single_output_op_from_nnef_tensors(
+        node, "hypot", inputs=[a, b]
+    )
+    return ["hypot"]
+
+
+@OP_REGISTRY.register()
+def xlogy(node, op_helper, **kwargs):
+    """aten::xlogy -> `xlogy` fragment (`x * log(y)` with x==0 -> 0)."""
+    x = op_helper.get_or_add_tensor_variable_in_nnef(node.inputs[0])
+    y = op_helper.get_or_add_tensor_variable_in_nnef(node.inputs[1])
+    op_helper.add_single_output_op_from_nnef_tensors(
+        node, "xlogy", inputs=[x, y]
+    )
+    return ["xlogy"]
+
+
+@OP_REGISTRY.register()
+def heaviside(node, op_helper, **kwargs):
+    """aten::heaviside -> `heaviside` fragment (step with tie-breaker)."""
+    x = op_helper.get_or_add_tensor_variable_in_nnef(node.inputs[0])
+    v = op_helper.get_or_add_tensor_variable_in_nnef(node.inputs[1])
+    op_helper.add_single_output_op_from_nnef_tensors(
+        node, "heaviside", inputs=[x, v]
+    )
+    return ["heaviside"]
+
+
+@OP_REGISTRY.register()
+def fmax(node, op_helper, **kwargs):
+    """aten::fmax -> NaN-skipping max."""
+    a = op_helper.get_or_add_tensor_variable_in_nnef(node.inputs[0])
+    b = op_helper.get_or_add_tensor_variable_in_nnef(node.inputs[1])
+    op_helper.add_single_output_op_from_nnef_tensors(
+        node, "fmax", inputs=[a, b]
+    )
+    return ["fmax"]
+
+
+@OP_REGISTRY.register()
+def fmin(node, op_helper, **kwargs):
+    """aten::fmin -> NaN-skipping min."""
+    a = op_helper.get_or_add_tensor_variable_in_nnef(node.inputs[0])
+    b = op_helper.get_or_add_tensor_variable_in_nnef(node.inputs[1])
+    op_helper.add_single_output_op_from_nnef_tensors(
+        node, "fmin", inputs=[a, b]
+    )
+    return ["fmin"]
+
+
+@OP_REGISTRY.register()
 def fmod(node, op_helper, **kwargs):
     """aten::fmod.
 

--- a/torch_to_nnef/op/aten/other.py
+++ b/torch_to_nnef/op/aten/other.py
@@ -123,7 +123,6 @@ def dropout(node, torch_graph, **kwargs):
         "contiguous",
         "resolve_conj",
         "resolve_neg",
-        "conj_physical",
     ]
 )
 def identity_remap(node, torch_graph, **kwargs):
@@ -131,9 +130,11 @@ def identity_remap(node, torch_graph, **kwargs):
 
     `resolve_conj` / `resolve_neg` flip an internal "is conjugated"
     / "is negated" view bit and are the identity once those bits are
-    cleared; for real-valued tensors they are unconditionally identity.
-    `conj_physical` actually conjugates, but for real tensors it is
-    also the identity.
+    cleared; for real-valued tensors they are unconditionally
+    identity. (`conj_physical` used to live here too, which silently
+    returned the input unchanged on complex inputs -- it now lives in
+    `op/aten/complex.py` next to `conj`, routed through the
+    `conjugate` fragment.)
     """
     torch_graph.remap_node(from_node=node.outputs[0], to_node=node.inputs[0])
     torch_graph.op_nodes = [_ for _ in torch_graph.op_nodes if _ is not node]

--- a/torch_to_nnef/op/fragment/complex.nnef
+++ b/torch_to_nnef/op/fragment/complex.nnef
@@ -1,0 +1,13 @@
+# Construct a complex tensor in t2n's `(..., 2)` real layout from a
+# pair of real tensors. `axis` is the position the new trailing-2 axis
+# sits at (always `rank(real)` for the standard `torch.complex` call).
+fragment complex(
+    real:  tensor<scalar>,
+    imag:  tensor<scalar>,
+    axis:  integer
+) -> ( output: tensor<scalar> )
+{
+    re_u = unsqueeze(real, axes = [axis]);
+    im_u = unsqueeze(imag, axes = [axis]);
+    output = concat([re_u, im_u], axis = axis);
+}

--- a/torch_to_nnef/op/fragment/conjugate.nnef
+++ b/torch_to_nnef/op/fragment/conjugate.nnef
@@ -1,0 +1,17 @@
+# Complex conjugate on t2n's `(..., 2)` real layout: negate the imag
+# slice. `axis` is the trailing-2 axis (always `rank(input) - 1` for
+# any caller; passed explicitly so the fragment stays rank-agnostic).
+#
+# Used by `aten::conj` and `aten::conj_physical`; `aten::resolve_conj`
+# stays identity (the IR sees `conj` -> `resolve_conj`, and we put the
+# work on `conj`).
+fragment conjugate(
+    input: tensor<scalar>,
+    axis:  integer
+) -> ( output: tensor<scalar> )
+{
+    re      = slice(input, axes = [axis], begin = [0], end = [1], stride = [1]);
+    im      = slice(input, axes = [axis], begin = [1], end = [2], stride = [1]);
+    neg_im  = mul(im, -1.0);
+    output  = concat([re, neg_im], axis = axis);
+}

--- a/torch_to_nnef/op/fragment/exp2.nnef
+++ b/torch_to_nnef/op/fragment/exp2.nnef
@@ -1,0 +1,7 @@
+# `2 ** x` via `exp(x * ln(2))`. NNEF stdlib `pow` requires a tensor
+# base, so going through `exp` avoids materialising a 2-tensor of the
+# input's shape.
+fragment exp2( input: tensor<scalar> ) -> ( output: tensor<scalar> )
+{
+    output = exp(input * 0.6931471805599453);
+}

--- a/torch_to_nnef/op/fragment/fmax.nnef
+++ b/torch_to_nnef/op/fragment/fmax.nnef
@@ -1,0 +1,15 @@
+# NaN-skipping max: `fmax(NaN, x) = x`, `fmax(x, NaN) = x`,
+# `fmax(NaN, NaN) = NaN`. Differs from `max` which propagates NaN.
+# NaN detection via the IEEE-754 `NaN != NaN` invariant -- pure NNEF
+# stdlib, no `tract_core_is_nan` dependency.
+fragment fmax(
+    a: tensor<scalar>,
+    b: tensor<scalar>
+) -> ( output: tensor<scalar> )
+{
+    a_is_nan = ne(a, a);
+    b_is_nan = ne(b, b);
+    # If `b` is NaN, prefer `a`; else if `a` is NaN, prefer `b`; else max.
+    pick_a_for_b_nan = select(b_is_nan, a, max(a, b));
+    output = select(a_is_nan, b, pick_a_for_b_nan);
+}

--- a/torch_to_nnef/op/fragment/fmin.nnef
+++ b/torch_to_nnef/op/fragment/fmin.nnef
@@ -1,0 +1,11 @@
+# Mirror of `fmax`: `fmin(NaN, x) = x`, `fmin(NaN, NaN) = NaN`.
+fragment fmin(
+    a: tensor<scalar>,
+    b: tensor<scalar>
+) -> ( output: tensor<scalar> )
+{
+    a_is_nan = ne(a, a);
+    b_is_nan = ne(b, b);
+    pick_a_for_b_nan = select(b_is_nan, a, min(a, b));
+    output = select(a_is_nan, b, pick_a_for_b_nan);
+}

--- a/torch_to_nnef/op/fragment/heaviside.nnef
+++ b/torch_to_nnef/op/fragment/heaviside.nnef
@@ -1,0 +1,16 @@
+# Heaviside step function:
+#   x > 0  -> 1
+#   x == 0 -> values (tie-breaker, broadcast to x's shape)
+#   x < 0  -> 0
+fragment heaviside(
+    x: tensor<scalar>,
+    values: tensor<scalar>
+) -> ( output: tensor<scalar> )
+{
+    zero_t = mul(x, 0.0);
+    one_t  = zero_t + 1.0;
+    is_pos = gt(x, zero_t);
+    is_zero = eq(x, zero_t);
+    at_zero_or_neg = select(is_zero, values, zero_t);
+    output = select(is_pos, one_t, at_zero_or_neg);
+}

--- a/torch_to_nnef/op/fragment/hypot.nnef
+++ b/torch_to_nnef/op/fragment/hypot.nnef
@@ -1,0 +1,9 @@
+# `sqrt(a^2 + b^2)`. Pointwise; no NaN handling beyond what `sqr` /
+# `add` / `sqrt` naturally do.
+fragment hypot(
+    a: tensor<scalar>,
+    b: tensor<scalar>
+) -> ( output: tensor<scalar> )
+{
+    output = sqrt(sqr(a) + sqr(b));
+}

--- a/torch_to_nnef/op/fragment/xlogy.nnef
+++ b/torch_to_nnef/op/fragment/xlogy.nnef
@@ -1,0 +1,12 @@
+# `x * log(y)` with the PyTorch special case `x == 0 -> 0` (even when
+# `log(y)` is `-inf` or `NaN`). The `0 * 0` from `mul(x, 0)` only works
+# to lift the literal `0` into `x`-shape -- `select` then picks the
+# zero branch.
+fragment xlogy(
+    x: tensor<scalar>,
+    y: tensor<scalar>
+) -> ( output: tensor<scalar> )
+{
+    is_zero = eq(x, mul(x, 0.0));
+    output = select(is_zero, mul(x, 0.0), x * log(y));
+}


### PR DESCRIPTION
## Summary

Two intertwined themes shipped in one PR.

### Theme A -- complex / audio
- `complex(real, imag)` via a new `complex` NNEF fragment: stacks real / imag on a new trailing axis to match t2n's `(..., 2)` layout (mirror of `polar` without the cos/sin).
- `conj` / `_conj` (aliased): negate imag on the trailing axis via a new `conjugate` fragment. Used by `aten::conj` paired with `aten::resolve_conj` (which stays a no-op in `identity_remap`).
- `conj_physical`: same handler. **Latent bug fix:** `conj_physical` was previously routed through `identity_remap` -- correct on real inputs but silently wrong on complex (returned the input unchanged). Now routes through `conjugate` on complex; real-input path stays identity.

### Theme B -- IEEE / NaN-aware elementwise
- `exp2(x) = exp(x * ln 2)` (avoids materialising a 2-tensor).
- `hypot(a, b) = sqrt(a^2 + b^2)`.
- `xlogy(x, y) = select(x == 0, 0, x * log(y))` -- preserves PyTorch's `x == 0 -> 0` even when `log(y)` is `-inf` / NaN.
- `heaviside(x, v)`: nested select over `x > 0` / `x == 0` / else.
- `fmax(a, b)` / `fmin(a, b)`: NaN-skipping (`fmax(NaN, x) = x`) using the IEEE-754 `NaN != NaN` invariant via `ne(t, t)`. Pure NNEF stdlib -- no `tract_core_is_nan` dependency.

Each elementwise op gets a one-liner NNEF fragment; handlers are 5-10 lines.

## Notes
- The `complex` handler must keep that Python name so `@OP_REGISTRY.register()` registers under the right aten name; the shadowing-the-builtin pylint warning is locally disabled.
- `_conj` alias matches trace paths that emit the underscored aten name.

## Test plan
- 6 new cases in `test_fft.py` covering `complex` / `conj` / `conj_physical` against tract 0.21.15 + 0.22.1
- 12 new cases in `test_primitive.py` covering the 6 elementwise ops
- 758 tests green across `test_primitive.py` + `test_fft.py` + `test_cumsum.py`
- Full ruff sweep (`torch_to_nnef tests packages examples`) clean
- `prospector --no-autodetect -X` reports 0 messages
- Doc regen: 357 -> 366 supported ops; 9 ops flip ❌->✅ in the TractNNEF tab (`conj_physical` was already ✅ due to identity-remap but is now substantively correct on complex)