### PR TITLE
ci: guard major torch/transformers bumps + de-flake cli_transformers HF downloads

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,6 +28,18 @@ updates:
     commit-message:
       prefix: "chore(deps)"
       include: "scope"
+    # t2n's export tracks the torch/transformers internals closely and a major
+    # bump has silently broken exports before (transformers 5.x rewrote
+    # attention). Hold majors of these back so they are taken deliberately,
+    # behind their own tested PR, rather than landing unattended. Minor/patch
+    # bumps still flow.
+    ignore:
+      - dependency-name: "transformers"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "torch"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "torchaudio"
+        update-types: ["version-update:semver-major"]
     groups:
       core-python:
         patterns: ["*"]
@@ -105,6 +117,16 @@ updates:
     commit-message:
       prefix: "chore(deps)"
       include: "scope"
+    # Same rationale as the core block: several examples pin a specific
+    # transformers/torch (e.g. llm_wasm on transformers 4.52) precisely because
+    # a major bump breaks their export. Hold majors for a deliberate PR.
+    ignore:
+      - dependency-name: "transformers"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "torch"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "torchaudio"
+        update-types: ["version-update:semver-major"]
     groups:
       examples-python:
         patterns: ["*"]

--- a/.github/workflows/ci-llm.yml
+++ b/.github/workflows/ci-llm.yml
@@ -54,5 +54,25 @@ jobs:
           python -m pip install --upgrade pip
           pip install tox==4.23.2
 
+      # Reuse downloaded HF models across runs so most runs need no network at
+      # all; key on the prefetch list + slug definitions so it busts when the
+      # set of models changes. Model blobs are python-agnostic, so the matrix
+      # jobs share one entry.
+      - name: Cache Hugging Face models
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ~/.cache/huggingface
+          key: hf-llm-${{ hashFiles('packages/llm/tests/prefetch_hf_models.py', 'packages/llm/torch_to_nnef_llm/config.py') }}
+          restore-keys: |
+            hf-llm-
+
+      # Warm the cache with retries before pytest: the suite downloads several
+      # tiny models at collection time, which intermittently hits HF's per-IP
+      # 429 on shared runners. Best-effort, so it never fails the build.
+      - name: Prefetch HF models (retry on 429)
+        run: |
+          python -m pip install "huggingface_hub>=0.23"
+          python packages/llm/tests/prefetch_hf_models.py
+
       - name: test with tox
         run: cd packages/llm && tox run -e ${{ matrix.tox-env }}

--- a/packages/llm/tests/prefetch_hf_models.py
+++ b/packages/llm/tests/prefetch_hf_models.py
@@ -26,6 +26,12 @@ MODELS = [
 ]
 
 
+# Only these are worth retrying: 429 (rate limit) + transient 5xx. An auth or
+# missing error (401/403/404, e.g. a gated repo without a token) will never
+# succeed on retry, so skip it immediately rather than burning the backoff.
+TRANSIENT = {429, 500, 502, 503, 504}
+
+
 def prefetch(repo_id: str, attempts: int = 5, base_delay: float = 3.0) -> None:
     from huggingface_hub import snapshot_download
     from huggingface_hub.utils import HfHubHTTPError
@@ -37,15 +43,18 @@ def prefetch(repo_id: str, attempts: int = 5, base_delay: float = 3.0) -> None:
             return
         except HfHubHTTPError as e:
             status = getattr(getattr(e, "response", None), "status_code", None)
+            if status not in TRANSIENT:
+                print(f"[prefetch] skip {repo_id}: HTTP {status} (permanent)")
+                return
             print(
                 f"[prefetch] attempt {i}/{attempts} for {repo_id} "
-                f"failed: {status or e}"
+                f"failed: HTTP {status}"
             )
             if i == attempts:
                 print(f"[prefetch] giving up on {repo_id} (best-effort)")
                 return
             time.sleep(base_delay * 2 ** (i - 1))
-        except Exception as e:  # gated/private/offline: skip, test decides
+        except Exception as e:  # offline/unknown: skip, test decides
             print(f"[prefetch] skip {repo_id}: {type(e).__name__}: {e}")
             return
 

