### PR TITLE
feat(op/aten): addbmm + addmv + addr + bias_addmm alias (fused matmul)

### DIFF
--- a/tests/test_primitive.py
+++ b/tests/test_primitive.py
@@ -1220,6 +1220,36 @@ test_suite.add(
     BinaryPrimitive(torch.ldexp),
     inference_conditions=skip_khronos_interpreter,
 )
+# Fused matmul family: addbmm (sum-bmm + bias), addmv (matrix-vector
+# + bias), addr (outer product + bias). All accept `beta` / `alpha`
+# scalars; defaults are 1.0.
+test_suite.add(
+    (
+        torch.arange(6.0).reshape(2, 3),
+        torch.arange(24.0).reshape(4, 2, 3),
+        torch.arange(36.0).reshape(4, 3, 3),
+    ),
+    TernaryPrimitive(torch.addbmm),
+    inference_conditions=skip_khronos_interpreter,
+)
+test_suite.add(
+    (
+        torch.arange(3.0),
+        torch.arange(12.0).reshape(3, 4),
+        torch.arange(4.0),
+    ),
+    TernaryPrimitive(torch.addmv),
+    inference_conditions=skip_khronos_interpreter,
+)
+test_suite.add(
+    (
+        torch.arange(12.0).reshape(3, 4),
+        torch.arange(3.0),
+        torch.arange(4.0),
+    ),
+    TernaryPrimitive(torch.addr),
+    inference_conditions=skip_khronos_interpreter,
+)
 # addcdiv: `self + value * (t1 / t2)` with non-zero divisor.
 test_suite.add(
     (

--- a/torch_to_nnef/op/aten/matmul.py
+++ b/torch_to_nnef/op/aten/matmul.py
@@ -546,9 +546,14 @@ def matmul(g, node, name_to_tensor, **kwargs):
     )
 
 
-@OP_REGISTRY.register(["baddbmm", "addmm"])
+@OP_REGISTRY.register(["baddbmm", "addmm", "bias_addmm"])
 def baddbmm(g, node, name_to_tensor, inference_target, **kwargs):
-    """Map PyTorch: 'aten:baddbmm', 'aten:addmm' to NNEF."""
+    """Map PyTorch: 'aten:baddbmm', 'aten:addmm', 'aten:bias_addmm'.
+
+    `bias_addmm` is a dispatcher-fused addmm variant (the `self`
+    operand is a broadcasted bias); semantics are identical so we
+    route it through the same `addmm` fragment.
+    """
     input_node, batch1_node, batch2_node, beta_node, alpha_node = node.inputs
     for ab_node in [alpha_node, beta_node]:
         if isinstance(alpha_node, PythonConstant):
@@ -587,6 +592,81 @@ def baddbmm(g, node, name_to_tensor, inference_target, **kwargs):
         attrs={"beta": beta_node.data, "alpha": alpha_node.data},
     )
     return ["addmm"]
+
+
+def _emit_fused_matmul(g, node, name_to_tensor, inference_target, fragment):
+    """Shared body for `addbmm` / `addmv` / `addr`.
+
+    All three follow the same `(self, A, B, *, beta, alpha)` aten
+    signature as `baddbmm` -- only the fragment that does the actual
+    math differs.
+    """
+    input_node, a_node, b_node, beta_node, alpha_node = node.inputs
+    for ab_node in [alpha_node, beta_node]:
+        if isinstance(ab_node, PythonConstant):
+            ab_node.set_data(float(ab_node.data))
+        else:
+            raise T2NErrorNotImplemented()
+    inputs = [
+        get_or_add_tensor_variable_in_nnef(g, _, name_to_tensor)
+        for _ in [input_node, a_node, b_node]
+    ]
+    new_inputs = []
+    target_dtype = node.outputs[0].dtype
+    for inp in inputs:
+        if NUMPY_TO_TORCH_DTYPE[inp.dtype] != target_dtype and isinstance(
+            inference_target, TractNNEF
+        ):
+            target_dtype_tract = TORCH_DTYPE_TO_TRACT_STR[target_dtype]
+            inp = add_single_output_op(
+                g,
+                node,
+                name_to_tensor,
+                "tract_core_cast",
+                inputs=inp,
+                attrs={"to": target_dtype_tract},
+                force_full_output_tensor_name=(
+                    f"{inp.name}_cast_{target_dtype_tract}"
+                ),
+            )
+        new_inputs.append(inp)
+    # `force_consistent_inputs_shapes=False`: the inputs of these
+    # fused-matmul fragments have intentionally different ranks
+    # (e.g. addbmm: `input` is `(n, p)`, `batch1` is `(b, n, m)`),
+    # so the default rank-alignment pass that unsqueezes the smaller
+    # input would corrupt the math.
+    add_single_output_op(
+        g,
+        node,
+        name_to_tensor,
+        fragment,
+        inputs=new_inputs,
+        attrs={"beta": beta_node.data, "alpha": alpha_node.data},
+        force_consistent_inputs_shapes=False,
+    )
+    return [fragment]
+
+
+@OP_REGISTRY.register()
+def addbmm(g, node, name_to_tensor, inference_target, **kwargs):
+    """aten::addbmm -> `beta*self + alpha*sum_b(bmm(b1, b2))`."""
+    return _emit_fused_matmul(
+        g, node, name_to_tensor, inference_target, "addbmm"
+    )
+
+
+@OP_REGISTRY.register()
+def addmv(g, node, name_to_tensor, inference_target, **kwargs):
+    """aten::addmv -> `beta*self + alpha*(mat @ vec)`."""
+    return _emit_fused_matmul(
+        g, node, name_to_tensor, inference_target, "addmv"
+    )
+
+
+@OP_REGISTRY.register()
+def addr(g, node, name_to_tensor, inference_target, **kwargs):
+    """aten::addr -> `beta*self + alpha*(vec1 outer vec2)`."""
+    return _emit_fused_matmul(g, node, name_to_tensor, inference_target, "addr")
 
 
 def _make_ntensor(g, name_to_tensor, name: str, shape, np_dtype):

