### PR TITLE
test(proptest): opt tier A2 specs into dynamic-axes variant

### DIFF
--- a/tests/proptest/op_specs/elementwise.py
+++ b/tests/proptest/op_specs/elementwise.py
@@ -1351,6 +1351,7 @@ def _special_function_specs() -> T.List[OpSpec]:
                 torch.special.entr, domain=Interval(0.0, 100.0)
             ),
             tolerance=VERY,
+            dynamic_axes_compatible=True,
         ),
     ]
 
@@ -1502,24 +1503,45 @@ def _trapezoid_sample_st() -> st.SearchStrategy[OpSample]:
 def _tier_a2_specs() -> T.List[OpSpec]:
     APPROX = TractCheckTolerance.APPROXIMATE
     VERY = TractCheckTolerance.VERY
+    # All of these emit pure pointwise / slice-shape primitives whose
+    # axis arguments stay independent of the dynamic axis 0, so the
+    # dyn-axes proptest passes.
     return [
-        OpSpec(name="ravel", sample_st=_ravel_sample_st(), tolerance=APPROX),
+        OpSpec(
+            name="ravel",
+            sample_st=_ravel_sample_st(),
+            tolerance=APPROX,
+            dynamic_axes_compatible=True,
+        ),
         OpSpec(
             name="float_power",
             sample_st=_float_power_sample_st(),
             tolerance=VERY,
+            dynamic_axes_compatible=True,
         ),
-        OpSpec(name="diff_n1", sample_st=_diff_sample_st(1), tolerance=VERY),
-        OpSpec(name="diff_n2", sample_st=_diff_sample_st(2), tolerance=VERY),
+        OpSpec(
+            name="diff_n1",
+            sample_st=_diff_sample_st(1),
+            tolerance=VERY,
+            dynamic_axes_compatible=True,
+        ),
+        OpSpec(
+            name="diff_n2",
+            sample_st=_diff_sample_st(2),
+            tolerance=VERY,
+            dynamic_axes_compatible=True,
+        ),
         OpSpec(
             name="trapezoid",
             sample_st=_trapezoid_sample_st(),
             tolerance=VERY,
+            dynamic_axes_compatible=True,
         ),
         OpSpec(
             name="special_xlog1py",
             sample_st=_xlog1py_sample_st(),
             tolerance=VERY,
+            dynamic_axes_compatible=True,
         ),
     ]
 

--- a/tests/proptest/op_specs/specialty.py
+++ b/tests/proptest/op_specs/specialty.py
@@ -1226,28 +1226,55 @@ def _diag_embed_sample_st() -> st.SearchStrategy[OpSample]:
 def _tier_a2_linalg_specs() -> T.List[OpSpec]:
     CLOSE = TractCheckTolerance.CLOSE
     return [
-        OpSpec(name="inner", sample_st=_inner_sample_st(), tolerance=CLOSE),
-        OpSpec(name="vdot", sample_st=_vdot_sample_st(), tolerance=CLOSE),
-        OpSpec(name="kron", sample_st=_kron_sample_st(), tolerance=CLOSE),
+        OpSpec(
+            name="inner",
+            sample_st=_inner_sample_st(),
+            tolerance=CLOSE,
+            dynamic_axes_compatible=True,
+        ),
+        OpSpec(
+            name="vdot",
+            sample_st=_vdot_sample_st(),
+            tolerance=CLOSE,
+            dynamic_axes_compatible=True,
+        ),
+        # `kron`: emits a static `[m*p, n*q]` reshape, so axis 0 of the
+        # input has to be statically known.
+        OpSpec(
+            name="kron",
+            sample_st=_kron_sample_st(),
+            tolerance=CLOSE,
+            dynamic_axes_skip_reason=(
+                "kron emits a `[m*p, n*q]` reshape; static shapes only."
+            ),
+        ),
         OpSpec(
             name="diag_1d_to_2d",
             sample_st=_diag_1d_to_2d_sample_st(),
             tolerance=CLOSE,
+            dynamic_axes_compatible=True,
         ),
         OpSpec(
             name="diag_2d_to_1d",
             sample_st=_diag_2d_to_1d_sample_st(),
             tolerance=CLOSE,
+            dynamic_axes_compatible=True,
         ),
+        # `diagflat`: total flat size is baked into the reshape; the
+        # eye(N, N) constant also needs static N.
         OpSpec(
             name="diagflat",
             sample_st=_diagflat_sample_st(),
             tolerance=CLOSE,
+            dynamic_axes_skip_reason=(
+                "diagflat bakes a static flat size into the reshape."
+            ),
         ),
         OpSpec(
             name="diag_embed",
             sample_st=_diag_embed_sample_st(),
             tolerance=CLOSE,
+            dynamic_axes_compatible=True,
         ),
     ]
 


### PR DESCRIPTION
Verified each new spec under `with_dynamic_axes` and marked the 12 that pass:

- elementwise: ravel, float_power, diff (n=1, n=2), trapezoid, special_entr, special_xlog1py.
- linalg: inner, vdot, diag (1-D->2-D and 2-D->1-D), diag_embed.

kron and diagflat stay opted out: both bake a static reshape size into the emit. The skip_reason fields document why so the dyn-axes test driver surfaces a meaningful skip.