### PR TITLE
ci(core): cache models + de-flake zoo HF downloads

### DIFF
--- a/.github/scripts/hf_prefetch.py
+++ b/.github/scripts/hf_prefetch.py
@@ -13,34 +13,49 @@ shared runners (the suites download small models at collection time).
 import sys
 import time
 
-# Worth retrying: 429 (rate limit) + transient 5xx. Auth/missing (401/403/404,
-# e.g. a gated repo without a token) will never succeed on retry, so skip those
-# immediately rather than burning the backoff.
-TRANSIENT = {429, 500, 502, 503, 504}
+# Auth/missing (401/403/404, e.g. a gated repo without a token) will never
+# succeed on retry, so skip those immediately. Everything else (429 rate limit,
+# transient 5xx, or a connection error with no status) is worth retrying.
+PERMANENT = {401, 403, 404}
+
+
+def _http_status(exc: BaseException) -> int | None:
+    """Find an HTTP status anywhere in the exception's cause chain.
+
+    snapshot_download wraps a rate-limited metadata fetch in a
+    LocalEntryNotFoundError whose cause is the real HfHubHTTPError, so the
+    status we must branch on (e.g. 429) is not on the outermost exception.
+    """
+    seen: set[int] = set()
+    cur: BaseException | None = exc
+    while cur is not None and id(cur) not in seen:
+        seen.add(id(cur))
+        status = getattr(getattr(cur, "response", None), "status_code", None)
+        if status is not None:
+            return status
+        cur = cur.__cause__ or cur.__context__
+    return None
 
 
 def prefetch(repo_id: str, attempts: int = 5, base_delay: float = 3.0) -> None:
     from huggingface_hub import snapshot_download
-    from huggingface_hub.utils import HfHubHTTPError
 
     for i in range(1, attempts + 1):
         try:
             snapshot_download(repo_id)
             print(f"[prefetch] ok: {repo_id}")
             return
-        except HfHubHTTPError as e:
-            status = getattr(getattr(e, "response", None), "status_code", None)
-            if status not in TRANSIENT:
+        except Exception as e:
+            status = _http_status(e)
+            if status in PERMANENT:
                 print(f"[prefetch] skip {repo_id}: HTTP {status} (permanent)")
                 return
-            print(f"[prefetch] attempt {i}/{attempts} {repo_id}: HTTP {status}")
+            label = f"HTTP {status}" if status else type(e).__name__
+            print(f"[prefetch] attempt {i}/{attempts} {repo_id}: {label}")
             if i == attempts:
                 print(f"[prefetch] giving up on {repo_id} (best-effort)")
                 return
             time.sleep(base_delay * 2 ** (i - 1))
-        except Exception as e:  # offline/unknown: skip, test decides
-            print(f"[prefetch] skip {repo_id}: {type(e).__name__}: {e}")
-            return
 
 
 def main(argv: list[str]) -> int:

--- a/.github/scripts/hf_prefetch.py
+++ b/.github/scripts/hf_prefetch.py
@@ -1,0 +1,53 @@
+"""Best-effort prefetch of Hugging Face models to warm the CI cache.
+
+Usage: python .github/scripts/hf_prefetch.py <repo_id> [<repo_id> ...]
+
+``snapshot_download``s each repo with backoff, retrying only transient errors
+(429 rate limit + 5xx) and skipping permanent ones (401/403/404) immediately.
+Best-effort by design: a model it cannot fetch is logged and skipped, never
+failing the step, so warming the cache can only help, never introduce a
+failure. CI runs this before pytest to dodge Hugging Face's per-IP 429 on
+shared runners (the suites download small models at collection time).
+"""
+
+import sys
+import time
+
+# Worth retrying: 429 (rate limit) + transient 5xx. Auth/missing (401/403/404,
+# e.g. a gated repo without a token) will never succeed on retry, so skip those
+# immediately rather than burning the backoff.
+TRANSIENT = {429, 500, 502, 503, 504}
+
+
+def prefetch(repo_id: str, attempts: int = 5, base_delay: float = 3.0) -> None:
+    from huggingface_hub import snapshot_download
+    from huggingface_hub.utils import HfHubHTTPError
+
+    for i in range(1, attempts + 1):
+        try:
+            snapshot_download(repo_id)
+            print(f"[prefetch] ok: {repo_id}")
+            return
+        except HfHubHTTPError as e:
+            status = getattr(getattr(e, "response", None), "status_code", None)
+            if status not in TRANSIENT:
+                print(f"[prefetch] skip {repo_id}: HTTP {status} (permanent)")
+                return
+            print(f"[prefetch] attempt {i}/{attempts} {repo_id}: HTTP {status}")
+            if i == attempts:
+                print(f"[prefetch] giving up on {repo_id} (best-effort)")
+                return
+            time.sleep(base_delay * 2 ** (i - 1))
+        except Exception as e:  # offline/unknown: skip, test decides
+            print(f"[prefetch] skip {repo_id}: {type(e).__name__}: {e}")
+            return
+
+
+def main(argv: list[str]) -> int:
+    for repo_id in argv:
+        prefetch(repo_id)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -60,5 +60,28 @@ jobs:
           python -m pip install --upgrade pip
           pip install tox==4.23.2
 