--- a/torch_to_nnef/op/fragment/addbmm.nnef
+++ b/torch_to_nnef/op/fragment/addbmm.nnef
@@ -1,0 +1,17 @@
+# `addbmm(M, b1, b2) = beta*M + alpha*sum_b(bmm(b1, b2))`.
+#
+# `b1` is `(B, n, m)`, `b2` is `(B, m, p)`; the bmm produces
+# `(B, n, p)` which we sum-reduce along the batch axis to `(n, p)`.
+fragment addbmm(
+    input:  tensor<scalar>,
+    batch1: tensor<scalar>,
+    batch2: tensor<scalar>,
+    alpha:  scalar,
+    beta:   scalar
+) -> ( output: tensor<scalar> )
+{
+    bmm_out      = matmul(batch1, batch2);
+    sum_unsqueeze = sum_reduce(bmm_out, axes = [0]);
+    sum_axis      = squeeze(sum_unsqueeze, axes = [0]);
+    output        = beta * input + alpha * sum_axis;
+}

--- a/torch_to_nnef/op/fragment/addmv.nnef
+++ b/torch_to_nnef/op/fragment/addmv.nnef
@@ -1,0 +1,17 @@
+# `addmv(self, mat, vec) = beta*self + alpha*(mat @ vec)`.
+# `mat` is `(n, m)`, `vec` is `(m,)` -> output `(n,)`.
+# `matmul` needs both inputs with matching rank, so we unsqueeze the
+# vector to `(m, 1)`, multiply to `(n, 1)`, then squeeze back.
+fragment addmv(
+    input: tensor<scalar>,
+    mat:   tensor<scalar>,
+    vec:   tensor<scalar>,
+    alpha: scalar,
+    beta:  scalar
+) -> ( output: tensor<scalar> )
+{
+    vec_col   = unsqueeze(vec, axes = [1]);
+    mat_vec   = matmul(mat, vec_col);
+    mat_vec_v = squeeze(mat_vec, axes = [1]);
+    output    = beta * input + alpha * mat_vec_v;
+}

--- a/torch_to_nnef/op/fragment/addr.nnef
+++ b/torch_to_nnef/op/fragment/addr.nnef
@@ -1,0 +1,17 @@
+# `addr(self, vec1, vec2) = beta*self + alpha*(vec1 outer vec2)`.
+# `vec1` is `(n,)`, `vec2` is `(m,)` -> output `(n, m)`. Outer product
+# expressed as broadcast multiply of the two unsqueezed vectors
+# (no `matmul` needed).
+fragment addr(
+    input: tensor<scalar>,
+    vec1:  tensor<scalar>,
+    vec2:  tensor<scalar>,
+    alpha: scalar,
+    beta:  scalar
+) -> ( output: tensor<scalar> )
+{
+    vec1_col = unsqueeze(vec1, axes = [1]);
+    vec2_row = unsqueeze(vec2, axes = [0]);
+    outer    = mul(vec1_col, vec2_row);
+    output   = beta * input + alpha * outer;
+}


### PR DESCRIPTION
## Summary

Four more category-A wins from the post-#128 buildable list. Fused matmul family.

| Op | Decomposition |
|---|---|
| `addbmm` | `beta*self + alpha*sum_b(bmm(b1, b2))` -- batched matmul, sum-reduce on batch axis, squeeze, then the standard `beta*input + alpha*X` tail. New `addbmm.nnef` fragment. |
| `addmv` | `beta*self + alpha*(mat @ vec)` -- unsqueeze the vector to `(m, 1)`, matmul, squeeze the singleton back. New `addmv.nnef` fragment. |
| `addr` | `beta*self + alpha*(vec1 outer vec2)` -- outer product via broadcast multiply (no matmul needed). New `addr.nnef` fragment. |
| `bias_addmm` | Aliased to the existing `addmm` handler. It's a dispatcher-fused variant of `addmm` (where `self` is a broadcasted bias); semantics are identical. |

## Notes

The three new handlers share `_emit_fused_matmul()` which mirrors the existing `baddbmm` prep (dtype-cast inputs to match output dtype, then call the fragment with `beta` / `alpha` scalar attrs).

**Important detail:** `force_consistent_inputs_shapes=False` on the fragment call. The inputs of these fragments have intentionally different ranks (e.g. `addbmm` has `input=(n, p)` but `batch1=(b, n, m)`); the default rank-alignment pass would unsqueeze `input` to rank 3 and corrupt the math. `baddbmm` doesn't hit this because all 3 of its inputs are already rank-3.

## Test plan
- 6 new cases in `tests/test_primitive.py` (3 ops × tract 0.21.15 + 0.22.1), all green
- 714 tests pass in `test_primitive.py`
- Full `ruff check torch_to_nnef tests packages examples` clean
- `prospector --no-autodetect -X` 0 messages
- Doc regen deferred until PR #128 (the inert-ops filter) lands; regenerating on this branch would temporarily inflate counts since this branch is off main pre-#128