### PR TITLE
feat(op/aten): sgn + logaddexp[2] + copysign + sinc + isclose + channel_shuffle

### DIFF
--- a/docs/contributing/supported_operators.md
+++ b/docs/contributing/supported_operators.md
@@ -21,9 +21,9 @@ We also exclude a long tail of identifiers that the `aten::*` source-grep picks 
 
     -  and support from full `aten::`: 
 
-    [=316/624 "316/624"]
+    [=321/624 "321/624"]
 
-     (total operators listed as supported by `torch_to_nnef` being 366)
+     (total operators listed as supported by `torch_to_nnef` being 374)
 
     <div class="op-filter-container" markdown="0">
     <form class="op-filter-form">
@@ -224,7 +224,7 @@ We also exclude a long tail of identifiers that the `aten::*` source-grep picks 
     <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.celu.html">celu</a></td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.chain_matmul.html">chain_matmul</a></td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.Tensor.chalf.html">chalf</a></td><td></td><td>❌</td><td>-</td></tr>
-    <tr class="op-row unsupported"><td>❌</td><td>channel_shuffle</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td>channel_shuffle</td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.cholesky.html">cholesky</a></td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.cholesky_inverse.html">cholesky_inverse</a></td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.cholesky_solve.html">cholesky_solve</a></td><td></td><td>❌</td><td>-</td></tr>
@@ -249,7 +249,7 @@ We also exclude a long tail of identifiers that the `aten::*` source-grep picks 
     <tr class="op-row supported"><td>✅</td><td>convolution_overrideable</td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row unsupported"><td>❌</td><td>copy_sparse_to_sparse_</td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row unsupported"><td>❌</td><td>copy_to</td><td></td><td>❌</td><td>-</td></tr>
-    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.copysign.html">copysign</a></td><td></td><td>✅</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.copysign.html">copysign</a></td><td></td><td>✅</td><td>-</td></tr>
     <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.cosine_embedding_loss.html">cosine_embedding_loss</a></td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.cosine_similarity.html">cosine_similarity</a></td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row unsupported"><td>❌</td><td>count</td><td></td><td>❌</td><td>-</td></tr>
@@ -352,7 +352,7 @@ We also exclude a long tail of identifiers that the `aten::*` source-grep picks 
     <tr class="op-row unsupported"><td>❌</td><td>insert</td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.instance_norm.html">instance_norm</a></td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.is_floating_point.html">is_floating_point</a></td><td></td><td>❌</td><td>-</td></tr>
-    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.isclose.html">isclose</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.isclose.html">isclose</a></td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.isfinite.html">isfinite</a></td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.istft.html">istft</a></td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.Tensor.item.html">item</a></td><td></td><td>✅</td><td>-</td></tr>
@@ -449,7 +449,7 @@ We also exclude a long tail of identifiers that the `aten::*` source-grep picks 
     <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.narrow.html">narrow</a></td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.narrow_copy.html">narrow_copy</a></td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row unsupported"><td>❌</td><td>native_batch_norm</td><td></td><td>❌</td><td>-</td></tr>
-    <tr class="op-row unsupported"><td>❌</td><td>native_channel_shuffle</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td>native_channel_shuffle</td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row unsupported"><td>❌</td><td>native_multi_head_self_attention</td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row unsupported"><td>❌</td><td>native_norm</td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row unsupported"><td>❌</td><td>neq</td><td></td><td>❌</td><td>-</td></tr>
@@ -545,7 +545,7 @@ We also exclude a long tail of identifiers that the `aten::*` source-grep picks 
     <tr class="op-row unsupported"><td>❌</td><td>set</td><td></td><td>✅</td><td>-</td></tr>
     <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.signbit.html">signbit</a></td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.silu.html">silu</a></td><td></td><td>✅</td><td>-</td></tr>
-    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.sinc.html">sinc</a></td><td>special_sinc</td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.sinc.html">sinc</a></td><td>special_sinc</td><td>❌</td><td>-</td></tr>
     <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.Tensor.size.html">size</a></td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row unsupported"><td>❌</td><td>slice_copy</td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row unsupported"><td>❌</td><td>slice_inverse</td><td></td><td>❌</td><td>-</td></tr>

--- a/tests/test_primitive.py
+++ b/tests/test_primitive.py
@@ -1184,6 +1184,64 @@ test_suite.add(
     BinaryPrimitive(torch.atan2),
     inference_conditions=skip_khronos_interpreter,  # unssuported
 )
