### PR TITLE
feat(op/aten): frac + signbit + erfc + tanhshrink + ldexp + addcdiv

### DIFF
--- a/tests/test_primitive.py
+++ b/tests/test_primitive.py
@@ -1189,6 +1189,47 @@ test_suite.add(
     UnaryPrimitive(torch.sgn),
     inference_conditions=skip_khronos_interpreter,
 )
+# frac, signbit, erfc, tanhshrink: simple decompositions.
+test_suite.add(
+    (torch.tensor([-2.7, -0.5, 0.0, 0.5, 1.7, 3.25]),),
+    UnaryPrimitive(torch.frac),
+    inference_conditions=skip_khronos_interpreter,
+)
+test_suite.add(
+    (torch.tensor([-1.5, 0.0, 0.1, -0.1, 2.5]),),
+    UnaryPrimitive(torch.signbit),
+    inference_conditions=skip_khronos_interpreter,
+)
+test_suite.add(
+    (torch.tensor([-2.0, -1.0, 0.0, 0.5, 1.0, 2.5]),),
+    UnaryPrimitive(torch.erfc),
+    inference_conditions=skip_khronos_interpreter,
+)
+test_suite.add(
+    (torch.tensor([-2.0, -0.5, 0.0, 0.5, 2.0]),),
+    UnaryPrimitive(nn.functional.tanhshrink),
+    inference_conditions=skip_khronos_interpreter,
+)
+# ldexp: int / float exponent (`other` may be either; PyTorch promotes
+# `other` to float in the math).
+test_suite.add(
+    (
+        torch.tensor([1.0, 2.0, 3.0, 4.0]),
+        torch.tensor([0.0, 1.0, -1.0, 2.0]),
+    ),
+    BinaryPrimitive(torch.ldexp),
+    inference_conditions=skip_khronos_interpreter,
+)
+# addcdiv: `self + value * (t1 / t2)` with non-zero divisor.
+test_suite.add(
+    (
+        torch.tensor([1.0, 2.0, 3.0]),
+        torch.tensor([1.0, -1.0, 0.5]),
+        torch.tensor([2.0, 0.5, 1.0]),
+    ),
+    TernaryPrimitive(partial(torch.addcdiv, value=0.5)),
+    inference_conditions=skip_khronos_interpreter,
+)
 test_suite.add(
     (
         torch.tensor([1.0, -2.0, 3.0]),

--- a/torch_to_nnef/op/aten/math.py
+++ b/torch_to_nnef/op/aten/math.py
@@ -1379,6 +1379,74 @@ def isclose(node, op_helper, **kwargs):
 
 
 @OP_REGISTRY.register()
+def frac(node, op_helper, **kwargs):
+    """aten::frac -> `x - trunc(x)` (sign-of-x fractional part)."""
+    inp = op_helper.get_or_add_tensor_variable_in_nnef(node.inputs[0])
+    op_helper.add_single_output_op_from_nnef_tensors(node, "frac", inputs=inp)
+    return ["trunc", "frac"]
+
+
+@OP_REGISTRY.register()
+def signbit(node, op_helper, **kwargs):
+    """aten::signbit -> `x < 0` (bool).
+
+    NNEF can't see the IEEE-754 sign bit, so `signbit(-0.0)` returns
+    False here (vs PyTorch's True); same caveat as `copysign` /
+    `atan2`.
+    """
+    inp = op_helper.get_or_add_tensor_variable_in_nnef(node.inputs[0])
+    op_helper.add_single_output_op_from_nnef_tensors(
+        node, "signbit", inputs=inp
+    )
+    return ["signbit"]
+
+
+@OP_REGISTRY.register()
+def erfc(node, op_helper, **kwargs):
+    """aten::erfc -> `1 - erf(x)`."""
+    inp = op_helper.get_or_add_tensor_variable_in_nnef(node.inputs[0])
+    op_helper.add_single_output_op_from_nnef_tensors(node, "erfc", inputs=inp)
+    return ["erf", "erfc"]
+
+
+@OP_REGISTRY.register()
+def tanhshrink(node, op_helper, **kwargs):
+    """aten::tanhshrink -> `x - tanh(x)`."""
+    inp = op_helper.get_or_add_tensor_variable_in_nnef(node.inputs[0])
+    op_helper.add_single_output_op_from_nnef_tensors(
+        node, "tanhshrink", inputs=inp
+    )
+    return ["tanhshrink"]
+
+
+@OP_REGISTRY.register()
+def ldexp(node, op_helper, **kwargs):
+    """aten::ldexp -> `x * 2^exp`."""
+    x = op_helper.get_or_add_tensor_variable_in_nnef(node.inputs[0])
+    e = op_helper.get_or_add_tensor_variable_in_nnef(node.inputs[1])
+    op_helper.add_single_output_op_from_nnef_tensors(
+        node, "ldexp", inputs=[x, e]
+    )
+    return ["exp2", "ldexp"]
+
+
+@OP_REGISTRY.register()
+def addcdiv(node, op_helper, **kwargs):
+    """aten::addcdiv -> `self + value * (t1 / t2)`."""
+    input_node, a_node, b_node, *opt = node.inputs
+    attrs = {}
+    if opt and opt[0].data is not None:
+        attrs["value"] = float(opt[0].data)
+    inp = op_helper.get_or_add_tensor_variable_in_nnef(input_node)
+    a = op_helper.get_or_add_tensor_variable_in_nnef(a_node)
+    b = op_helper.get_or_add_tensor_variable_in_nnef(b_node)
+    op_helper.add_single_output_op_from_nnef_tensors(
+        node, "addcdiv", inputs=[inp, a, b], attrs=attrs
+    )
+    return ["addcdiv"]
+
+
+@OP_REGISTRY.register()
 def fmod(node, op_helper, **kwargs):
     """aten::fmod.
 

--- a/torch_to_nnef/op/fragment/addcdiv.nnef
+++ b/torch_to_nnef/op/fragment/addcdiv.nnef
@@ -1,0 +1,10 @@
+# `addcdiv(self, t1, t2, value=1.0) = self + value * (t1 / t2)`.
+fragment addcdiv(
+    input: tensor<scalar>,
+    a:     tensor<scalar>,
+    b:     tensor<scalar>,
+    value: scalar = 1.0
+) -> ( output: tensor<scalar> )
+{
+    output = input + value * (a / b);
+}

--- a/torch_to_nnef/op/fragment/erfc.nnef
+++ b/torch_to_nnef/op/fragment/erfc.nnef
@@ -1,0 +1,6 @@
+# Complementary error function: `1 - erf(x)`. Direct use of NNEF
+# `erf` (registered via `tract_core`).
+fragment erfc( input: tensor<scalar> ) -> ( output: tensor<scalar> )
+{
+    output = sub(1.0, erf(input));
+}

--- a/torch_to_nnef/op/fragment/frac.nnef
+++ b/torch_to_nnef/op/fragment/frac.nnef
@@ -1,0 +1,7 @@
+# `x - trunc(x)`: fractional part with the sign of `x`. PyTorch's
+# `torch.frac` matches this (e.g. `frac(-2.7) = -0.7`). Uses the
+# existing `trunc` fragment (`select(x < 0, ceil, floor)`).
+fragment frac( input: tensor<scalar> ) -> ( output: tensor<scalar> )
+{
+    output = input - trunc(input);
+}

--- a/torch_to_nnef/op/fragment/ldexp.nnef
+++ b/torch_to_nnef/op/fragment/ldexp.nnef
@@ -1,0 +1,9 @@
+# `ldexp(x, exp) = x * 2^exp`. Built on the existing `exp2` fragment
+# (which itself lowers to `exp(exp * ln 2)`).
+fragment ldexp(
+    input:    tensor<scalar>,
+    exponent: tensor<scalar>
+) -> ( output: tensor<scalar> )
+{
+    output = input * exp2(exponent);
+}

--- a/torch_to_nnef/op/fragment/signbit.nnef
+++ b/torch_to_nnef/op/fragment/signbit.nnef
@@ -1,0 +1,7 @@
+# `True` where `x < 0`. NNEF / tract can't see the IEEE-754 sign
+# bit, so `signbit(-0.0) = False` here vs PyTorch's `True` (same
+# signed-zero caveat as `copysign` and `atan2`).
+fragment signbit( input: tensor<scalar> ) -> ( output: tensor<logical> )
+{
+    output = lt(input, mul(input, 0.0));
+}

--- a/torch_to_nnef/op/fragment/tanhshrink.nnef
+++ b/torch_to_nnef/op/fragment/tanhshrink.nnef
@@ -1,0 +1,4 @@
+fragment tanhshrink( input: tensor<scalar> ) -> ( output: tensor<scalar> )
+{
+    output = input - tanh(input);
+}


### PR DESCRIPTION
## Summary

Six trivial elementwise math gap-fillers from the category-A buildable list (continuation of PRs #126 / #127). Each is a one-line fragment over existing tract primitives.

| Op | Decomposition | Notes |
|---|---|---|
| `frac` | `x - trunc(x)` | Reuses existing `trunc` fragment |
| `signbit` | `x < 0` (bool) | Signed-zero caveat: `signbit(-0.0) = False` here vs torch's True (same NNEF-can't-see-the-sign-bit limit as `copysign` / `atan2`) |
| `erfc` | `1 - erf(x)` | Reuses existing `erf` fragment |
| `tanhshrink` | `x - tanh(x)` | |
| `ldexp` | `x * 2^exp` | Reuses the `exp2` fragment from PR #126 |
| `addcdiv` | `self + value * (t1 / t2)` | `value` as scalar fragment attribute (default 1.0) |

## Test plan
- 12 new cases in `tests/test_primitive.py` (6 ops × tract 0.21.15 + 0.22.1), all green
- 708 tests pass in `test_primitive.py`
- Full `ruff check torch_to_nnef tests packages examples` clean
- `prospector --no-autodetect -X` 0 messages
- Doc regen deferred until PR #128 (the inert-ops filter) lands; regenerating on this branch would temporarily regress the count since this branch is off main pre-#128