### PR TITLE
feat(op/aten): l1_loss + gru_cell + rnn_{tanh,relu}_cell

### DIFF
--- a/docs/contributing/generate_support_page.py
+++ b/docs/contributing/generate_support_page.py
@@ -489,6 +489,20 @@ _EXCLUDED_SLOW_CONV_FALLBACK = frozenset(
     }
 )
 
+_EXCLUDED_REGEX_SCRAPE_ARTIFACTS = frozenset(
+    {
+        # Phantom names produced by `get_aten_torch_from_code`'s regex
+        # against pytorch source. The sweep captures everything matching
+        # `aten::([a-zA-Z0-9_]*)`, so an f-string like
+        # `f"aten::conv{dim}d("` in
+        # `test/quantization/jit/test_quantize_jit.py` reports a bare
+        # `conv` -- no such aten op exists. Actual ops are
+        # `conv1d` / `conv2d` / `conv3d` / `_convolution` /
+        # `_convolution_mode`.
+        "conv",
+    }
+)
+
 _EXCLUDED_PYTHON_SCALAR_BUILTINS_EXTRA = frozenset(
     {
         # More Python / TorchScript scalar builtins routed through
@@ -601,9 +615,7 @@ NEVER_IN_INFERENCE_TRACE = {
     "`linalg_*_ex` paired-output variants + deprecated linalg wrappers": (
         _EXCLUDED_LINALG_EX_AND_LEGACY
     ),
-    "QAT `fake_quantize_*` training-only ops": (
-        _EXCLUDED_FAKE_QUANT_TRAINING
-    ),
+    "QAT `fake_quantize_*` training-only ops": (_EXCLUDED_FAKE_QUANT_TRAINING),
     "`slow_conv*` / `thnn_conv*` dispatcher-fallback kernels": (
         _EXCLUDED_SLOW_CONV_FALLBACK
     ),
@@ -615,6 +627,9 @@ NEVER_IN_INFERENCE_TRACE = {
     ),
     "Backward / dynamo-autograd internals": (
         _EXCLUDED_AUTOGRAD_TRAINING_INTERNALS
+    ),
+    "Regex-scrape artifacts (phantom names from f-strings)": (
+        _EXCLUDED_REGEX_SCRAPE_ARTIFACTS
     ),
 }
 

--- a/docs/contributing/supported_operators.md
+++ b/docs/contributing/supported_operators.md
@@ -21,9 +21,9 @@ We also exclude a long tail of identifiers that the `aten::*` source-grep picks 
 
     -  and support from full `aten::`: 
 
-    [=340/530 "340/530"]
+    [=344/529 "344/529"]
 
-     (total operators listed as supported by `torch_to_nnef` being 394)
+     (total operators listed as supported by `torch_to_nnef` being 398)
 
     <div class="op-filter-container" markdown="0">
     <form class="op-filter-form">
@@ -227,7 +227,6 @@ We also exclude a long tail of identifiers that the `aten::*` source-grep picks 
     <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.conj.html">conj</a></td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.conj_physical.html">conj_physical</a></td><td></td><td>✅</td><td>-</td></tr>
     <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.Tensor.contiguous.html">contiguous</a></td><td></td><td>❌</td><td>-</td></tr>
-    <tr class="op-row unsupported"><td>❌</td><td>conv</td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.conv1d.html">conv1d</a></td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.conv2d.html">conv2d</a></td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.conv3d.html">conv3d</a></td><td></td><td>❌</td><td>-</td></tr>
@@ -294,7 +293,7 @@ We also exclude a long tail of identifiers that the `aten::*` source-grep picks 
     <tr class="op-row unsupported"><td>❌</td><td>grid_sampler_3d</td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.group_norm.html">group_norm</a></td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row supported"><td>✅</td><td>gru</td><td></td><td>❌</td><td>-</td></tr>
-    <tr class="op-row unsupported"><td>❌</td><td>gru_cell</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td>gru_cell</td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.hamming_window.html">hamming_window</a></td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.hann_window.html">hann_window</a></td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.hardshrink.html">hardshrink</a></td><td></td><td>❌</td><td>-</td></tr>
@@ -323,7 +322,7 @@ We also exclude a long tail of identifiers that the `aten::*` source-grep picks 
     <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.kaiser_window.html">kaiser_window</a></td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.kl_div.html">kl_div</a></td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.kthvalue.html">kthvalue</a></td><td></td><td>❌</td><td>-</td></tr>
-    <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.l1_loss.html">l1_loss</a></td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.l1_loss.html">l1_loss</a></td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.layer_norm.html">layer_norm</a></td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.lcm.html">lcm</a></td><td></td><td>✅</td><td>-</td></tr>
     <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.ldexp.html">ldexp</a></td><td></td><td>✅</td><td>-</td></tr>
@@ -459,9 +458,9 @@ We also exclude a long tail of identifiers that the `aten::*` source-grep picks 
     <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.resolve_conj.html">resolve_conj</a></td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.resolve_neg.html">resolve_neg</a></td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row supported"><td>✅</td><td>rnn_relu</td><td></td><td>❌</td><td>-</td></tr>
-    <tr class="op-row unsupported"><td>❌</td><td>rnn_relu_cell</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td>rnn_relu_cell</td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row supported"><td>✅</td><td>rnn_tanh</td><td></td><td>❌</td><td>-</td></tr>
-    <tr class="op-row unsupported"><td>❌</td><td>rnn_tanh_cell</td><td></td><td>❌</td><td>-</td></tr>
+    <tr class="op-row supported"><td>✅</td><td>rnn_tanh_cell</td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.roll.html">roll</a></td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.rot90.html">rot90</a></td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.rrelu.html">rrelu</a></td><td></td><td>❌</td><td>-</td></tr>
@@ -579,7 +578,7 @@ We also exclude a long tail of identifiers that the `aten::*` source-grep picks 
 
     -  and support from full `aten::`: 
 
-    [=306/530 "306/530"]
+    [=306/529 "306/529"]
 
      (total operators listed as supported by PyTorch's TorchScript ONNX exporter being 348)
 
@@ -785,7 +784,6 @@ We also exclude a long tail of identifiers that the `aten::*` source-grep picks 
     <tr class="op-row unsupported"><td>❌</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.conj.html">conj</a></td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.conj_physical.html">conj_physical</a></td><td></td><td>✅</td><td>-</td></tr>
     <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.Tensor.contiguous.html">contiguous</a></td><td></td><td>❌</td><td>-</td></tr>
-    <tr class="op-row unsupported"><td>❌</td><td>conv</td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.conv1d.html">conv1d</a></td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.conv2d.html">conv2d</a></td><td></td><td>❌</td><td>-</td></tr>
     <tr class="op-row supported"><td>✅</td><td><a href="https://docs.pytorch.org/docs/2.11/generated/torch.nn.functional.conv3d.html">conv3d</a></td><td></td><td>❌</td><td>-</td></tr>
@@ -1196,4 +1194,7 @@ These names are filtered out of the support tables above because they cannot sur
 
 ??? note "Backward / dynamo-autograd internals (10 names)"
     `embedding_renorm`, `from_file`, `glu_jvp`, `log_sigmoid_forward`, `multilabel_margin_loss_forward`, `nll_loss_forward`, `normal_functional`, `rowwise_prune`, `rrelu_with_noise_functional`, `sum_to`
+
+??? note "Regex-scrape artifacts (phantom names from f-strings) (1 names)"
+    `conv`
 

--- a/tests/proptest/op_specs/loss.py
+++ b/tests/proptest/op_specs/loss.py
@@ -23,7 +23,15 @@ from ._common import OpSample, OpSpec
 _REDUCTIONS = ("none", "mean", "sum")
 
 
-def _mse_sample_st() -> st.SearchStrategy[OpSample]:
+def _pointwise_loss_sample_st(
+    callable_factory: T.Callable[[str], T.Callable[..., torch.Tensor]],
+) -> st.SearchStrategy[OpSample]:
+    """Shared (input, target, reduction) draw for the elementwise losses.
+
+    `callable_factory(reduction)` returns the actual `F.<loss>(...)` to
+    invoke, capturing any scalar params (`delta`, `beta`) closure-style.
+    """
+
     @st.composite
     def _draw(draw) -> OpSample:
         rank = draw(st.integers(min_value=1, max_value=3))
@@ -49,12 +57,36 @@ def _mse_sample_st() -> st.SearchStrategy[OpSample]:
         )
         return OpSample(
             inputs=(a, b),
-            module=BinaryPrimitive(
-                lambda x, y, _r=reduction: F.mse_loss(x, y, reduction=_r)
-            ),
+            module=BinaryPrimitive(callable_factory(reduction)),
         )
 
     return _draw()
+
+
+def _mse_sample_st() -> st.SearchStrategy[OpSample]:
+    return _pointwise_loss_sample_st(
+        lambda r: lambda x, y, _r=r: F.mse_loss(x, y, reduction=_r)
+    )
+
+
+def _l1_sample_st() -> st.SearchStrategy[OpSample]:
+    return _pointwise_loss_sample_st(
+        lambda r: lambda x, y, _r=r: F.l1_loss(x, y, reduction=_r)
+    )
+
+
+def _huber_sample_st() -> st.SearchStrategy[OpSample]:
+    # Default `delta=1.0`; mixed -3..3 range exercises both branches.
+    return _pointwise_loss_sample_st(
+        lambda r: lambda x, y, _r=r: F.huber_loss(x, y, reduction=_r)
+    )
+
+
+def _smooth_l1_sample_st() -> st.SearchStrategy[OpSample]:
+    # Default `beta=1.0`; same range covers both branches.
+    return _pointwise_loss_sample_st(
+        lambda r: lambda x, y, _r=r: F.smooth_l1_loss(x, y, reduction=_r)
+    )
 
 
 def _bce_logits_sample_st() -> st.SearchStrategy[OpSample]:
@@ -230,6 +262,21 @@ def _loss_specs() -> T.List[OpSpec]:
         OpSpec(
             name="mse_loss",
             sample_st=_mse_sample_st(),
+            tolerance=APPROX,
+        ),
+        OpSpec(
+            name="l1_loss",
+            sample_st=_l1_sample_st(),
+            tolerance=APPROX,
+        ),
+        OpSpec(
+            name="huber_loss",
+            sample_st=_huber_sample_st(),
+            tolerance=APPROX,
+        ),
+        OpSpec(
+            name="smooth_l1_loss",
+            sample_st=_smooth_l1_sample_st(),
             tolerance=APPROX,
         ),
         OpSpec(

--- a/tests/test_aten_gru_cell.py
+++ b/tests/test_aten_gru_cell.py
@@ -1,0 +1,131 @@
+"""Tests for the `aten::gru_cell` aten handler.
+
+`emit_gru_cell_via_fragment` materializes a single `gru_cell` NNEF
+fragment call (`op/fragment/gru_cell.nnef`). t2n's default trace-based
+export decomposes `nn.GRUCell.forward` into `aten::linear + chunk + ...`
+rather than emitting `aten::gru_cell`; the aten handler kicks in for
+scripted graphs or explicit `_VF.gru_cell(...)` calls. The unit tests
+below pin the fragment-based shape.
+"""
+
+import nnef_tools.model
+import numpy as np
+from torch import nn
+
+from torch_to_nnef.op.aten import aten_ops_registry
+from torch_to_nnef.op.aten.rnn import emit_gru_cell_via_fragment
+
+
+def test_gru_cell_is_registered_in_aten_registry():
+    """Sanity: aten handler reachable through the standard registry."""
+    fn = aten_ops_registry.get("gru_cell")
+    assert callable(fn)
+
+
+def _build_graph(batch: int, in_size: int, hidden: int):
+    g = nnef_tools.model.Graph(name="test")
+    name_to_tensor = {}
+    nnef_dtype = np.float32
+
+    def mk(name, shape):
+        t = nnef_tools.model.Tensor(g, name, dtype=nnef_dtype, shape=shape)
+        name_to_tensor[name] = t
+        return t
+
+    return (
+        g,
+        name_to_tensor,
+        nnef_dtype,
+        mk("x", (batch, in_size)),
+        mk("h", (batch, hidden)),
+    )
+
+
+def test_helper_emits_single_gru_cell_fragment_call():
+    """Fragment-based shape: one `gru_cell` op, regardless of bias."""
+    batch, in_size, hidden = 2, 8, 4
+    g, name_to_tensor, nnef_dtype, input_ref, h_ref = _build_graph(
+        batch, in_size, hidden
+    )
+
+    cell = nn.GRUCell(in_size, hidden)
+    used = emit_gru_cell_via_fragment(
+        g,
+        name_to_tensor,
+        base="cell",
+        nnef_dtype=nnef_dtype,
+        batch_dim=batch,
+        hidden=hidden,
+        input_ref=input_ref,
+        h_prev_ref=h_ref,
+        w_ih=cell.weight_ih.detach(),
+        w_hh=cell.weight_hh.detach(),
+        b_ih=cell.bias_ih.detach(),
+        b_hh=cell.bias_hh.detach(),
+        h_new_tv=None,
+    )
+
+    assert used == ["gru_cell"]
+    op_kinds = [op.type for op in g.operations]
+    compute_kinds = [k for k in op_kinds if k != "variable"]
+    assert compute_kinds == ["gru_cell"]
+
+
+def test_fragment_call_carries_correct_slice_bounds():
+    """Slice bounds describe the gate boundaries: H, 2H, 3H."""
+    batch, in_size, hidden = 1, 6, 7
+    g, name_to_tensor, nnef_dtype, input_ref, h_ref = _build_graph(
+        batch, in_size, hidden
+    )
+    cell = nn.GRUCell(in_size, hidden)
+    emit_gru_cell_via_fragment(
+        g,
+        name_to_tensor,
+        base="cell",
+        nnef_dtype=nnef_dtype,
+        batch_dim=batch,
+        hidden=hidden,
+        input_ref=input_ref,
+        h_prev_ref=h_ref,
+        w_ih=cell.weight_ih.detach(),
+        w_hh=cell.weight_hh.detach(),
+        b_ih=cell.bias_ih.detach(),
+        b_hh=cell.bias_hh.detach(),
+        h_new_tv=None,
+    )
+    fragment_ops = [o for o in g.operations if o.type == "gru_cell"]
+    assert len(fragment_ops) == 1
+    op = fragment_ops[0]
+    assert op.attribs["r_end"] == hidden
+    assert op.attribs["z_end"] == 2 * hidden
+    assert op.attribs["n_end"] == 3 * hidden
+
+
+def test_helper_supports_bias_less_cell():
+    """Bias-less variant: helper materializes zero biases internally."""
+    batch, in_size, hidden = 1, 4, 4
+    g, name_to_tensor, nnef_dtype, input_ref, h_ref = _build_graph(
+        batch, in_size, hidden
+    )
+
+    cell = nn.GRUCell(in_size, hidden, bias=False)
+    used = emit_gru_cell_via_fragment(
+        g,
+        name_to_tensor,
+        base="cell",
+        nnef_dtype=nnef_dtype,
+        batch_dim=batch,
+        hidden=hidden,
+        input_ref=input_ref,
+        h_prev_ref=h_ref,
+        w_ih=cell.weight_ih.detach(),
+        w_hh=cell.weight_hh.detach(),
+        b_ih=None,
+        b_hh=None,
+        h_new_tv=None,
+    )
+
+    assert used == ["gru_cell"]
+    op_kinds = [op.type for op in g.operations]
+    compute_kinds = [k for k in op_kinds if k != "variable"]
+    assert compute_kinds == ["gru_cell"]

--- a/tests/test_aten_rnn_cell.py
+++ b/tests/test_aten_rnn_cell.py
@@ -1,0 +1,117 @@
+"""Tests for the `aten::rnn_{tanh,relu}_cell` aten handlers.
+
+`emit_rnn_cell_via_fragment` materializes a single `rnn_tanh_cell` or
+`rnn_relu_cell` NNEF fragment call (`op/fragment/rnn_tanh_cell.nnef` /
+`op/fragment/rnn_relu_cell.nnef`). Same trace caveat as `gru_cell`: the
+aten path only fires for scripted graphs / explicit `_VF.rnn_*_cell`
+calls, while trace decomposition routes through `aten::linear + ...`.
+"""
+
+import nnef_tools.model
+import numpy as np
+import pytest
+from torch import nn
+
+from torch_to_nnef.op.aten import aten_ops_registry
+from torch_to_nnef.op.aten.rnn import emit_rnn_cell_via_fragment
+
+
+@pytest.mark.parametrize(
+    ("aten_name", "nonlinearity", "fragment"),
+    [
+        ("rnn_tanh_cell", "tanh", "rnn_tanh_cell"),
+        ("rnn_relu_cell", "relu", "rnn_relu_cell"),
+    ],
+)
+def test_rnn_cell_is_registered_in_aten_registry(
+    aten_name, nonlinearity, fragment
+):
+    """Sanity: both aten handlers reachable through the standard registry."""
+    del nonlinearity, fragment
+    fn = aten_ops_registry.get(aten_name)
+    assert callable(fn)
+
+
+def _build_graph(batch: int, in_size: int, hidden: int):
+    g = nnef_tools.model.Graph(name="test")
+    name_to_tensor = {}
+    nnef_dtype = np.float32
+
+    def mk(name, shape):
+        t = nnef_tools.model.Tensor(g, name, dtype=nnef_dtype, shape=shape)
+        name_to_tensor[name] = t
+        return t
+
+    return (
+        g,
+        name_to_tensor,
+        nnef_dtype,
+        mk("x", (batch, in_size)),
+        mk("h", (batch, hidden)),
+    )
+
+
+@pytest.mark.parametrize("nonlinearity", ["tanh", "relu"])
+def test_helper_emits_single_rnn_cell_fragment_call(nonlinearity):
+    """Fragment-based shape: one `rnn_{tanh,relu}_cell` op."""
+    batch, in_size, hidden = 2, 8, 4
+    g, name_to_tensor, nnef_dtype, input_ref, h_ref = _build_graph(
+        batch, in_size, hidden
+    )
+
+    cell = nn.RNNCell(in_size, hidden, nonlinearity=nonlinearity)
+    used = emit_rnn_cell_via_fragment(
+        g,
+        name_to_tensor,
+        base="cell",
+        nnef_dtype=nnef_dtype,
+        batch_dim=batch,
+        hidden=hidden,
+        input_ref=input_ref,
+        h_prev_ref=h_ref,
+        w_ih=cell.weight_ih.detach(),
+        w_hh=cell.weight_hh.detach(),
+        b_ih=cell.bias_ih.detach(),
+        b_hh=cell.bias_hh.detach(),
+        h_new_tv=None,
+        nonlinearity=nonlinearity,
+    )
+
+    fragment = f"rnn_{nonlinearity}_cell"
+    assert used == [fragment]
+    op_kinds = [op.type for op in g.operations]
+    compute_kinds = [k for k in op_kinds if k != "variable"]
+    assert compute_kinds == [fragment]
+
+
+@pytest.mark.parametrize("nonlinearity", ["tanh", "relu"])
+def test_helper_supports_bias_less_cell(nonlinearity):
+    """Bias-less variant: helper synthesizes a zero bias internally."""
+    batch, in_size, hidden = 1, 4, 4
+    g, name_to_tensor, nnef_dtype, input_ref, h_ref = _build_graph(
+        batch, in_size, hidden
+    )
+
+    cell = nn.RNNCell(in_size, hidden, bias=False, nonlinearity=nonlinearity)
+    used = emit_rnn_cell_via_fragment(
+        g,
+        name_to_tensor,
+        base="cell",
+        nnef_dtype=nnef_dtype,
+        batch_dim=batch,
+        hidden=hidden,
+        input_ref=input_ref,
+        h_prev_ref=h_ref,
+        w_ih=cell.weight_ih.detach(),
+        w_hh=cell.weight_hh.detach(),
+        b_ih=None,
+        b_hh=None,
+        h_new_tv=None,
+        nonlinearity=nonlinearity,
+    )
+
+    fragment = f"rnn_{nonlinearity}_cell"
+    assert used == [fragment]
+    op_kinds = [op.type for op in g.operations]
+    compute_kinds = [k for k in op_kinds if k != "variable"]
+    assert compute_kinds == [fragment]

--- a/tests/test_primitive.py
+++ b/tests/test_primitive.py
@@ -913,6 +913,15 @@ class SmoothL1LossMod(nn.Module):
         )
 
 
+class L1LossMod(nn.Module):
+    def __init__(self, reduction="mean") -> None:
+        super().__init__()
+        self.reduction = reduction
+
+    def forward(self, x, y):
+        return torch.nn.functional.l1_loss(x, y, reduction=self.reduction)
+
+
 # Mix small (|diff| < delta) and large residuals so both branches of
 # the piecewise loss run.
 _huber_in = torch.tensor([[0.1, 0.5, -2.0], [3.0, -0.2, 1.0]])
@@ -945,6 +954,21 @@ test_suite.add(
 test_suite.add(
     (_huber_in, _huber_tgt),
     SmoothL1LossMod(reduction="none"),
+    inference_conditions=skip_khronos_interpreter,
+)
+test_suite.add(
+    (_huber_in, _huber_tgt),
+    L1LossMod(),
+    inference_conditions=skip_khronos_interpreter,
+)
+test_suite.add(
+    (_huber_in, _huber_tgt),
+    L1LossMod(reduction="sum"),
+    inference_conditions=skip_khronos_interpreter,
+)
+test_suite.add(
+    (_huber_in, _huber_tgt),
+    L1LossMod(reduction="none"),
     inference_conditions=skip_khronos_interpreter,
 )
 

--- a/torch_to_nnef/op/aten/loss.py
+++ b/torch_to_nnef/op/aten/loss.py
@@ -129,6 +129,23 @@ def mse_loss(node, op_helper, **kwargs):
 
 
 @OP_REGISTRY.register()
+def l1_loss(node, op_helper, **kwargs):
+    """Map PyTorch `aten::l1_loss(input, target, reduction)` to NNEF.
+
+    Pointwise `|input - target|` via the `l1_loss` fragment, then
+    reduced. Like `mse_loss`, torch broadcasts upstream via
+    `aten::broadcast_tensors`, so the fragment assumes matching shapes.
+    """
+    input_node, target_node, reduction_node = node.inputs
+    reduction = _reduction_value(reduction_node, "l1_loss")
+    inp = op_helper.get_or_add_tensor_variable_in_nnef(input_node)
+    tgt = op_helper.get_or_add_tensor_variable_in_nnef(target_node)
+    return _emit_pointwise_loss(
+        op_helper, node, "l1_loss", [inp, tgt], reduction, input_node.rank
+    )
+
+
+@OP_REGISTRY.register()
 def huber_loss(node, op_helper, **kwargs):
     """Map PyTorch `aten::huber_loss(input, target, reduction, delta)`.
 

--- a/torch_to_nnef/op/aten/rnn.py
+++ b/torch_to_nnef/op/aten/rnn.py
@@ -19,8 +19,11 @@ Layout:
     per-variant tensor_params from the aten op's flat
     `params: Tensor[]` argument.
   - Aten op handlers: `aten::lstm`, `aten::gru`, `aten::rnn_tanh`,
-    `aten::rnn_relu`, plus `aten::lstm_cell` (single-step,
-    fragment-based via `lstm_cell.nnef`).
+    `aten::rnn_relu`, plus the single-step cell variants
+    (`aten::lstm_cell`, `aten::gru_cell`, `aten::rnn_tanh_cell`,
+    `aten::rnn_relu_cell`), each routed through a one-call NNEF
+    fragment (`lstm_cell.nnef` / `gru_cell.nnef` /
+    `rnn_tanh_cell.nnef` / `rnn_relu_cell.nnef`).
 """
 
 from __future__ import annotations
@@ -94,6 +97,30 @@ def _multi_output_pair(
         return nt
 
     return make("h_new", h_new_tv), make("c_new", c_new_tv)
+
+
+def _single_output(
+    g,
+    name_to_tensor,
+    base: str,
+    nnef_dtype,
+    batch_dim: int,
+    hidden: int,
+    h_new_tv: T.Optional[TensorVariable],
+    suffix: str = "h_new",
+) -> NTensor:
+    if h_new_tv is not None:
+        return add_tensor_variable_node_as_nnef_tensor(
+            g, h_new_tv, name_to_tensor, prevent_variable=True
+        )
+    nt = NTensor(
+        g,
+        name=f"{base}_{suffix}",
+        dtype=nnef_dtype,
+        shape=(batch_dim, hidden),
+    )
+    name_to_tensor[nt.name] = nt
+    return nt
 
 
 def emit_lstm_cell_via_fragment(
@@ -237,6 +264,262 @@ def lstm_cell(g, node, name_to_tensor, **kwargs):
         h_new_tv=h_new_tv,
         c_new_tv=c_new_tv,
     )
+
+
+# -------------------------------------------------------------------------
+# GRUCell (single step, see gru_cell.nnef fragment)
+# -------------------------------------------------------------------------
+
+
+def emit_gru_cell_via_fragment(
+    g,
+    name_to_tensor,
+    base: str,
+    nnef_dtype,
+    batch_dim: int,
+    hidden: int,
+    input_ref: NTensor,
+    h_prev_ref: NTensor,
+    w_ih: torch.Tensor,
+    w_hh: torch.Tensor,
+    b_ih: T.Optional[torch.Tensor],
+    b_hh: T.Optional[torch.Tensor],
+    h_new_tv: T.Optional[TensorVariable],
+) -> T.List[str]:
+    """Emit a single `gru_cell` NNEF fragment call.
+
+    Unlike `lstm_cell`, GRU keeps `b_ih` and `b_hh` separate because the
+    new-gate biases are split across the reset-gated branch (see the
+    fragment docstring for the equations).
+    """
+    w_ih_ref = _add_weight_tensor(g, name_to_tensor, base, "weight_ih", w_ih)
+    w_hh_ref = _add_weight_tensor(g, name_to_tensor, base, "weight_hh", w_hh)
+
+    zeros = torch.zeros(3 * hidden, dtype=w_ih.dtype)
+    b_ih_full = (b_ih if b_ih is not None else zeros).unsqueeze(0)
+    b_hh_full = (b_hh if b_hh is not None else zeros).unsqueeze(0)
+    b_ih_ref = _add_weight_tensor(g, name_to_tensor, base, "bias_ih", b_ih_full)
+    b_hh_ref = _add_weight_tensor(g, name_to_tensor, base, "bias_hh", b_hh_full)
+
+    h_new_ref = _single_output(
+        g, name_to_tensor, base, nnef_dtype, batch_dim, hidden, h_new_tv
+    )
+
+    NOperation(
+        graph=g,
+        type="gru_cell",
+        inputs=(input_ref, h_prev_ref, w_ih_ref, w_hh_ref, b_ih_ref, b_hh_ref),
+        outputs=(h_new_ref,),
+        attribs={
+            "r_end": int(hidden),
+            "z_end": int(2 * hidden),
+            "n_end": int(3 * hidden),
+        },
+    )
+    return ["gru_cell"]
+
+
+@OP_REGISTRY.register()
+def gru_cell(g, node, name_to_tensor, **kwargs):
+    """Map `aten::gru_cell(input, hx, w_ih, w_hh, b_ih?, b_hh?)` to NNEF.
+
+    `hx` is a single 2D state tensor (unlike LSTM's 2-element list).
+    """
+    if len(node.inputs) < 4:
+        raise T2NErrorNotImplemented(
+            "aten::gru_cell expects (input, hx, w_ih, w_hh[, b_ih, b_hh]); "
+            f"got {len(node.inputs)} inputs"
+        )
+    input_node = node.inputs[0]
+    hx_node = node.inputs[1]
+    w_ih_node = node.inputs[2]
+    w_hh_node = node.inputs[3]
+    b_ih_node = node.inputs[4] if len(node.inputs) >= 5 else None
+    b_hh_node = node.inputs[5] if len(node.inputs) >= 6 else None
+
+    input_ref = get_or_add_tensor_variable_in_nnef(
+        g, input_node, name_to_tensor
+    )
+    h_prev_ref = get_or_add_tensor_variable_in_nnef(g, hx_node, name_to_tensor)
+
+    def _torch_tensor_or_none(n):
+        if n is None or n.data is None:
+            return None
+        return n.data
+
+    w_ih = _torch_tensor_or_none(w_ih_node)
+    w_hh = _torch_tensor_or_none(w_hh_node)
+    if w_ih is None or w_hh is None:
+        raise T2NErrorNotImplemented(
+            "aten::gru_cell requires statically-resolved weight tensors"
+        )
+    b_ih = _torch_tensor_or_none(b_ih_node)
+    b_hh = _torch_tensor_or_none(b_hh_node)
+
+    hidden = w_hh.shape[1]
+    batch_dim = (
+        input_node.shape[0]
+        if input_node.shape and input_node.shape[0] is not None
+        else 1
+    )
+
+    if len(node.outputs) != 1:
+        raise T2NErrorNotImplemented(
+            f"aten::gru_cell expects 1 output; got {len(node.outputs)}"
+        )
+    (h_new_tv,) = node.outputs
+
+    return emit_gru_cell_via_fragment(
+        g,
+        name_to_tensor,
+        base=h_new_tv.export_name,
+        nnef_dtype=input_ref.dtype,
+        batch_dim=batch_dim,
+        hidden=hidden,
+        input_ref=input_ref,
+        h_prev_ref=h_prev_ref,
+        w_ih=w_ih,
+        w_hh=w_hh,
+        b_ih=b_ih,
+        b_hh=b_hh,
+        h_new_tv=h_new_tv,
+    )
+
+
+# -------------------------------------------------------------------------
+# RNNCell (single step Elman cell, tanh/relu variants -- see
+# rnn_tanh_cell.nnef / rnn_relu_cell.nnef fragments)
+# -------------------------------------------------------------------------
+
+
+def emit_rnn_cell_via_fragment(
+    g,
+    name_to_tensor,
+    base: str,
+    nnef_dtype,
+    batch_dim: int,
+    hidden: int,
+    input_ref: NTensor,
+    h_prev_ref: NTensor,
+    w_ih: torch.Tensor,
+    w_hh: torch.Tensor,
+    b_ih: T.Optional[torch.Tensor],
+    b_hh: T.Optional[torch.Tensor],
+    h_new_tv: T.Optional[TensorVariable],
+    nonlinearity: str,
+) -> T.List[str]:
+    """Emit a single `rnn_{tanh,relu}_cell` NNEF fragment call.
+
+    Like `lstm_cell` the biases are pre-summed to a single `(1, H)` term
+    -- the Elman cell's nonlinearity sits on the full preactivation so
+    `b_ih` and `b_hh` are interchangeable in the math.
+    """
+    if nonlinearity not in ("tanh", "relu"):
+        raise T2NErrorNotImplemented(
+            f"unsupported RNN cell nonlinearity {nonlinearity!r}"
+        )
+    fragment = f"rnn_{nonlinearity}_cell"
+
+    w_ih_ref = _add_weight_tensor(g, name_to_tensor, base, "weight_ih", w_ih)
+    w_hh_ref = _add_weight_tensor(g, name_to_tensor, base, "weight_hh", w_hh)
+
+    if b_ih is None and b_hh is None:
+        bias = torch.zeros(1, hidden, dtype=w_ih.dtype)
+    else:
+        zeros = torch.zeros(hidden, dtype=w_ih.dtype)
+        bi = b_ih if b_ih is not None else zeros
+        bh = b_hh if b_hh is not None else zeros
+        bias = (bi + bh).unsqueeze(0)
+    b_ref = _add_weight_tensor(g, name_to_tensor, base, "bias", bias)
+
+    h_new_ref = _single_output(
+        g, name_to_tensor, base, nnef_dtype, batch_dim, hidden, h_new_tv
+    )
+
+    NOperation(
+        graph=g,
+        type=fragment,
+        inputs=(input_ref, h_prev_ref, w_ih_ref, w_hh_ref, b_ref),
+        outputs=(h_new_ref,),
+    )
+    return [fragment]
+
+
+def _emit_aten_rnn_cell_simple(g, node, name_to_tensor, nonlinearity: str):
+    if len(node.inputs) < 4:
+        raise T2NErrorNotImplemented(
+            f"aten::rnn_{nonlinearity}_cell expects (input, hx, w_ih, w_hh"
+            f"[, b_ih, b_hh]); got {len(node.inputs)} inputs"
+        )
+    input_node = node.inputs[0]
+    hx_node = node.inputs[1]
+    w_ih_node = node.inputs[2]
+    w_hh_node = node.inputs[3]
+    b_ih_node = node.inputs[4] if len(node.inputs) >= 5 else None
+    b_hh_node = node.inputs[5] if len(node.inputs) >= 6 else None
+
+    input_ref = get_or_add_tensor_variable_in_nnef(
+        g, input_node, name_to_tensor
+    )
+    h_prev_ref = get_or_add_tensor_variable_in_nnef(g, hx_node, name_to_tensor)
+
+    def _torch_tensor_or_none(n):
+        if n is None or n.data is None:
+            return None
+        return n.data
+
+    w_ih = _torch_tensor_or_none(w_ih_node)
+    w_hh = _torch_tensor_or_none(w_hh_node)
+    if w_ih is None or w_hh is None:
+        raise T2NErrorNotImplemented(
+            f"aten::rnn_{nonlinearity}_cell requires statically-resolved "
+            "weight tensors"
+        )
+    b_ih = _torch_tensor_or_none(b_ih_node)
+    b_hh = _torch_tensor_or_none(b_hh_node)
+
+    hidden = w_hh.shape[1]
+    batch_dim = (
+        input_node.shape[0]
+        if input_node.shape and input_node.shape[0] is not None
+        else 1
+    )
+
+    if len(node.outputs) != 1:
+        raise T2NErrorNotImplemented(
+            f"aten::rnn_{nonlinearity}_cell expects 1 output; "
+            f"got {len(node.outputs)}"
+        )
+    (h_new_tv,) = node.outputs
+
+    return emit_rnn_cell_via_fragment(
+        g,
+        name_to_tensor,
+        base=h_new_tv.export_name,
+        nnef_dtype=input_ref.dtype,
+        batch_dim=batch_dim,
+        hidden=hidden,
+        input_ref=input_ref,
+        h_prev_ref=h_prev_ref,
+        w_ih=w_ih,
+        w_hh=w_hh,
+        b_ih=b_ih,
+        b_hh=b_hh,
+        h_new_tv=h_new_tv,
+        nonlinearity=nonlinearity,
+    )
+
+
+@OP_REGISTRY.register()
+def rnn_tanh_cell(g, node, name_to_tensor, **kwargs):
+    """Map `aten::rnn_tanh_cell(input, hx, w_ih, w_hh, b_ih?, b_hh?)`."""
+    return _emit_aten_rnn_cell_simple(g, node, name_to_tensor, "tanh")
+
+
+@OP_REGISTRY.register()
+def rnn_relu_cell(g, node, name_to_tensor, **kwargs):
+    """Map `aten::rnn_relu_cell(input, hx, w_ih, w_hh, b_ih?, b_hh?)`."""
+    return _emit_aten_rnn_cell_simple(g, node, name_to_tensor, "relu")
 
 
 # -------------------------------------------------------------------------

--- a/torch_to_nnef/op/fragment/gru_cell.nnef
+++ b/torch_to_nnef/op/fragment/gru_cell.nnef
@@ -1,0 +1,41 @@
+extension tract_registry tract_core;
+
+# Single-step GRUCell. Same one-fragment-per-step shape as `lstm_cell`,
+# mirroring the multi-step `gru_scan_loop` math:
+#   r = sigmoid(W_ir x + b_ir + W_hr h + b_hr)
+#   z = sigmoid(W_iz x + b_iz + W_hz h + b_hz)
+#   n = tanh(W_in x + b_in + r * (W_hn h + b_hn))
+#   h_new = (1 - z) * n + z * h_prev
+# Note the asymmetric bias placement on `n`: torch keeps `b_in` and
+# `b_hh.n` separate (because of `r * (W_hn h + b_hn)`), so the emitter
+# passes `b_ih` and `b_hh` as two `(1, 3H)` tensors rather than a single
+# summed bias like `lstm_cell` can use.
+
+fragment gru_cell(
+    input: tensor<scalar>,        # (B, I)
+    h_prev: tensor<scalar>,       # (B, H)
+    W_ih: tensor<scalar>,         # (3H, I) -- combined [r; z; n] input weights
+    W_hh: tensor<scalar>,         # (3H, H) -- combined [r; z; n] hidden weights
+    b_ih: tensor<scalar>,         # (1, 3H) -- [b_ir, b_iz, b_in]
+    b_hh: tensor<scalar>,         # (1, 3H) -- [b_hr, b_hz, b_hn]
+    r_end: integer,               # = H
+    z_end: integer,               # = 2*H
+    n_end: integer                # = 3*H
+) -> ( h_new: tensor<scalar> ) {
+    preact_x = matmul(input, W_ih, transposeB = true) + b_ih;
+    preact_h = matmul(h_prev, W_hh, transposeB = true) + b_hh;
+
+    rx = slice(preact_x, axes = [1], begin = [0],     end = [r_end]);
+    zx = slice(preact_x, axes = [1], begin = [r_end], end = [z_end]);
+    nx = slice(preact_x, axes = [1], begin = [z_end], end = [n_end]);
+
+    rh = slice(preact_h, axes = [1], begin = [0],     end = [r_end]);
+    zh = slice(preact_h, axes = [1], begin = [r_end], end = [z_end]);
+    nh = slice(preact_h, axes = [1], begin = [z_end], end = [n_end]);
+
+    r = sigmoid(rx + rh);
+    z = sigmoid(zx + zh);
+    n = tanh(nx + r * nh);
+
+    h_new = (1.0 - z) * n + z * h_prev;
+}

--- a/torch_to_nnef/op/fragment/l1_loss.nnef
+++ b/torch_to_nnef/op/fragment/l1_loss.nnef
@@ -1,0 +1,10 @@
+# Pointwise absolute error: |input - target|.
+# Reduction (mean / sum / none) is applied by the emitter.
+fragment l1_loss(
+    input: tensor<scalar>,
+    target: tensor<scalar>
+) -> ( output: tensor<scalar> )
+{
+    diff   = sub(input, target);
+    output = abs(diff);
+}

--- a/torch_to_nnef/op/fragment/rnn_relu_cell.nnef
+++ b/torch_to_nnef/op/fragment/rnn_relu_cell.nnef
@@ -1,0 +1,17 @@
+extension tract_registry tract_core;
+
+# Single-step Elman RNN cell with `relu` nonlinearity:
+#   h_new = relu(W_ih x + b_ih + W_hh h_prev + b_hh)
+# See `rnn_tanh_cell` for the bias convention.
+fragment rnn_relu_cell(
+    input: tensor<scalar>,        # (B, I)
+    h_prev: tensor<scalar>,       # (B, H)
+    W_ih: tensor<scalar>,         # (H, I)
+    W_hh: tensor<scalar>,         # (H, H)
+    b: tensor<scalar>             # (1, H) -- `b_ih + b_hh`
+) -> ( h_new: tensor<scalar> ) {
+    preact = matmul(input, W_ih, transposeB = true)
+           + matmul(h_prev, W_hh, transposeB = true)
+           + b;
+    h_new  = relu(preact);
+}

--- a/torch_to_nnef/op/fragment/rnn_tanh_cell.nnef
+++ b/torch_to_nnef/op/fragment/rnn_tanh_cell.nnef
@@ -1,0 +1,18 @@
+extension tract_registry tract_core;
+
+# Single-step Elman RNN cell with `tanh` nonlinearity:
+#   h_new = tanh(W_ih x + b_ih + W_hh h_prev + b_hh)
+# Bias is the summed `b_ih + b_hh` to match how the multi-step
+# `rnn_tanh` fragment receives it.
+fragment rnn_tanh_cell(
+    input: tensor<scalar>,        # (B, I)
+    h_prev: tensor<scalar>,       # (B, H)
+    W_ih: tensor<scalar>,         # (H, I)
+    W_hh: tensor<scalar>,         # (H, H)
+    b: tensor<scalar>             # (1, H) -- `b_ih + b_hh`
+) -> ( h_new: tensor<scalar> ) {
+    preact = matmul(input, W_ih, transposeB = true)
+           + matmul(h_prev, W_hh, transposeB = true)
+           + b;
+    h_new  = tanh(preact);
+}


### PR DESCRIPTION
## Summary

Four real aten ops the user flagged as surprising omissions, plus one phantom name to filter from the doc:

- **`aten::l1_loss`**: pointwise `|input - target|` via new `l1_loss.nnef` fragment + handler in `op/aten/loss.py`. Mirrors `mse_loss` exactly (broadcasting handled by upstream `aten::broadcast_tensors`).
- **`aten::gru_cell`**: single-step `nn.GRUCell` math. New `gru_cell.nnef` fragment uses the same one-node-per-step shape as the existing `lstm_cell` fragment; equations match the multi-step `gru_scan_loop` body (separate `b_ih` / `b_hh` because of the reset-gated branch).
- **`aten::rnn_tanh_cell`** / **`aten::rnn_relu_cell`**: single-step Elman cells with `tanh` / `relu` nonlinearity. Combined-bias fragments since the nonlinearity sits on the full preactivation.
- **doc filter**: drop phantom `conv` (regex-scrape artifact from `f\"aten::conv{dim}d(\"` in `pytorch/test/quantization/jit/test_quantize_jit.py`; no such bare `aten::conv` op exists). New exclusion bucket \"Regex-scrape artifacts (phantom names from f-strings)\".
- **proptest specs**: added `l1_loss`, `huber_loss`, `smooth_l1_loss` (the last two landed without specs in an earlier batch). Refactored their shared `(input, target, reduction)` draw into one helper.

Note: like `aten::lstm_cell`, the trace-based export decomposes `nn.GRUCell.forward` etc. into `aten::linear + chunk + ...`, so these aten handlers fire on scripted graphs / explicit `_VF.gru_cell(...)` calls. Trace-path GRU/RNN/LSTM cell exports already worked via decomposition; this PR closes the support-page gap and gives scripted-mode exports a one-fragment-per-step shape that's easier on tract's declutter.

## Test plan

- [x] `tests/test_aten_gru_cell.py` + `tests/test_aten_rnn_cell.py` pin the fragment shape (one node per cell call, correct slice bounds, bias-less path)
- [x] `tests/test_primitive.py::L1LossMod` covers all 3 reductions
- [x] `tests/test_primitive_proptest.py` exercises `l1_loss` / `huber_loss` / `smooth_l1_loss`
- [x] `ruff check` / `ruff format` clean across the repo
- [x] `prospector` clean for the touched files (only pre-existing W605 in the doc generator)
