### PR TITLE
ci: cargo-deny security gate for example crates + rustc-freshness check

### DIFF
--- a/.github/workflows/deps-check.yml
+++ b/.github/workflows/deps-check.yml
@@ -3,8 +3,8 @@ name: deps check
 # Gate for dependency-related changes (Dependabot PRs, manifest/lockfile edits)
 # that the path-filtered ci-*.yml suites would otherwise leave untested.
 # Deliberately lightweight: schema/consistency/pinning checks, no heavy builds.
-# Deep Rust auditing (cargo-deny) and CVE scanning (Trivy) land here in the
-# later steps of the security initiative.
+# Deep Rust auditing (cargo-deny: advisories/bans/sources) runs here. CVE
+# scanning (Trivy) and license enforcement are planned to land here too.
 on:
   pull_request:
     paths:
@@ -12,6 +12,7 @@ on:
       - "**/requirements*.txt"
       - "**/Cargo.toml"
       - "**/Cargo.lock"
+      - "**/deny.toml"
       - ".github/dependabot.yml"
       - ".github/workflows/**"
       - ".github/scripts/**"
@@ -67,5 +68,45 @@ jobs:
           for d in "${roots[@]}"; do
             echo "::group::$d"
             cargo verify-project --manifest-path "$d/Cargo.toml"
+            echo "::endgroup::"
+          done
+
+  cargo-deny:
+    name: cargo-deny (advisories/bans/sources)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - name: Install cargo-deny
+        run: |
+          set -euo pipefail
+          VERSION=0.19.8
+          base="https://github.com/EmbarkStudios/cargo-deny/releases/download"
+          asset="cargo-deny-${VERSION}-x86_64-unknown-linux-musl.tar.gz"
+          curl -fsSL "${base}/${VERSION}/${asset}" \
+            | tar xz --strip-components=1 -C /usr/local/bin --wildcards '*/cargo-deny'
+          cargo-deny --version
+      # advisories = RUSTSEC vulnerabilities (hard fail) + acknowledged
+      # unmaintained ignores; bans = duplicate/wildcard policy; sources = only
+      # crates.io + allowed git. licenses is intentionally excluded for now
+      # (see examples/deny.toml). Single shared policy via --config.
+      - name: cargo-deny check (all example crate roots)
+        run: |
+          set -euo pipefail
+          roots=(
+            examples/getting_started_rs
+            examples/imageclass-wasm
+            examples/llm_wasm
+            examples/yolo
+            examples/nemo_asr
+            examples/vad/FSMN-wasm
+            examples/mamba/pulse/mamba-rs
+            examples/mamba/external_state/mamba-rs
+            examples/speech_enhancement/dpdfnet/wav-cleaner-rs
+            examples/tts/pocket_tts/cli
+          )
+          for d in "${roots[@]}"; do
+            echo "::group::$d"
+            cargo-deny --manifest-path "$d/Cargo.toml" \
+              check advisories bans sources --config examples/deny.toml
             echo "::endgroup::"
           done

--- a/.github/workflows/deps-check.yml
+++ b/.github/workflows/deps-check.yml
@@ -89,7 +89,11 @@ jobs:
       # unmaintained ignores; bans = duplicate/wildcard policy; sources = only
       # crates.io + allowed git. licenses is intentionally excluded for now
       # (see examples/deny.toml). Single shared policy via --config.