--- a/packages/llm/tests/prefetch_hf_models.py
+++ b/packages/llm/tests/prefetch_hf_models.py
@@ -1,0 +1,60 @@
+"""Pre-fetch the small Hugging Face models the LLM test suite downloads.
+
+Run before pytest in CI to warm the shared HF cache (``~/.cache/huggingface``)
+with a few retries and backoff, so the collection-time ``from_pretrained`` calls
+hit the cache instead of racing Hugging Face's per-IP rate limit (HTTP 429) on
+shared CI runners.
+
+Best-effort by design: a model that cannot be fetched is logged and skipped,
+never failing the step (the test will still attempt its own download). This can
+only help, never introduce a failure.
+
+The slugs mirror the *real-download* entries in ``torch_to_nnef_llm.config``;
+the ``*_debug`` slugs there are synthetic local configs and are intentionally
+absent. Keep this list in sync if the suite starts exercising a new hub model.
+"""
+
+import sys
+import time
+
+# Real HF repos pulled by tests/ (see torch_to_nnef_llm.config slug enums).
+MODELS = [
+    "yujiepan/llama-2-tiny-random",  # LlamaSlugs.DUMMY (the usual 429 victim)
+    "HuggingFaceTB/SmolLM-135M",  # SmolSlugs.TINY
+    "Qwen/Qwen3-0.6B",  # Qwen3Slugs.TINY
+    "google/gemma-3-270m",  # Gemma3Slugs.TINY
+]
+
+
+def prefetch(repo_id: str, attempts: int = 5, base_delay: float = 3.0) -> None:
+    from huggingface_hub import snapshot_download
+    from huggingface_hub.utils import HfHubHTTPError
+
+    for i in range(1, attempts + 1):
+        try:
+            snapshot_download(repo_id)
+            print(f"[prefetch] ok: {repo_id}")
+            return
+        except HfHubHTTPError as e:
+            status = getattr(getattr(e, "response", None), "status_code", None)
+            print(
+                f"[prefetch] attempt {i}/{attempts} for {repo_id} "
+                f"failed: {status or e}"
+            )
+            if i == attempts:
+                print(f"[prefetch] giving up on {repo_id} (best-effort)")
+                return
+            time.sleep(base_delay * 2 ** (i - 1))
+        except Exception as e:  # gated/private/offline: skip, test decides
+            print(f"[prefetch] skip {repo_id}: {type(e).__name__}: {e}")
+            return
+
+
+def main() -> int:
+    for repo_id in MODELS:
+        prefetch(repo_id)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Two CI-robustness changes from the security-initiative follow-up list.

## 1. Dependabot: hold back transformers / torch / torchaudio major bumps

`transformers` 5.x rewrote attention and silently broke t2n's LLM export (the regression we fixed earlier). To stop a repeat landing unattended, the core `uv` block and the examples `uv` block now `ignore` `version-update:semver-major` for `transformers`, `torch`, and `torchaudio`. Minor and patch bumps still flow normally; a major is then a deliberate, separately-tested PR. Several examples (e.g. `llm_wasm` on `transformers==4.52`) pin a version precisely for this reason, so the rule applies there too.

## 2. De-flake `cli_transformers` HF downloads (429)

The `cli_transformers_*` jobs intermittently fail at pytest collection with HTTP 429 from Hugging Face (shared-runner per-IP rate limit) while pulling small test models. Two-part fix, mirroring the `hf_pull` approach used in the examples:

- **Cache** `~/.cache/huggingface` across runs (`actions/cache`), keyed on the prefetch list + slug definitions. Most runs then need no network at all.
- **Prefetch with retry** before pytest: `packages/llm/tests/prefetch_hf_models.py` `snapshot_download`s the 4 tiny hub models the suite uses (`yujiepan/llama-2-tiny-random`, `SmolLM-135M`, `Qwen3-0.6B`, `gemma-3-270m`) with exponential backoff, warming the cache before the collection-time `from_pretrained` calls. It is **best-effort** (a model it cannot fetch is logged and skipped), so it can only help, never introduce a failure. The `*_debug` slugs are synthetic local configs and are intentionally excluded.

## Validation

`check_dependabot.py` passes on the new config; the prefetch script is ruff-clean and was run locally (fetched the tiny llama successfully); workflow YAML parses and the action SHA-pin check passes.