### PR TITLE
chore(security): Dependabot config + CI gate for dependency PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,121 @@
+# Dependabot config for the torch-to-nnef security initiative.
+#
+# Covers:
+#   - main Python packages  : the uv workspace (core + packages/llm +
+#                             packages/nemo-asr, locked by the root uv.lock)
+#                             and the standalone examples/.../nemo_asr_py project
+#   - example Rust crates    : crates.io deps + Cargo.lock for every crate root
+#   - example Python deps    : the requirements.txt pins under examples/
+#   - GitHub Actions         : keeps the SHA pins (+ "# vN" comment) current
+#
+# Intentionally NOT handled here (Dependabot cannot):
+#   - git dependencies on sonos/tract (pinned by rev/branch in several example
+#     Cargo.toml files). A separate scheduled job bumps those (Rust-hygiene
+#     step of the initiative).
+#   - examples/**/requirements.lock: these are `uv pip compile` outputs, not a
+#     manifest Dependabot recognises. Dependabot bumps the requirements.txt
+#     pins; the .lock files are refreshed separately.
+version: 2
+updates:
+  # ---------------------------------------------------------------------------
+  # Main packages: torch_to_nnef (core) + packages/llm + packages/nemo-asr form
+  # a single uv workspace locked by the root uv.lock.
+  # ---------------------------------------------------------------------------
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    labels: ["dependencies", "python", "core"]
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+    groups:
+      core-python:
+        patterns: ["*"]
+
+  # Standalone example uv project (own uv.lock, outside the workspace).
+  - package-ecosystem: "uv"
+    directory: "/examples/nemo_asr/src/nemo_asr_py"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 5
+    labels: ["dependencies", "python", "examples"]
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+    groups:
+      nemo-asr-py:
+        patterns: ["*"]
+
+  # ---------------------------------------------------------------------------
+  # GitHub Actions (we SHA-pin; Dependabot bumps the SHA and the "# vN" comment)
+  # ---------------------------------------------------------------------------
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels: ["dependencies", "github-actions"]
+    commit-message:
+      prefix: "chore(ci)"
+      include: "scope"
+    groups:
+      github-actions:
+        patterns: ["*"]
+
+  # ---------------------------------------------------------------------------
+  # Example Rust crates (crates.io deps + Cargo.lock; git/tract deps untouched).
+  # ---------------------------------------------------------------------------
+  - package-ecosystem: "cargo"
+    directories:
+      - "/examples/getting_started_rs"
+      - "/examples/imageclass-wasm"
+      - "/examples/llm_wasm"
+      - "/examples/yolo"
+      - "/examples/nemo_asr"
+      - "/examples/vad/FSMN-wasm"
+      - "/examples/mamba/pulse/mamba-rs"
+      - "/examples/mamba/external_state/mamba-rs"
+      - "/examples/speech_enhancement/dpdfnet/wav-cleaner-rs"
+      - "/examples/tts/pocket_tts/cli"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 10
+    labels: ["dependencies", "rust", "examples"]
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+    groups:
+      examples-cargo:
+        patterns: ["*"]
+
+  # ---------------------------------------------------------------------------
+  # Example Python deps (requirements.txt pins; .lock refreshed separately).
+  # ---------------------------------------------------------------------------
+  - package-ecosystem: "pip"
+    directories:
+      - "/examples/dynamic_axes"
+      - "/examples/getting_started_py"
+      - "/examples/image_gen"
+      - "/examples/imageclass-wasm"
+      - "/examples/llm_wasm"
+      - "/examples/mamba/external_state"
+      - "/examples/multi_io_py"
+      - "/examples/nemo_asr"
+      - "/examples/speech_enhancement/deepfilternet"
+      - "/examples/speech_enhancement/dpdfnet"
+      - "/examples/tts/pocket_tts"
+      - "/examples/vad/FSMN-wasm"
+      - "/examples/vad/silero-jit"
+      - "/examples/yolo"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 10
+    labels: ["dependencies", "python", "examples"]
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+    groups:
+      examples-pip:
+        patterns: ["*"]

