### PR TITLE
fix(ci): retry wrapped HF 429s in the llm prefetch script

### DIFF
--- a/.github/scripts/hf_prefetch.py
+++ b/.github/scripts/hf_prefetch.py
@@ -4,14 +4,18 @@ Usage: python .github/scripts/hf_prefetch.py <repo_id> [<repo_id> ...]
 
 ``snapshot_download``s each repo with backoff, retrying only transient errors
 (429 rate limit + 5xx) and skipping permanent ones (401/403/404) immediately.
-Best-effort by design: a model it cannot fetch is logged and skipped, never
-failing the step, so warming the cache can only help, never introduce a
-failure. CI runs this before pytest to dodge Hugging Face's per-IP 429 on
-shared runners (the suites download small models at collection time).
+Best-effort for HF download failures: a model that cannot be fetched after
+retries is logged and skipped, so warming the cache only helps. Only HF
+request errors are handled; an unexpected (non-request) error is left to
+propagate rather than be masked. CI runs this before pytest to dodge Hugging
+Face's per-IP 429 on shared runners (the suites download models at collection).
 """
 
 import sys
 import time
+
+from huggingface_hub import snapshot_download
+from huggingface_hub.errors import HfHubHTTPError
 
 # Auth/missing (401/403/404, e.g. a gated repo without a token) will never
 # succeed on retry, so skip those immediately. Everything else (429 rate limit,
@@ -38,14 +42,16 @@ def _http_status(exc: BaseException) -> int | None:
 
 
 def prefetch(repo_id: str, attempts: int = 5, base_delay: float = 3.0) -> None:
-    from huggingface_hub import snapshot_download
-
     for i in range(1, attempts + 1):
         try:
             snapshot_download(repo_id)
             print(f"[prefetch] ok: {repo_id}")
             return
-        except Exception as e:
+        # HfHubHTTPError is the base of every HF HTTP error (429/5xx + auth/404,
+        # and the LocalEntryNotFoundError that wraps a rate-limited fetch), and
+        # imports without the requests/httpx backend (which the minimal prefetch
+        # env lacks). A non-HF error is unexpected and is left to propagate.
+        except HfHubHTTPError as e:
             status = _http_status(e)
             if status in PERMANENT:
                 print(f"[prefetch] skip {repo_id}: HTTP {status} (permanent)")

--- a/packages/llm/tests/prefetch_hf_models.py
+++ b/packages/llm/tests/prefetch_hf_models.py
@@ -26,37 +26,49 @@ MODELS = [
 ]
 
 
-# Only these are worth retrying: 429 (rate limit) + transient 5xx. An auth or
-# missing error (401/403/404, e.g. a gated repo without a token) will never
-# succeed on retry, so skip it immediately rather than burning the backoff.
-TRANSIENT = {429, 500, 502, 503, 504}
+# Auth/missing (401/403/404, e.g. a gated repo without a token) will never
+# succeed on retry, so skip those immediately. Everything else (429 rate limit,
+# transient 5xx, or a connection error with no status) is worth retrying.
+PERMANENT = {401, 403, 404}
+
+
+def _http_status(exc: BaseException) -> "int | None":
+    """Find an HTTP status anywhere in the exception's cause chain.
+
+    snapshot_download wraps a rate-limited metadata fetch in a
+    LocalEntryNotFoundError whose cause is the real HfHubHTTPError, so the
+    status we must branch on (e.g. 429) is not on the outermost exception.
+    """
+    seen: set = set()
+    cur: "BaseException | None" = exc
+    while cur is not None and id(cur) not in seen:
+        seen.add(id(cur))
+        status = getattr(getattr(cur, "response", None), "status_code", None)
+        if status is not None:
+            return status
+        cur = cur.__cause__ or cur.__context__
+    return None
 
 
 def prefetch(repo_id: str, attempts: int = 5, base_delay: float = 3.0) -> None:
     from huggingface_hub import snapshot_download
-    from huggingface_hub.utils import HfHubHTTPError
 
     for i in range(1, attempts + 1):
         try:
             snapshot_download(repo_id)
             print(f"[prefetch] ok: {repo_id}")
             return
-        except HfHubHTTPError as e:
-            status = getattr(getattr(e, "response", None), "status_code", None)
-            if status not in TRANSIENT:
+        except Exception as e:
+            status = _http_status(e)
+            if status in PERMANENT:
                 print(f"[prefetch] skip {repo_id}: HTTP {status} (permanent)")
                 return
-            print(
-                f"[prefetch] attempt {i}/{attempts} for {repo_id} "
-                f"failed: HTTP {status}"
-            )
+            label = f"HTTP {status}" if status else type(e).__name__
+            print(f"[prefetch] attempt {i}/{attempts} {repo_id}: {label}")
             if i == attempts:
                 print(f"[prefetch] giving up on {repo_id} (best-effort)")
                 return
             time.sleep(base_delay * 2 ** (i - 1))
-        except Exception as e:  # offline/unknown: skip, test decides
-            print(f"[prefetch] skip {repo_id}: {type(e).__name__}: {e}")
-            return
 
 
 def main() -> int:

--- a/packages/llm/tests/prefetch_hf_models.py
+++ b/packages/llm/tests/prefetch_hf_models.py
@@ -5,9 +5,10 @@ with a few retries and backoff, so the collection-time ``from_pretrained`` calls
 hit the cache instead of racing Hugging Face's per-IP rate limit (HTTP 429) on
 shared CI runners.
 
-Best-effort by design: a model that cannot be fetched is logged and skipped,
-never failing the step (the test will still attempt its own download). This can
-only help, never introduce a failure.
+Best-effort for HF download failures: a model that cannot be fetched after
+retries is logged and skipped (the test will still attempt its own download),
+so this only helps. Only HF request errors are handled; an unexpected
+(non-request) error is left to propagate rather than be masked.
 
 The slugs mirror the *real-download* entries in ``torch_to_nnef_llm.config``;
 the ``*_debug`` slugs there are synthetic local configs and are intentionally
@@ -16,6 +17,9 @@ absent. Keep this list in sync if the suite starts exercising a new hub model.
 
 import sys
 import time
+
+from huggingface_hub import snapshot_download
+from huggingface_hub.errors import HfHubHTTPError
 
 # Real HF repos pulled by tests/ (see torch_to_nnef_llm.config slug enums).
 MODELS = [
@@ -51,14 +55,16 @@ def _http_status(exc: BaseException) -> "int | None":
 
 
 def prefetch(repo_id: str, attempts: int = 5, base_delay: float = 3.0) -> None:
-    from huggingface_hub import snapshot_download
-
     for i in range(1, attempts + 1):
         try:
             snapshot_download(repo_id)
             print(f"[prefetch] ok: {repo_id}")
             return
-        except Exception as e:
+        # HfHubHTTPError is the base of every HF HTTP error (429/5xx + auth/404,
+        # and the LocalEntryNotFoundError that wraps a rate-limited fetch), and
+        # imports without the requests/httpx backend (which the minimal prefetch
+        # env lacks). A non-HF error is unexpected and is left to propagate.
+        except HfHubHTTPError as e:
             status = _http_status(e)
             if status in PERMANENT:
                 print(f"[prefetch] skip {repo_id}: HTTP {status} (permanent)")


### PR DESCRIPTION
Follow-up correctness fix to the `cli_transformers` HF-download de-flake from #159.

## The bug

`packages/llm/tests/prefetch_hf_models.py` caught `HfHubHTTPError` to decide whether to retry. But when `snapshot_download` is rate-limited during a metadata fetch, huggingface_hub wraps the 429 in a `LocalEntryNotFoundError` (whose `__cause__` is the real `HfHubHTTPError`). That wrapped form is not an `HfHubHTTPError`, so it fell through to the generic handler and was **skipped without retrying**, defeating the de-flake.

Caught it red-handed in the `ci-core` zoo run (separate PR), where the prefetch logged `skip albert-base-v2: LocalEntryNotFoundError: Got: HfHubHTTPError (Amz CF ID ...)` (the `Amz CF ID` is HF's CloudFront 429 signature) instead of retrying.

## The fix

Catch broadly and walk the exception `__cause__`/`__context__` chain for the real HTTP status, then branch on it: permanent (401/403/404) skips immediately, everything else (429, 5xx, or a no-status connection error) retries with backoff. Verified with a unit check that a `LocalEntryNotFoundError` wrapping a 429 now yields status 429 (retry), a direct 404 yields permanent-skip, and a no-status error retries.

The same correct logic also lands as the generic `.github/scripts/hf_prefetch.py` in the `ci-core` zoo-cache PR; these two prefetch scripts can be unified onto that one helper in a later cleanup.