-      - name: cargo-deny check (all example crate roots)
+      # vad/FSMN-wasm is intentionally absent: it depends on getrandom 0.4.2
+      # under two names (a wasm RNG-backend setup) and `cargo metadata` itself
+      # refuses such graphs, so cargo-deny cannot analyze it. It stays covered
+      # by the verify-project job and the examples-run wasm build.
+      - name: cargo-deny check (example crate roots)
         run: |
           set -euo pipefail
           roots=(
@@ -98,7 +102,6 @@ jobs:
             examples/llm_wasm
             examples/yolo
             examples/nemo_asr
-            examples/vad/FSMN-wasm
             examples/mamba/pulse/mamba-rs
             examples/mamba/external_state/mamba-rs
             examples/speech_enhancement/dpdfnet/wav-cleaner-rs

--- a/.github/workflows/rustc-freshness.yml
+++ b/.github/workflows/rustc-freshness.yml
@@ -1,0 +1,63 @@
+name: rustc freshness
+
+# Track the latest stable rustc on a ~6-week cadence (the Rust release
+# cadence). Rather than a blind timer, this runs weekly and only acts when
+# examples/rust-toolchain.toml has actually drifted behind the current stable
+# release, so it self-adjusts to the real schedule.
+#
+# It opens (once) a tracking issue rather than an auto-PR on purpose: opening a
+# PR from Actions depends on an org-level setting and a third-party action,
+# both of which are avoidable supply-chain surface for a security workflow. A
+# maintainer bumps the single channel line (and re-checks the tract git revs
+# while there) and the issue auto-closes on the next run once in sync.
+on:
+  schedule:
+    - cron: "0 5 * * 1" # Mondays 05:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  check:
+    name: pinned rustc vs latest stable
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+      TITLE: "Bump examples rust-toolchain to latest stable rustc"
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - name: Compare pinned toolchain to latest stable
+        run: |
+          set -euo pipefail
+          latest=$(curl -fsSL https://static.rust-lang.org/dist/channel-rust-stable.toml \
+            | awk '/^\[pkg.rust\]/{f=1} f && /^version = /{gsub(/[",]/,""); print $3; exit}')
+          current=$(awk -F'"' '/^channel/{print $2; exit}' examples/rust-toolchain.toml)
+          echo "pinned=$current latest-stable=$latest"
+          if [ -z "$latest" ]; then echo "could not resolve latest stable"; exit 1; fi
+
+          existing=$(gh issue list --state open --search "$TITLE in:title" \
+            --json number --jq '.[0].number // empty')
+
+          if [ "$current" = "$latest" ]; then
+            echo "rust-toolchain is current."
+            if [ -n "$existing" ]; then
+              gh issue close "$existing" \
+                --comment "examples/rust-toolchain.toml is now on $current (latest stable). Auto-closing."
+            fi
+            exit 0
+          fi
+
+          echo "::warning::pinned rustc $current is behind latest stable $latest"
+          body=$(printf '%s\n' \
+            "\`examples/rust-toolchain.toml\` pins **$current**; latest stable is **$latest**." \
+            "" \
+            "Bump the single \`channel\` line, then run the examples-run workflow to confirm the crates still build. While here, re-check the pinned \`sonos/tract\` git revs/branches for updates (Dependabot does not track git-branch deps)." \
+            "" \
+            "Tracked automatically by \`.github/workflows/rustc-freshness.yml\`; this issue closes itself once the pin matches latest stable.")
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --body "Still behind: pinned $current, latest stable $latest."
+          else
+            gh issue create --title "$TITLE" --body "$body"
+          fi

--- a/examples/deny.toml
+++ b/examples/deny.toml
@@ -1,0 +1,93 @@
+# Shared cargo-deny policy for ALL example crates.
+#
+# There is no Cargo workspace spanning the examples, so the CI job runs
+# cargo-deny per crate root with `--config examples/deny.toml`, pointing every
+# crate at this single source of truth. Bump the example crates' deps via the
+# `examples-cargo` Dependabot group; this file is the gate those bumps clear.
+#
+# Validate locally:  cargo deny --manifest-path examples/<crate>/Cargo.toml \
+#                      check --config examples/deny.toml
+
+[graph]
+# Examples build for the host plus the wasm target (imageclass-wasm, llm_wasm,
+# yolo, FSMN-wasm). Audit both so wasm-only dependencies are not skipped.
+targets = [
+    "x86_64-unknown-linux-gnu",
+    "wasm32-unknown-unknown",
+]
+all-features = true
+
+# --- Security advisories: the core of this gate ----------------------------
+# advisories schema v2: a RUSTSEC vulnerability is a hard error by default and
+# unmaintained crates warn. We keep yanked crates as an error too. `ignore` is
+# the documented escape hatch: add `"RUSTSEC-XXXX-NNNN"` with a comment when an
+# advisory is acknowledged and unfixable (e.g. only reachable on an unused
+# feature), so the audit trail lives in git rather than in a CI override.
+[advisories]
+version = 2
+yanked = "deny"
+# Acknowledged, unfixable transitive advisories. Each below is an *unmaintained*
+# notice (crate abandonment), NOT an exploitable vulnerability, and is pulled in
+# transitively by tract / its CLI deps -- there is no upstream-fixed version to
+# bump to. Any actual `vulnerability` advisory is intentionally absent here so it
+# stays a hard CI failure (that is how RUSTSEC-2026-0009 in `time` was caught and
+# fixed by bumping the lockfile). Re-audit when tract drops these dependencies.
+ignore = [
+    "RUSTSEC-2024-0375", # atty unmaintained (transitive via clap-era CLI deps)
+    "RUSTSEC-2024-0436", # paste unmaintained (transitive via tract-linalg)
+    "RUSTSEC-2025-0119", # number_prefix unmaintained (transitive via indicatif)
+]
+
+# --- Licenses ---------------------------------------------------------------
+# Allow the OSI-permissive set the Rust ecosystem actually uses. A copyleft or
+# unknown license in the example dependency graph fails the build and forces a
+# conscious decision rather than silently shipping it.
+#
+# NOTE: the CI job runs `check advisories bans sources` only -- license
+# enforcement is NOT wired in yet. It is deferred to a dedicated license /
+# SPDX-compliance pass, which also resolves the two prerequisites: first-party
+# example crates need `publish = false`, and the sonos/tract git crates
+# (causal_llm, tract-*) carry no license metadata on their feature branches and
+# need `[[licenses.clarify]]` entries. This block is kept here, configured and
+# ready, so enabling it later only means adding `licenses` to the check list.
+[licenses]
+version = 2
+confidence-threshold = 0.9
+# The example crates themselves are path crates that are never published and
+# carry no `license` field; skip them so the policy applies to dependencies
+# only. `unused-allowed-license` is silenced because the allow-list below is a
+# superset shared by all crates, so any single crate leaves some entries unhit.
+private = { ignore = true }
+unused-allowed-license = "allow"
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "ISC",
+    "Zlib",
+    "MPL-2.0",
+    "Unicode-3.0",
+    "Unicode-DFS-2016",
+    "CC0-1.0",
+    "Unlicense",
+    "BSL-1.0",
+    "OpenSSL",
+]
+
+# --- Bans -------------------------------------------------------------------
+# Duplicate transitive versions are noise across this many independent crates,
+# so warn rather than fail. Wildcards are allowed because several examples
+# depend on tract via a pinned git rev (a legitimate non-semver dependency).
+[bans]
+multiple-versions = "warn"
+wildcards = "allow"
+
+# --- Sources ----------------------------------------------------------------
+# Only crates.io and GitHub-hosted git deps (tract pulse/STFT branches, etc.)
+# are expected. An unknown registry is a supply-chain red flag and fails.
+[sources]
+unknown-registry = "deny"
+unknown-git = "allow"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]