--- a/.github/scripts/check_actions_pinned.py
+++ b/.github/scripts/check_actions_pinned.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Fail if any GitHub Action is not pinned to a full commit SHA.
+
+Enforces the supply-chain policy established when the workflows were first
+pinned: third-party (and first-party) actions must reference a 40-char commit
+SHA, not a floating tag. Validates that Dependabot's action bumps keep that
+form. Local actions (./ or ../) are exempt; docker:// refs must use @sha256:.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+import sys
+
+WORKFLOWS = pathlib.Path(".github/workflows")
+SHA40 = re.compile(r"^[0-9a-f]{40}$")
+USES = re.compile(r"""uses:\s*['"]?([^'"\s#]+)""")
+
+
+def main() -> int:
+    errors: list[str] = []
+    files = sorted(WORKFLOWS.glob("*.yml")) + sorted(WORKFLOWS.glob("*.yaml"))
+    for path in files:
+        for lineno, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+            match = USES.search(line)
+            if not match:
+                continue
+            ref = match.group(1)
+            if ref.startswith("./") or ref.startswith("../"):
+                continue  # local action
+            if ref.startswith("docker://"):
+                if "@sha256:" not in ref:
+                    errors.append((path, lineno, ref, "docker ref not pinned by @sha256:"))
+                continue
+            if "@" not in ref:
+                errors.append((path, lineno, ref, "no @ref (must be a commit SHA)"))
+                continue
+            tag = ref.split("@", 1)[1]
+            if not SHA40.match(tag):
+                errors.append((path, lineno, ref, "not pinned to a 40-char commit SHA"))
+
+    for path, lineno, ref, why in errors:
+        print(f"::error file={path},line={lineno}::{ref} -> {why}")
+    if errors:
+        print(f"\n{len(errors)} unpinned action reference(s).")
+        return 1
+    print(f"All GitHub Actions across {len(files)} workflow(s) are SHA-pinned.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/check_dependabot.py
+++ b/.github/scripts/check_dependabot.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Validate .github/dependabot.yml.
+
+Checks that the config is schema version 2 and that every directory it
+references actually contains the manifest its ecosystem expects. Keeps
+Dependabot from silently skipping a path that was moved or mistyped.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import yaml
+
+MANIFEST = {
+    "uv": "uv.lock",
+    "cargo": "Cargo.toml",
+    "pip": "requirements.txt",
+    "github-actions": ".github/workflows",
+}
+
+
+def main() -> int:
+    with open(".github/dependabot.yml", encoding="utf-8") as fh:
+        cfg = yaml.safe_load(fh)
+
+    errors: list[str] = []
+    if cfg.get("version") != 2:
+        errors.append("top-level `version` must be 2")
+
+    for upd in cfg.get("updates", []):
+        eco = upd.get("package-ecosystem")
+        manifest = MANIFEST.get(eco)
+        if manifest is None:
+            errors.append(f"unhandled package-ecosystem: {eco!r}")
+            continue
+        dirs = upd.get("directories") or [upd.get("directory")]
+        for d in dirs:
+            if d is None:
+                errors.append(f"{eco}: entry has neither `directory` nor `directories`")
+                continue
+            path = os.path.join("." + d, manifest)
+            if not os.path.exists(path):
+                errors.append(f"{eco}: {d} has no {manifest}")
+
+    for err in errors:
+        print(f"::error::{err}")
+    if errors:
+        print(f"\n{len(errors)} dependabot.yml problem(s).")
+        return 1
+    print("dependabot.yml OK: version 2 and all referenced directories have manifests.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -8,6 +8,8 @@ on:
       - "tests/**"
       - "packages/**"
       - "pyproject.toml"
+      - "uv.lock"
+      - ".github/workflows/ci-core.yml"
   pull_request:
     branches: [main]
     paths:
@@ -15,6 +17,8 @@ on:
       - "tests/**"
       - "packages/**"
       - "pyproject.toml"
+      - "uv.lock"
+      - ".github/workflows/ci-core.yml"
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/ci-llm.yml
+++ b/.github/workflows/ci-llm.yml
@@ -6,11 +6,15 @@ on:
     paths:
       - "packages/llm/**"
       - "torch_to_nnef/**"
+      - "uv.lock"
+      - ".github/workflows/ci-llm.yml"
   pull_request:
     branches: [main]
     paths:
       - "packages/llm/**"
       - "torch_to_nnef/**"
+      - "uv.lock"
+      - ".github/workflows/ci-llm.yml"
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/ci-nemo.yml
+++ b/.github/workflows/ci-nemo.yml
@@ -6,11 +6,15 @@ on:
     paths:
       - "packages/nemo-asr/**"
       - "torch_to_nnef/**"
+      - "uv.lock"
+      - ".github/workflows/ci-nemo.yml"
   pull_request:
     branches: [main]
     paths:
       - "packages/nemo-asr/**"
       - "torch_to_nnef/**"
+      - "uv.lock"
+      - ".github/workflows/ci-nemo.yml"
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/deps-check.yml
+++ b/.github/workflows/deps-check.yml
@@ -1,0 +1,71 @@
+name: deps check
+
+# Gate for dependency-related changes (Dependabot PRs, manifest/lockfile edits)
+# that the path-filtered ci-*.yml suites would otherwise leave untested.
+# Deliberately lightweight: schema/consistency/pinning checks, no heavy builds.
+# Deep Rust auditing (cargo-deny) and CVE scanning (Trivy) land here in the
+# later steps of the security initiative.
+on:
+  pull_request:
+    paths:
+      - "**/uv.lock"
+      - "**/requirements*.txt"
+      - "**/Cargo.toml"
+      - "**/Cargo.lock"
+      - ".github/dependabot.yml"
+      - ".github/workflows/**"
+      - ".github/scripts/**"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  config:
+    name: dependabot config + action pinning
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6
+      - name: Validate .github/dependabot.yml
+        run: uv run --no-project --with pyyaml python .github/scripts/check_dependabot.py
+      - name: Enforce SHA-pinned GitHub Actions
+        run: python3 .github/scripts/check_actions_pinned.py
+
+  uv-lock:
+    name: uv lockfiles consistent
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6
+      - name: Workspace lock up to date with pyproject
+        run: uv lock --check
+      - name: Standalone nemo_asr_py lock up to date
+        working-directory: examples/nemo_asr/src/nemo_asr_py
+        run: uv lock --check
+
+  cargo:
+    name: example Cargo manifests valid
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: cargo verify-project (all example crate roots)
+        run: |
+          set -euo pipefail
+          roots=(
+            examples/getting_started_rs
+            examples/imageclass-wasm
+            examples/llm_wasm
+            examples/yolo
+            examples/nemo_asr
+            examples/vad/FSMN-wasm
+            examples/mamba/pulse/mamba-rs
+            examples/mamba/external_state/mamba-rs
+            examples/speech_enhancement/dpdfnet/wav-cleaner-rs
+            examples/tts/pocket_tts/cli
+          )
+          for d in "${roots[@]}"; do
+            echo "::group::$d"
+            cargo verify-project --manifest-path "$d/Cargo.toml"
+            echo "::endgroup::"
+          done

--- a/examples/nemo_asr/src/nemo_asr_py/uv.lock
+++ b/examples/nemo_asr/src/nemo_asr_py/uv.lock
@@ -2696,6 +2696,7 @@ dependencies = [
 
 [package.optional-dependencies]
 eval = [
+    { name = "datasets" },
     { name = "evaluate" },
     { name = "jiwer" },
     { name = "nemo-toolkit", extra = ["asr"] },
@@ -2707,6 +2708,7 @@ eval = [
 
 [package.metadata]
 requires-dist = [
+    { name = "datasets", marker = "extra == 'eval'", specifier = ">=4.0.0" },
     { name = "evaluate", marker = "extra == 'eval'", specifier = ">=0.4.6" },
     { name = "jiwer", marker = "extra == 'eval'", specifier = ">=4.0.0" },
     { name = "nemo-toolkit", extras = ["asr"], marker = "extra == 'eval'", specifier = ">=2.0.0,<2.7.0" },


### PR DESCRIPTION
Step 2 of the security initiative: enable Dependabot **and** make sure the PRs it opens actually get tested. Stacked originally on #143 (now merged), so this targets `main`.

## 1. Dependabot config (`.github/dependabot.yml`)
- **Main packages (`uv`)**: workspace at `/` (core + `packages/llm` + `packages/nemo-asr`, root `uv.lock`) weekly; standalone `examples/nemo_asr/src/nemo_asr_py` monthly.
- **GitHub Actions**: keeps the SHA pins (+ `# vN` comment) current, weekly.
- **Example Rust (`cargo`)**: all 10 crate roots, monthly.
- **Example Python (`pip`)**: all 14 example `requirements.txt`, monthly.
- Grouped per ecosystem; `chore(deps)` / `chore(ci)` commit prefixes.

## 2. CI gate for dependency PRs
The existing `ci-*.yml` suites are path-filtered to source/tests/packages, so dependency-only PRs (lockfile bumps, example Cargo/pip updates, action bumps) would merge **untested**. Two fixes:

**Widened path filters** so dependency bumps hit the real suites:
- `ci-core` / `ci-llm` / `ci-nemo` now also trigger on `uv.lock` and on their own workflow file.

**New lightweight `deps-check.yml`** (runs on lockfiles/manifests/`dependabot.yml`/workflow changes), no third-party actions:
- `check_dependabot.py` - validates `dependabot.yml` is schema v2 and every referenced directory has its manifest.
- `check_actions_pinned.py` - fails if any `uses:` is not pinned to a 40-char commit SHA (enforces the #143 policy and validates Dependabot's action bumps keep the SHA form).
- `uv lock --check` on the workspace and on `nemo_asr_py` - lockfile must match `pyproject`.
- `cargo verify-project` on all 10 example crate roots - catches malformed `Cargo.toml`.

Deep Rust auditing (`cargo-deny`) and CVE scanning (Trivy) will plug into this same workflow in the later steps.

## Caught by the new gate
The `uv lock --check` step found `examples/nemo_asr/src/nemo_asr_py/uv.lock` was **stale**: `datasets>=4.0.0` had been added to the `eval` extra in `pyproject.toml` without re-locking. Regenerated (2-line diff) so the gate is green. `uv` also reports a pre-existing yanked transitive `wandb==0.24.0` there - left as-is (transitive; a natural catch for the Trivy step).

## Still not covered by Dependabot (documented in the config)
- git/`tract` deps pinned by `rev`/`branch` (Dependabot can't bump git revisions) - needs a scheduled job (Rust-hygiene step).
- `examples/**/requirements.lock` are `uv pip compile` outputs, not a Dependabot manifest; it bumps the `requirements.txt` pins and the `.lock` is refreshed separately.