### PR TITLE
ci: enable cargo-deny licenses check across example crates

### DIFF
--- a/.github/workflows/deps-check.yml
+++ b/.github/workflows/deps-check.yml
@@ -3,8 +3,8 @@ name: deps check
 # Gate for dependency-related changes (Dependabot PRs, manifest/lockfile edits)
 # that the path-filtered ci-*.yml suites would otherwise leave untested.
 # Deliberately lightweight: schema/consistency/pinning checks, no heavy builds.
-# Deep Rust auditing (cargo-deny: advisories/bans/sources) runs here. CVE
-# scanning (Trivy) and license enforcement are planned to land here too.
+# Deep Rust auditing (cargo-deny: advisories/bans/sources/licenses) runs here.
+# Python CVE scanning + SPDX SBOM live in security-scan.yml.
 on:
   pull_request:
     paths:
@@ -72,7 +72,7 @@ jobs:
           done
 
   cargo-deny:
-    name: cargo-deny (advisories/bans/sources)
+    name: cargo-deny (advisories/bans/sources/licenses)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -87,8 +87,8 @@ jobs:
           cargo-deny --version
       # advisories = RUSTSEC vulnerabilities (hard fail) + acknowledged
       # unmaintained ignores; bans = duplicate/wildcard policy; sources = only
-      # crates.io + allowed git. licenses is intentionally excluded for now
-      # (see examples/deny.toml). Single shared policy via --config.
+      # crates.io + allowed git; licenses = OSI-permissive allow-list (first-party
+      # crates are publish=false and skipped). Single shared policy via --config.
       # vad/FSMN-wasm is intentionally absent: it depends on getrandom 0.4.2
       # under two names (a wasm RNG-backend setup) and `cargo metadata` itself
       # refuses such graphs, so cargo-deny cannot analyze it. It stays covered
@@ -110,6 +110,6 @@ jobs:
           for d in "${roots[@]}"; do
             echo "::group::$d"
             cargo-deny --manifest-path "$d/Cargo.toml" \
-              check advisories bans sources --config examples/deny.toml
+              check advisories bans sources licenses --config examples/deny.toml
             echo "::endgroup::"
           done