--- a/examples/getting_started_rs/Cargo.lock
+++ b/examples/getting_started_rs/Cargo.lock
@@ -1304,9 +1304,9 @@ dependencies = [
 
 [[package]]
 name = "tar"
-version = "0.4.44"
+version = "0.4.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d863878d212c87a19c1a610eb53bb01fe12951c0501cf5a0d65f724914a667a"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
 dependencies = [
  "filetime",
  "libc",

--- a/examples/imageclass-wasm/Cargo.lock
+++ b/examples/imageclass-wasm/Cargo.lock
@@ -1376,9 +1376,9 @@ dependencies = [
 
 [[package]]
 name = "tar"
-version = "0.4.44"
+version = "0.4.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d863878d212c87a19c1a610eb53bb01fe12951c0501cf5a0d65f724914a667a"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
 dependencies = [
  "filetime",
  "libc",

--- a/examples/llm_wasm/Cargo.lock
+++ b/examples/llm_wasm/Cargo.lock
@@ -328,9 +328,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.4.0"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
 ]
@@ -887,9 +887,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.1.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-integer"
@@ -1426,9 +1426,9 @@ dependencies = [
 
 [[package]]
 name = "tar"
-version = "0.4.44"
+version = "0.4.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d863878d212c87a19c1a610eb53bb01fe12951c0501cf5a0d65f724914a667a"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
 dependencies = [
  "filetime",
  "libc",
@@ -1457,30 +1457,30 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.41"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
  "num-conv",
  "powerfmt",
- "serde",
+ "serde_core",
  "time-core",
  "time-macros",
 ]
 
 [[package]]
 name = "time-core"
-version = "0.1.4"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "time-macros"
-version = "0.2.22"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3526739392ec93fd8b359c8e98514cb3e8e021beb4e5f597b00a0221f8ed8a49"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",

--- a/examples/nemo_asr/Cargo.lock
+++ b/examples/nemo_asr/Cargo.lock
@@ -1832,9 +1832,9 @@ dependencies = [
 
 [[package]]
 name = "tar"
-version = "0.4.44"
+version = "0.4.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d863878d212c87a19c1a610eb53bb01fe12951c0501cf5a0d65f724914a667a"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
 dependencies = [
  "filetime",
  "libc",

--- a/examples/rust-toolchain.toml
+++ b/examples/rust-toolchain.toml
@@ -1,7 +1,8 @@
 # Single rust toolchain for ALL example crates. rustup searches parent
 # directories, so every crate under examples/ inherits this automatically --
 # no per-example rust-toolchain files, no symlinks. Bump this one line every
-# ~6 weeks to track the latest stable rustc (security initiative, step 3).
+# ~6 weeks to track the latest stable rustc (the rustc-freshness workflow opens
+# a tracking issue when this drifts behind stable).
 [toolchain]
 channel = "1.95.0"
 targets = ["wasm32-unknown-unknown"]

--- a/examples/vad/FSMN-wasm/Cargo.lock
+++ b/examples/vad/FSMN-wasm/Cargo.lock
@@ -1669,9 +1669,9 @@ dependencies = [
 
 [[package]]
 name = "tar"
-version = "0.4.45"
+version = "0.4.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
 dependencies = [
  "filetime",
  "libc",

--- a/examples/yolo/Cargo.lock
+++ b/examples/yolo/Cargo.lock
@@ -1647,9 +1647,9 @@ dependencies = [
 
 [[package]]
 name = "tar"
-version = "0.4.44"
+version = "0.4.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d863878d212c87a19c1a610eb53bb01fe12951c0501cf5a0d65f724914a667a"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
 dependencies = [
  "filetime",
  "libc",


### PR DESCRIPTION
## What

Adds a `cargo-deny` gate over the example crate roots (run from `deps-check.yml`), a shared `examples/deny.toml` policy, and a weekly `rustc-freshness` workflow that flags when the pinned example toolchain drifts behind latest stable.

## The gate immediately found (and this PR fixes) two real RUSTSEC advisories

Both are vulnerabilities pulled in transitively via `tract`, fixed by bumping the committed lockfiles (no version-range edits needed):

- `RUSTSEC-2026-0068`: `tar` < 0.4.45 (PAX header parsing), bumped to `0.4.46` in 6 lockfiles.
- `RUSTSEC-2026-0009`: `time` < 0.3.47 (DoS via stack exhaustion, via `liquid` / `tract-linalg`), bumped to `0.3.47` in `llm_wasm`.

## Policy (`examples/deny.toml`, one shared config)

- `advisories`: a RUSTSEC **vulnerability** is a hard CI failure. Three **unmaintained** notices (`atty`, `paste`, `number_prefix`) are acknowledged in `ignore` with per-ID comments: they are abandonment notices, not exploitable CVEs, and have no upstream-fixed version (all transitive via `tract` / its CLI deps). Vulnerabilities are deliberately never in that list, so new ones stay red.
- `bans`: duplicate versions warn (noisy across this many independent crates), wildcards allowed (examples pin `tract` via git).
- `sources`: only `crates.io` plus GitHub git deps.
- `licenses`: configured but **not** enforced yet. Deferred to a dedicated license/SPDX pass, which also needs `publish = false` on the first-party example crates and `clarify` entries for the `sonos/tract` git crates that carry no license metadata on their branches.

## Scope

9 of the 10 example crate roots are checked. `vad/FSMN-wasm` is excluded: it depends on `getrandom 0.4.2` under two names (wasm RNG backend) and `cargo metadata` itself rejects that graph, so cargo-deny cannot analyze it. It stays covered by the `verify-project` job and the examples-run wasm build.

## rustc-freshness workflow

Weekly check comparing `examples/rust-toolchain.toml` to current stable. On drift it opens (once) a tracking issue and auto-closes it when back in sync. It opens an issue rather than a PR on purpose: auto-PRs from Actions depend on an org setting and a third-party action, both avoidable supply-chain surface. Uses only the preinstalled `gh` CLI.

## Validation

`cargo-deny check advisories bans sources` passes locally (by exit code) on all 9 checked roots after the lockfile fixes. Workflow YAML parses and the SHA-pin check passes (cargo-deny is installed via a pinned release tarball, no new action dependency).