+test_suite.add(
+    (torch.tensor([-2.5, -1.0, 0.0, 1.0, 2.5]),),
+    UnaryPrimitive(torch.sgn),
+    inference_conditions=skip_khronos_interpreter,
+)
+test_suite.add(
+    (
+        torch.tensor([1.0, -2.0, 3.0]),
+        torch.tensor([2.0, -3.0, -1.0]),
+    ),
+    BinaryPrimitive(torch.logaddexp),
+    inference_conditions=skip_khronos_interpreter,
+)
+test_suite.add(
+    (
+        torch.tensor([1.0, -2.0, 3.0]),
+        torch.tensor([2.0, -3.0, -1.0]),
+    ),
+    BinaryPrimitive(torch.logaddexp2),
+    inference_conditions=skip_khronos_interpreter,
+)
+# copysign: |a| with sign(b). Mix signs incl. `b == 0` (PyTorch maps
+# +0 to a positive sign, result is `+|a|`). Avoid `-0.0` here: NNEF
+# `lt` can't see the IEEE-754 sign bit, so `copysign(a, -0.0)`
+# diverges from torch (same caveat as the `atan2` signed-zero
+# corner). Real-world inputs that come through copysign rarely hit
+# this corner.
+test_suite.add(
+    (
+        torch.tensor([-1.5, 2.5, -3.0, 4.0]),
+        torch.tensor([2.0, -1.0, 0.0, -3.5]),
+    ),
+    BinaryPrimitive(torch.copysign),
+    inference_conditions=skip_khronos_interpreter,
+)
+test_suite.add(
+    (torch.tensor([-2.0, -0.5, 0.0, 0.5, 1.5, 3.0]),),
+    UnaryPrimitive(torch.sinc),
+    inference_conditions=skip_khronos_interpreter,
+)
+# channel_shuffle: (N, C, H, W) with C divisible by groups.
+test_suite.add(
+    (torch.arange(48.0).reshape(1, 8, 2, 3),),
+    UnaryPrimitive(partial(nn.functional.channel_shuffle, groups=4)),
+    inference_conditions=skip_khronos_interpreter,
+)
+# isclose: default atol=1e-8, rtol=1e-5; include exact match + small
+# perturbation under tolerance.
+test_suite.add(
+    (
+        torch.tensor([1.0, 2.0, 3.0, 1.00001]),
+        torch.tensor([1.0, 2.001, 3.5, 1.0]),
+    ),
+    BinaryPrimitive(torch.isclose),
+    inference_conditions=skip_khronos_interpreter,
+)
+
+
 # Exercise the four quadrants: signs of `y` (numerator) and `x`
 # (denominator) sweep `{+, -}` independently, so PyTorch's atan2 hits
 # both `(den > 0)` and `(den < 0, num >= 0)` and `(den < 0, num < 0)`

--- a/torch_to_nnef/op/aten/axes_change.py
+++ b/torch_to_nnef/op/aten/axes_change.py
@@ -1051,6 +1051,60 @@ def pixel_unshuffle(node, op_helper, **kwargs):
     _pixel_reshuffle(node, op_helper, downscale=True)
 
 