+      # The zoo suite downloads torchvision pretrained weights (-> ~/.cache/torch)
+      # and albert-base-v2 from Hugging Face (-> ~/.cache/huggingface), and other
+      # envs pull torch.hub models (e.g. silero). Reuse them across runs; key on
+      # the model-defining test so it busts when the set changes.
+      - name: Cache models (torch hub + Hugging Face)
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ~/.cache/torch
+            ~/.cache/huggingface
+          key: core-models-${{ hashFiles('tests/test_model_zoo.py', '.github/scripts/hf_prefetch.py') }}
+          restore-keys: |
+            core-models-
+
+      # Warm the HF cache with retries before pytest: the zoo suite pulls
+      # albert-base-v2 at collection time, which intermittently hits HF's per-IP
+      # 429 on shared runners. Best-effort, so it never fails the build.
+      - name: Prefetch HF models for the zoo suite (retry on 429)
+        if: contains(matrix.tox-env, 'zoo')
+        run: |
+          python -m pip install "huggingface_hub>=0.23"
+          python .github/scripts/hf_prefetch.py albert-base-v2
+
       - name: test with tox
         run: tox run -e ${{ matrix.tox-env }}


### PR DESCRIPTION
Extends the HF-download hardening to `ci-core.yml`, which had no caching at all. Follows the same pattern landed for `ci-llm` and already present in the examples.

## Why

The `zoo_*` jobs (`zoo_torch_2_2`, `zoo_py313`, `zoo_py314`) run `tests/test_model_zoo.py`, which downloads:
- torchvision pretrained weights (`weights=...DEFAULT`) from `download.pytorch.org` -> `~/.cache/torch`
- `albert-base-v2` via `from_pretrained` -> Hugging Face -> `~/.cache/huggingface`

`ci-core.yml` cached none of it, so every run re-downloaded everything and was exposed to the same per-IP HF 429 on `albert-base-v2` that bit `cli_transformers`. It just had not flaked yet.

## What

- **Cache** `~/.cache/torch` + `~/.cache/huggingface` across runs, keyed on `tests/test_model_zoo.py` (+ the prefetch script) so it busts when the model set changes. Applies to all matrix jobs (also helps e.g. `silero_vad_demo`'s torch.hub pull).
- **Prefetch with retry** before pytest, gated to the `zoo` jobs (the only ones that hit HF): `python .github/scripts/hf_prefetch.py albert-base-v2`.
- New generic `.github/scripts/hf_prefetch.py` (argv-based): `snapshot_download` with backoff, retrying only transient errors (429/5xx) and skipping permanent ones (401/403/404) immediately. Best-effort, so it can only help, never fail the build.

## Notes

- This is the generic, reusable form of the per-suite prefetch helper. `packages/llm`'s equivalent (from the cli_transformers de-flake) can be unified onto this script in a follow-up.
- Validated: `hf_prefetch.py` is ruff-clean and was run locally (fetched albert, cleanly skipped a 404). Workflow YAML parses and the action SHA-pin check passes.