--- a/examples/deny.toml
+++ b/examples/deny.toml
@@ -41,15 +41,8 @@ ignore = [
 # --- Licenses ---------------------------------------------------------------
 # Allow the OSI-permissive set the Rust ecosystem actually uses. A copyleft or
 # unknown license in the example dependency graph fails the build and forces a
-# conscious decision rather than silently shipping it.
-#
-# NOTE: the CI job runs `check advisories bans sources` only -- license
-# enforcement is NOT wired in yet. It is deferred to a dedicated license /
-# SPDX-compliance pass, which also resolves the two prerequisites: first-party
-# example crates need `publish = false`, and the sonos/tract git crates
-# (causal_llm, tract-*) carry no license metadata on their feature branches and
-# need `[[licenses.clarify]]` entries. This block is kept here, configured and
-# ready, so enabling it later only means adding `licenses` to the check list.
+# conscious decision rather than silently shipping it. First-party example
+# crates are marked `publish = false` and skipped via `private.ignore` below.
 [licenses]
 version = 2
 confidence-threshold = 0.9
@@ -75,6 +68,17 @@ allow = [
     "BSL-1.0",
     "OpenSSL",
 ]
+
+# causal_llm is an example crate living inside the sonos/tract repo (pulled in
+# by llm_wasm as a git dep) that omits the `license` field. The tract repo is
+# dual MIT/Apache-2.0 (its published crates declare exactly this, and the repo
+# ships LICENSE-MIT + LICENSE-APACHE), so assert that here rather than allow an
+# unlicensed crate through. license-files is empty: the field is simply absent
+# upstream, this is not an ambiguous-detection override.
+[[licenses.clarify]]
+crate = "causal_llm"
+expression = "MIT OR Apache-2.0"
+license-files = []
 
 # --- Bans -------------------------------------------------------------------
 # Duplicate transitive versions are noise across this many independent crates,

--- a/examples/getting_started_rs/Cargo.toml
+++ b/examples/getting_started_rs/Cargo.toml
@@ -1,4 +1,5 @@
 [package]
+publish = false  # example crate, never published
 name = "getting_started_tract"
 version = "0.1.0"
 edition = "2024"

--- a/examples/imageclass-wasm/Cargo.toml
+++ b/examples/imageclass-wasm/Cargo.toml
@@ -1,4 +1,5 @@
 [package]
+publish = false  # example crate, never published
 name = "imageclass-wasm"
 version = "0.1.0"
 edition = "2024"

--- a/examples/llm_wasm/Cargo.toml
+++ b/examples/llm_wasm/Cargo.toml
@@ -1,4 +1,5 @@
 [package]
+publish = false  # example crate, never published
 name = "llm_wasm"
 version = "0.1.0"
 edition = "2024"

--- a/examples/nemo_asr/src/nemo_asr/Cargo.toml
+++ b/examples/nemo_asr/src/nemo_asr/Cargo.toml
@@ -1,4 +1,5 @@
 [package]
+publish = false  # example crate, never published
 name = "nemo_asr"
 version = "0.1.0"
 edition = "2024"

--- a/examples/nemo_asr/src/nemo_asr_ffi/Cargo.toml
+++ b/examples/nemo_asr/src/nemo_asr_ffi/Cargo.toml
@@ -1,4 +1,5 @@
 [package]
+publish = false  # example crate, never published
 name = "nemo_asr_ffi"
 version = "0.1.0"
 edition = "2024"

--- a/examples/tts/pocket_tts/cli/Cargo.toml
+++ b/examples/tts/pocket_tts/cli/Cargo.toml
@@ -1,4 +1,5 @@
 [package]
+publish = false  # example crate, never published
 name = "pocket-tts-tract"
 version = "0.1.0"
 edition = "2024"

--- a/examples/vad/FSMN-wasm/Cargo.toml
+++ b/examples/vad/FSMN-wasm/Cargo.toml
@@ -1,4 +1,5 @@
 [package]
+publish = false  # example crate, never published
 name = "vad-wasm"
 version = "0.1.0"
 edition = "2024"

--- a/examples/yolo/Cargo.toml
+++ b/examples/yolo/Cargo.toml
@@ -1,4 +1,5 @@
 [package]
+publish = false  # example crate, never published
 name = "yolo"
 version = "0.1.0"
 edition = "2024"


### PR DESCRIPTION
## What

Turns on the `licenses` check in the cargo-deny gate (it previously ran `advisories bans sources` only). The shared `examples/deny.toml` allow-list of OSI-permissive licenses is now enforced: a copyleft or unknown license entering the example dependency graph fails CI.

## Prerequisites this PR resolves

Enabling `licenses` is not just a flag flip; two metadata gaps had to be closed first:

1. **First-party example crates carried no `license` field**, so cargo-deny flagged them `unlicensed`. Marked the 8 that lacked it `publish = false` (matching the 3 that already were, e.g. `wav-cleaner`, `mamba`), which `private.ignore` then skips. These crates are examples and are never published, so this is the honest declaration.
2. **`causal_llm` has no license metadata.** It is an example crate living inside the `sonos/tract` repo (pulled in by `llm_wasm` as a git dep) that omits the `license` field. tract is dual `MIT OR Apache-2.0` (its published crates declare exactly that and the repo ships `LICENSE-MIT` + `LICENSE-APACHE`), so this is asserted with a `[[licenses.clarify]]` entry rather than letting an unlicensed crate through.

## Validation

`cargo-deny check advisories bans sources licenses` passes (by exit code) on all 9 audited roots. `vad/FSMN-wasm` remains excluded for the same `cargo metadata` reason as before. YAML and the action SHA-pin check pass.

This completes the cargo-deny side of the license/SPDX story. The Python SPDX SBOM already ships via `security-scan.yml` (#157).