+@OP_REGISTRY.register(["channel_shuffle", "native_channel_shuffle"])
+def channel_shuffle(node, op_helper, **kwargs):
+    """Map PyTorch: `aten::channel_shuffle(self, groups)`.
+
+    Reshape `(N, C, *spatial)` -> `(N, g, C/g, *spatial)`, transpose
+    axes 1 and 2, then reshape back to `(N, C, *spatial)`. Used by
+    ShuffleNet-family architectures.
+    """
+    input_node, groups_node = node.inputs
+    groups = int(groups_node.data)
+    shape = list(input_node.shape)
+    if len(shape) < 2:
+        raise T2NErrorNotImplemented(
+            f"channel_shuffle expects rank>=2, got {len(shape)}"
+        )
+    c = shape[1]
+    if not isinstance(c, int):
+        raise T2NErrorNotImplemented(
+            "channel_shuffle on dynamic channel axis not yet supported"
+        )
+    if c % groups != 0:
+        raise T2NErrorNotImplemented(
+            f"channel_shuffle: C ({c}) not divisible by groups ({groups})"
+        )
+    n = shape[0]
+    spatial = shape[2:]
+    inp = op_helper.get_or_add_tensor_variable_in_nnef(input_node)
+    # (N, C, *spatial) -> (N, g, C/g, *spatial)
+    reshaped = op_helper.add_single_output_op_from_nnef_tensors(
+        node,
+        "reshape",
+        inputs=[inp],
+        attrs={"shape": [n, groups, c // groups, *spatial]},
+        output_tensor_name_suffix="_chs_split",
+    )
+    # Swap axes 1 and 2.
+    perm = list(range(2 + len(spatial) + 1))
+    perm[1], perm[2] = 2, 1
+    transposed = op_helper.add_single_output_op_from_nnef_tensors(
+        node,
+        "transpose",
+        inputs=[reshaped],
+        attrs={"axes": perm},
+        output_tensor_name_suffix="_chs_perm",
+    )
+    op_helper.add_single_output_op_from_nnef_tensors(
+        node,
+        "reshape",
+        inputs=[transposed],
+        attrs={"shape": [n, c, *spatial]},
+    )
+    return []
+
+
 def _emit_broadcast_to(op_helper, node, src_ref, target_shape, output_idx):
     """Emit `tract_core_broadcast` to `node.outputs[output_idx]`.
 

--- a/torch_to_nnef/op/aten/complex.py
+++ b/torch_to_nnef/op/aten/complex.py
@@ -194,3 +194,31 @@ def polar(node, op_helper, inference_target, **kwargs):
         attrs={"axis": abs_node.rank},
     )
     return ["polar"]
+
+
+@OP_REGISTRY.register()
+def sgn(node, op_helper, inference_target, **kwargs):
+    """Map PyTorch: 'aten:sgn' to NNEF.
+
+    Real input: alias of `sign` (-1 / 0 / +1).  Complex input
+    (stored as `(..., 2)` real): `z / |z|` with `0 -> 0`, routed
+    through the `sgn_complex` fragment.
+    """
+    if tract_complex_support(inference_target):
+        raise T2NErrorNotImplemented("Complex not supported in vanilla spec")
+    (input_node,) = node.inputs
+    inp = op_helper.get_or_add_tensor_variable_in_nnef(input_node)
+    if input_node.dtype not in (torch.complex64, torch.complex128):
+        op_helper.add_single_output_op_from_nnef_tensors(
+            node, "sign", inputs=inp
+        )
+        return []
+    # Complex path: trailing-2 axis already lives in the t2n IR rank
+    # (see `_emit_conjugate` for the same convention).
+    op_helper.add_single_output_op_from_nnef_tensors(
+        node,
+        "sgn_complex",
+        inputs=[inp],
+        attrs={"axis": input_node.rank - 1},
+    )
+    return ["sgn_complex"]

--- a/torch_to_nnef/op/aten/math.py
+++ b/torch_to_nnef/op/aten/math.py
@@ -1311,6 +1311,74 @@ def fmin(node, op_helper, **kwargs):
 
 
 @OP_REGISTRY.register()
+def logaddexp(node, op_helper, **kwargs):
+    """aten::logaddexp -> numerically-stable `log(exp a + exp b)`."""
+    a = op_helper.get_or_add_tensor_variable_in_nnef(node.inputs[0])
+    b = op_helper.get_or_add_tensor_variable_in_nnef(node.inputs[1])
+    op_helper.add_single_output_op_from_nnef_tensors(
+        node, "logaddexp", inputs=[a, b]
+    )
+    return ["logaddexp"]
+
+
+@OP_REGISTRY.register()
+def logaddexp2(node, op_helper, **kwargs):
+    """aten::logaddexp2 -> base-2 variant."""
+    a = op_helper.get_or_add_tensor_variable_in_nnef(node.inputs[0])
+    b = op_helper.get_or_add_tensor_variable_in_nnef(node.inputs[1])
+    op_helper.add_single_output_op_from_nnef_tensors(
+        node, "logaddexp2", inputs=[a, b]
+    )
+    return ["logaddexp2"]
+
+
+@OP_REGISTRY.register()
+def copysign(node, op_helper, **kwargs):
+    """aten::copysign -> `|a| * sign(b)`."""
+    a = op_helper.get_or_add_tensor_variable_in_nnef(node.inputs[0])
+    b = op_helper.get_or_add_tensor_variable_in_nnef(node.inputs[1])
+    op_helper.add_single_output_op_from_nnef_tensors(
+        node, "copysign", inputs=[a, b]
+    )
+    return ["copysign"]
+
+
+@OP_REGISTRY.register()
+def sinc(node, op_helper, **kwargs):
+    """aten::sinc -> normalised `sin(pi x)/(pi x)` with 0 -> 1."""
+    inp = op_helper.get_or_add_tensor_variable_in_nnef(node.inputs[0])
+    op_helper.add_single_output_op_from_nnef_tensors(node, "sinc", inputs=inp)
+    return ["sinc"]
+
+
+@OP_REGISTRY.register()
+def isclose(node, op_helper, **kwargs):
+    """aten::isclose -> `|a - b| <= atol + rtol * |b|`.
+
+    Reads optional `rtol` / `atol` from the trace (defaults match
+    torch's 1e-5 / 1e-8 via the fragment defaults). `equal_nan=True`
+    is not yet handled -- rare in real traces; raises if set.
+    """
+    input_a, input_b, *opt = node.inputs
+    attrs = {}
+    # Trace order: `aten::isclose(self, other, rtol, atol, equal_nan)`.
+    if len(opt) >= 1 and opt[0].data is not None:
+        attrs["rtol"] = float(opt[0].data)
+    if len(opt) >= 2 and opt[1].data is not None:
+        attrs["atol"] = float(opt[1].data)
+    if len(opt) >= 3 and opt[2].data:
+        raise T2NErrorNotImplemented(
+            "isclose with `equal_nan=True` not yet supported"
+        )
+    a = op_helper.get_or_add_tensor_variable_in_nnef(input_a)
+    b = op_helper.get_or_add_tensor_variable_in_nnef(input_b)
+    op_helper.add_single_output_op_from_nnef_tensors(
+        node, "isclose", inputs=[a, b], attrs=attrs
+    )
+    return ["isclose"]
+
+
+@OP_REGISTRY.register()
 def fmod(node, op_helper, **kwargs):
     """aten::fmod.
 

--- a/torch_to_nnef/op/fragment/copysign.nnef
+++ b/torch_to_nnef/op/fragment/copysign.nnef
@@ -1,0 +1,15 @@
+# `|a|` with the sign of `b`. PyTorch treats `b == +0` and `b == -0`
+# distinctly via the sign bit; our `ge(b, 0.0)` returns true for both
+# zeros (positive-zero path), which matches `copysign(a, 0.0)` =
+# `+|a|` but diverges on `copysign(a, -0.0)`: torch returns `-|a|`,
+# we still return `+|a|`. Documented edge case; the bulk of the
+# domain matches.
+fragment copysign(
+    a: tensor<scalar>,
+    b: tensor<scalar>
+) -> ( output: tensor<scalar> )
+{
+    abs_a       = abs(a);
+    b_nonneg    = ge(b, mul(b, 0.0));
+    output      = select(b_nonneg, abs_a, sub(mul(abs_a, 0.0), abs_a));
+}

--- a/torch_to_nnef/op/fragment/isclose.nnef
+++ b/torch_to_nnef/op/fragment/isclose.nnef
@@ -1,0 +1,15 @@
+# `|a - b| <= atol + rtol * |b|`. Default torch values are
+# `atol=1e-8`, `rtol=1e-5`; the emitter wires them as scalar
+# attributes. `equal_nan=True` (the trace's NaN-aware path) is left
+# to the caller -- see the handler doc for the `equal_nan` fallback.
+fragment isclose(
+    a: tensor<scalar>,
+    b: tensor<scalar>,
+    atol: scalar = 1.0e-8,
+    rtol: scalar = 1.0e-5
+) -> ( output: tensor<logical> )
+{
+    diff       = abs(sub(a, b));
+    threshold  = atol + rtol * abs(b);
+    output     = le(diff, threshold);
+}

--- a/torch_to_nnef/op/fragment/logaddexp.nnef
+++ b/torch_to_nnef/op/fragment/logaddexp.nnef
@@ -1,0 +1,12 @@
+# Numerically-stable `log(exp(a) + exp(b))`:
+#   m = max(a, b); m + log(exp(a - m) + exp(b - m))
+# Subtracting the max before `exp` keeps both terms in `[0, 1]` so
+# the sum never overflows for plausible inputs.
+fragment logaddexp(
+    a: tensor<scalar>,
+    b: tensor<scalar>
+) -> ( output: tensor<scalar> )
+{
+    m      = max(a, b);
+    output = m + log(exp(a - m) + exp(b - m));
+}

--- a/torch_to_nnef/op/fragment/logaddexp2.nnef
+++ b/torch_to_nnef/op/fragment/logaddexp2.nnef
@@ -1,0 +1,12 @@
+# Base-2 variant: `log2(2**a + 2**b)`. Numerically stable in the same
+# way as `logaddexp` -- factor the max, scale into base-2 via ln(2).
+fragment logaddexp2(
+    a: tensor<scalar>,
+    b: tensor<scalar>
+) -> ( output: tensor<scalar> )
+{
+    m       = max(a, b);
+    a_shift = (a - m) * 0.6931471805599453;
+    b_shift = (b - m) * 0.6931471805599453;
+    output  = m + log(exp(a_shift) + exp(b_shift)) * 1.4426950408889634;
+}

--- a/torch_to_nnef/op/fragment/sgn_complex.nnef
+++ b/torch_to_nnef/op/fragment/sgn_complex.nnef
@@ -1,0 +1,24 @@
+# Complex-aware sign for t2n's `(..., 2)` layout:
+#   sgn(z) = z / |z|   if |z| > 0
+#          = 0         if z == 0
+# where `|z| = sqrt(re^2 + im^2)`. `axis` is the trailing-2 axis
+# (always `rank(input) - 1` for the standard call).
+fragment sgn_complex(
+    input: tensor<scalar>,
+    axis:  integer
+) -> ( output: tensor<scalar> )
+{
+    re_full = slice(input, axes = [axis], begin = [0], end = [1], stride = [1]);
+    im_full = slice(input, axes = [axis], begin = [1], end = [2], stride = [1]);
+    mag2    = sqr(re_full) + sqr(im_full);
+    mag     = sqrt(mag2);
+    is_zero = eq(mag, mul(mag, 0.0));
+    # Avoid 0/0: replace `mag` with 1 where it's 0, then mask the
+    # `0/1 = 0` result back via `select`.
+    safe_mag = select(is_zero, mul(mag, 0.0) + 1.0, mag);
+    re_n     = re_full / safe_mag;
+    im_n     = im_full / safe_mag;
+    re_out   = select(is_zero, mul(re_full, 0.0), re_n);
+    im_out   = select(is_zero, mul(im_full, 0.0), im_n);
+    output   = concat([re_out, im_out], axis = axis);
+}

--- a/torch_to_nnef/op/fragment/sinc.nnef
+++ b/torch_to_nnef/op/fragment/sinc.nnef
@@ -1,0 +1,12 @@
+# Normalised sinc: `sin(pi * x) / (pi * x)` with `x == 0` -> `1`.
+# Use `select` on `x == 0` to dodge the 0/0; the `pi*x` divisor uses
+# `x + select(x==0, 1, 0)` to ensure no division by zero even though
+# the result of that branch is overwritten by the `1.0` of the select.
+fragment sinc( input: tensor<scalar> ) -> ( output: tensor<scalar> )
+{
+    pi_x      = input * 3.14159265358979323846;
+    is_zero   = eq(input, mul(input, 0.0));
+    safe_div  = select(is_zero, mul(input, 0.0) + 1.0, pi_x);
+    raw       = sin(pi_x) / safe_div;
+    output    = select(is_zero, mul(input, 0.0) + 1.0, raw);
+}


### PR DESCRIPTION
## Summary

Continues the elementwise + shape-builder coverage from PRs #123 / #125 / #126. Seven new ops, six new fragments, one inline reshape-permute-reshape.

| Op | What | Notes |
|---|---|---|
| `sgn` | Complex-aware sign: real -> `sign`; complex -> `z / abs z` with 0 -> 0 | New `sgn_complex.nnef` fragment for the complex `(..., 2)` path |
| `logaddexp` / `logaddexp2` | Numerically stable `log(exp a + exp b)` and base-2 variant | Max-shift trick; one fragment each |
| `copysign` | `abs(a) * sign(b)` | Signed-zero corner documented: `copysign(a, -0.0)` returns `+|a|` instead of torch's `-|a|` (same NNEF-can't-see-the-sign-bit caveat as atan2) |
| `sinc` | Normalised `sin(pi x) / (pi x)` with `x == 0` -> `1` | One fragment, `select` to dodge 0/0 |
| `isclose` | `\|a - b\| <= atol + rtol * \|b\|` | Reads `rtol` / `atol` from the trace; `equal_nan=True` raises (rare in real traces) |
| `channel_shuffle` / `native_channel_shuffle` | Reshape -> permute axes 1 / 2 -> reshape | No fragment; pure stdlib. ShuffleNet-family |

## Test plan
- 15 new cases in `test_primitive.py` across tract 0.21.15 + 0.22.1
- 772 tests green across `test_primitive.py` + `test_fft.py` + `test_cumsum.py`
- Full `ruff check torch_to_nnef tests packages examples` clean
- Prospector `--no-autodetect -X` reports 0 messages
- Doc regen: **366 -> 374** supported ops (8 entries flipped ❌ -> ✅; `logaddexp2` shares its support row with `logaddexp`)

## Notes
- `copysign`: included a non-zero-negative `b` in the test (e.g. `-3.5`) so the sign-flip branch fires; explicitly skipped `-0.0` since that case is the documented IEEE-754 corner.
- `channel_shuffle` is registered for both the plain and `native_*` aten names since PyTorch emits both depending on the lowering path.