### PR TITLE
feat(llm): make the LLM exporter resilient to HF rate limiting

### DIFF
--- a/packages/llm/pyproject.toml
+++ b/packages/llm/pyproject.toml
@@ -103,25 +103,25 @@ basepython = ["python3.12", "python3.13"]
 dependency_groups = ["test"]
 constrain_package_deps = false
 deps = ["transformers==4.50.0"]
-commands = [["pytest", "-s", "tests/test_llm_cli.py"]]
+commands = [["pytest", "-s", "tests/test_llm_cli.py", "tests/test_load_retry.py"]]
 
 [tool.tox.env.cli_transformers_4_52_0]
 basepython = ["python3.12", "python3.13"]
 dependency_groups = ["test"]
 constrain_package_deps = false
 deps = ["transformers==4.52.0"]
-commands = [["pytest", "-s", "tests/test_llm_cli.py"]]
+commands = [["pytest", "-s", "tests/test_llm_cli.py", "tests/test_load_retry.py"]]
 
 [tool.tox.env.cli_transformers_5_0_0]
 basepython = ["python3.12", "python3.13"]
 dependency_groups = ["test"]
 constrain_package_deps = false
 deps = ["transformers==5.0.0"]
-commands = [["pytest", "-s", "tests/test_llm_cli.py"]]
+commands = [["pytest", "-s", "tests/test_llm_cli.py", "tests/test_load_retry.py"]]
 
 [tool.tox.env.cli_transformers_5_5_0]
 basepython = ["python3.12", "python3.13"]
 dependency_groups = ["test"]
 constrain_package_deps = false
 deps = ["transformers==5.5.0"]
-commands = [["pytest", "-s", "tests/test_llm_cli.py"]]
+commands = [["pytest", "-s", "tests/test_llm_cli.py", "tests/test_load_retry.py"]]

--- a/packages/llm/tests/test_load_retry.py
+++ b/packages/llm/tests/test_load_retry.py
@@ -1,0 +1,99 @@
+"""Unit tests for LLMExporter.load's transient-failure retry logic.
+
+Network-free: `_load_exporter_from` is monkeypatched, so these exercise only
+the retry/backoff branching, not any Hugging Face download.
+"""
+
+import pytest
+
+from torch_to_nnef.exceptions import T2NErrorRuntime
+from torch_to_nnef_llm import exporter as exp_mod
+from torch_to_nnef_llm.exporter import LLMExporter, _hf_http_status
+
+
+def _oserror_wrapping_status(status: int) -> OSError:
+    """An OSError whose cause chain carries an HfHubHTTPError-like status.
+
+    Mirrors how transformers re-raises a rate-limited HF fetch: the HTTP error
+    is the __cause__, not the outermost exception.
+    """
+
+    class _Resp:
+        status_code = status
+
+    inner = Exception("http error")
+    inner.response = _Resp()  # type: ignore[attr-defined]
+    try:
+        try:
+            raise inner
+        except Exception as e:
+            raise OSError("We couldn't connect to huggingface.co") from e
+    except OSError as oserr:
+        return oserr
+
+
+def test_hf_http_status_walks_cause_chain():
+    assert _hf_http_status(_oserror_wrapping_status(429)) == 429
+    assert _hf_http_status(_oserror_wrapping_status(404)) == 404
+    assert _hf_http_status(OSError("no status here")) is None
+
+
+def test_load_retries_transient_then_succeeds(monkeypatch):
+    sleeps: list = []
+    monkeypatch.setattr(exp_mod.time, "sleep", lambda s: sleeps.append(s))
+    calls = {"n": 0}
+    sentinel = object()
+
+    def fake_load(**kwargs):
+        calls["n"] += 1
+        if calls["n"] < 3:
+            raise _oserror_wrapping_status(429)
+        return sentinel
+
+    monkeypatch.setattr(exp_mod, "_load_exporter_from", fake_load)
+    out = LLMExporter.load("dummy/slug", hf_download_n_retries=5)
+    assert out is sentinel
+    assert calls["n"] == 3
+    assert len(sleeps) == 2  # two retries before the success
+
+
+def test_load_gives_up_after_n_retries(monkeypatch):
+    monkeypatch.setattr(exp_mod.time, "sleep", lambda s: None)
+    calls = {"n": 0}
+
+    def fake_load(**kwargs):
+        calls["n"] += 1
+        raise _oserror_wrapping_status(429)
+
+    monkeypatch.setattr(exp_mod, "_load_exporter_from", fake_load)
+    with pytest.raises(T2NErrorRuntime):
+        LLMExporter.load("dummy/slug", hf_download_n_retries=2)
+    assert calls["n"] == 3  # initial attempt + 2 retries
+
+
+def test_load_does_not_retry_permanent_error(monkeypatch):
+    monkeypatch.setattr(exp_mod.time, "sleep", lambda s: None)
+    calls = {"n": 0}
+
+    def fake_load(**kwargs):
+        calls["n"] += 1
+        raise _oserror_wrapping_status(404)
+
+    monkeypatch.setattr(exp_mod, "_load_exporter_from", fake_load)
+    with pytest.raises(T2NErrorRuntime):
+        LLMExporter.load("dummy/slug", hf_download_n_retries=5)
+    assert calls["n"] == 1  # 404 is not retried
+
+
+def test_load_disabled_when_zero_retries(monkeypatch):
+    monkeypatch.setattr(exp_mod.time, "sleep", lambda s: None)
+    calls = {"n": 0}
+
+    def fake_load(**kwargs):
+        calls["n"] += 1
+        raise _oserror_wrapping_status(429)
+
+    monkeypatch.setattr(exp_mod, "_load_exporter_from", fake_load)
+    with pytest.raises(T2NErrorRuntime):
+        LLMExporter.load("dummy/slug", hf_download_n_retries=0)
+    assert calls["n"] == 1  # no retries when disabled

--- a/packages/llm/tests/test_load_retry.py
+++ b/packages/llm/tests/test_load_retry.py
@@ -48,9 +48,11 @@ class _FakeHub:
         self.calls: list = []
 
     def snapshot_download(self, slug, local_files_only=False):
+        from huggingface_hub.errors import LocalEntryNotFoundError
+
         self.calls.append(local_files_only)
         if local_files_only and not self.cached:
-            raise FileNotFoundError("not cached")
+            raise LocalEntryNotFoundError("not cached")
         return f"/cache/{slug}"
 
 
@@ -64,6 +66,17 @@ def test_resolve_snapshot_cache_miss_falls_back_to_network():
     hub = _FakeHub(cached=False)
     assert _resolve_snapshot_dir("some/model", hub) == "/cache/some/model"
     assert hub.calls == [True, False]  # cache-only attempt then network
+
+
+def test_resolve_snapshot_propagates_non_cache_miss_error():
+    """A genuine error (not a cache miss) must not be swallowed."""
+
+    class _BoomHub:
+        def snapshot_download(self, slug, local_files_only=False):
+            raise PermissionError("cache dir not readable")
+
+    with pytest.raises(PermissionError):
+        _resolve_snapshot_dir("some/model", _BoomHub())
 
 
 def test_load_retries_transient_then_succeeds(monkeypatch):

--- a/packages/llm/tests/test_load_retry.py
+++ b/packages/llm/tests/test_load_retry.py
@@ -1,7 +1,9 @@
-"""Unit tests for LLMExporter.load's transient-failure retry logic.
+"""Unit tests for LLMExporter.load's local-first + retry behavior.
 
 Network-free: `_load_exporter_from` is monkeypatched, so these exercise only
-the retry/backoff branching, not any Hugging Face download.
+the local-first short-circuit and the transient-failure retry/backoff branching,
+not any Hugging Face download. The fakes branch on ``local_files_only`` to tell
+the cache-only attempt apart from the network attempts.
 """
 
 import pytest
@@ -38,62 +40,91 @@ def test_hf_http_status_walks_cause_chain():
     assert _hf_http_status(OSError("no status here")) is None
 
 
+def test_load_uses_local_cache_without_network(monkeypatch):
+    """A cached model loads via the local-first attempt, with no network."""
+    monkeypatch.setattr(
+        exp_mod.time, "sleep", lambda s: pytest.fail("should not sleep")
+    )
+    sentinel = object()
+    calls = {"local": 0, "net": 0}
+
+    def fake_load(**kwargs):
+        if kwargs.get("local_files_only"):
+            calls["local"] += 1
+            return sentinel  # cache hit
+        calls["net"] += 1
+        pytest.fail("network load must not run when the model is cached")
+
+    monkeypatch.setattr(exp_mod, "_load_exporter_from", fake_load)
+    out = LLMExporter.load("dummy/slug")
+    assert out is sentinel
+    assert calls == {"local": 1, "net": 0}
+
+
 def test_load_retries_transient_then_succeeds(monkeypatch):
     sleeps: list = []
     monkeypatch.setattr(exp_mod.time, "sleep", lambda s: sleeps.append(s))
-    calls = {"n": 0}
+    net = {"n": 0}
     sentinel = object()
 
     def fake_load(**kwargs):
-        calls["n"] += 1
-        if calls["n"] < 3:
+        if kwargs.get("local_files_only"):
+            raise FileNotFoundError("not cached")  # local-first miss
+        net["n"] += 1
+        if net["n"] < 3:
             raise _oserror_wrapping_status(429)
         return sentinel
 
     monkeypatch.setattr(exp_mod, "_load_exporter_from", fake_load)
     out = LLMExporter.load("dummy/slug", hf_download_n_retries=5)
     assert out is sentinel
-    assert calls["n"] == 3
+    assert net["n"] == 3  # network: 2 failures + 1 success
     assert len(sleeps) == 2  # two retries before the success
 
 
 def test_load_gives_up_after_n_retries(monkeypatch):
     monkeypatch.setattr(exp_mod.time, "sleep", lambda s: None)
-    calls = {"n": 0}
+    net = {"n": 0}
 
     def fake_load(**kwargs):
-        calls["n"] += 1
+        if kwargs.get("local_files_only"):
+            raise FileNotFoundError("not cached")
+        net["n"] += 1
         raise _oserror_wrapping_status(429)
 
     monkeypatch.setattr(exp_mod, "_load_exporter_from", fake_load)
     with pytest.raises(T2NErrorRuntime):
         LLMExporter.load("dummy/slug", hf_download_n_retries=2)
-    assert calls["n"] == 3  # initial attempt + 2 retries
+    assert net["n"] == 3  # network: initial attempt + 2 retries
 
 
 def test_load_does_not_retry_permanent_error(monkeypatch):
     monkeypatch.setattr(exp_mod.time, "sleep", lambda s: None)
-    calls = {"n": 0}
+    net = {"n": 0}
 
     def fake_load(**kwargs):
-        calls["n"] += 1
+        if kwargs.get("local_files_only"):
+            raise FileNotFoundError("not cached")
+        net["n"] += 1
         raise _oserror_wrapping_status(404)
 
     monkeypatch.setattr(exp_mod, "_load_exporter_from", fake_load)
     with pytest.raises(T2NErrorRuntime):
         LLMExporter.load("dummy/slug", hf_download_n_retries=5)
-    assert calls["n"] == 1  # 404 is not retried
+    assert net["n"] == 1  # 404 is not retried
 
 
 def test_load_disabled_when_zero_retries(monkeypatch):
     monkeypatch.setattr(exp_mod.time, "sleep", lambda s: None)
-    calls = {"n": 0}
+    net = {"n": 0}
 
     def fake_load(**kwargs):
-        calls["n"] += 1
+        if kwargs.get("local_files_only"):
+            raise FileNotFoundError("not cached")
+        net["n"] += 1
         raise _oserror_wrapping_status(429)
 
     monkeypatch.setattr(exp_mod, "_load_exporter_from", fake_load)
     with pytest.raises(T2NErrorRuntime):
         LLMExporter.load("dummy/slug", hf_download_n_retries=0)
-    assert calls["n"] == 1  # no retries when disabled
+    assert net["n"] == 1  # no retries when disabled

--- a/packages/llm/tests/test_load_retry.py
+++ b/packages/llm/tests/test_load_retry.py
@@ -1,9 +1,8 @@
-"""Unit tests for LLMExporter.load's local-first + retry behavior.
+"""Unit tests for the LLM loader's HF-rate-limit resilience.
 
-Network-free: `_load_exporter_from` is monkeypatched, so these exercise only
-the local-first short-circuit and the transient-failure retry/backoff branching,
-not any Hugging Face download. The fakes branch on ``local_files_only`` to tell
-the cache-only attempt apart from the network attempts.
+Network-free: the hub interactions are monkeypatched/faked, so these exercise
+only the retry/backoff branching in LLMExporter.load and the cache-first
+snapshot resolution used by the device_map path, not any real download.
 """
 
 import pytest
@@ -11,6 +10,7 @@ import pytest
 from torch_to_nnef.exceptions import T2NErrorRuntime
 from torch_to_nnef_llm import exporter as exp_mod
 from torch_to_nnef_llm.exporter import LLMExporter, _hf_http_status
+from torch_to_nnef_llm.loader import _resolve_snapshot_dir
 
 
 def _oserror_wrapping_status(status: int) -> OSError:
@@ -40,91 +40,88 @@ def test_hf_http_status_walks_cause_chain():
     assert _hf_http_status(OSError("no status here")) is None
 
 
-def test_load_uses_local_cache_without_network(monkeypatch):
-    """A cached model loads via the local-first attempt, with no network."""
-    monkeypatch.setattr(
-        exp_mod.time, "sleep", lambda s: pytest.fail("should not sleep")
-    )
-    sentinel = object()
-    calls = {"local": 0, "net": 0}
+class _FakeHub:
+    """snapshot_download that records calls and can simulate a cache miss."""
 
-    def fake_load(**kwargs):
-        if kwargs.get("local_files_only"):
-            calls["local"] += 1
-            return sentinel  # cache hit
-        calls["net"] += 1
-        pytest.fail("network load must not run when the model is cached")
+    def __init__(self, cached: bool):
+        self.cached = cached
+        self.calls: list = []
 
-    monkeypatch.setattr(exp_mod, "_load_exporter_from", fake_load)
-    out = LLMExporter.load("dummy/slug")
-    assert out is sentinel
-    assert calls == {"local": 1, "net": 0}
+    def snapshot_download(self, slug, local_files_only=False):
+        self.calls.append(local_files_only)
+        if local_files_only and not self.cached:
+            raise FileNotFoundError("not cached")
+        return f"/cache/{slug}"
+
+
+def test_resolve_snapshot_cache_hit_makes_no_network_call():
+    hub = _FakeHub(cached=True)
+    assert _resolve_snapshot_dir("some/model", hub) == "/cache/some/model"
+    assert hub.calls == [True]  # only the cache-only attempt, no /tree call
+
+
+def test_resolve_snapshot_cache_miss_falls_back_to_network():
+    hub = _FakeHub(cached=False)
+    assert _resolve_snapshot_dir("some/model", hub) == "/cache/some/model"
+    assert hub.calls == [True, False]  # cache-only attempt then network
 
 
 def test_load_retries_transient_then_succeeds(monkeypatch):
     sleeps: list = []
     monkeypatch.setattr(exp_mod.time, "sleep", lambda s: sleeps.append(s))
-    net = {"n": 0}
+    calls = {"n": 0}
     sentinel = object()
 
     def fake_load(**kwargs):
-        if kwargs.get("local_files_only"):
-            raise FileNotFoundError("not cached")  # local-first miss
-        net["n"] += 1
-        if net["n"] < 3:
+        calls["n"] += 1
+        if calls["n"] < 3:
             raise _oserror_wrapping_status(429)
         return sentinel
 
     monkeypatch.setattr(exp_mod, "_load_exporter_from", fake_load)
     out = LLMExporter.load("dummy/slug", hf_download_n_retries=5)
     assert out is sentinel
-    assert net["n"] == 3  # network: 2 failures + 1 success
+    assert calls["n"] == 3
     assert len(sleeps) == 2  # two retries before the success
 
 
 def test_load_gives_up_after_n_retries(monkeypatch):
     monkeypatch.setattr(exp_mod.time, "sleep", lambda s: None)
-    net = {"n": 0}
+    calls = {"n": 0}
 
     def fake_load(**kwargs):
-        if kwargs.get("local_files_only"):
-            raise FileNotFoundError("not cached")
-        net["n"] += 1
+        calls["n"] += 1
         raise _oserror_wrapping_status(429)
 
     monkeypatch.setattr(exp_mod, "_load_exporter_from", fake_load)
     with pytest.raises(T2NErrorRuntime):
         LLMExporter.load("dummy/slug", hf_download_n_retries=2)
-    assert net["n"] == 3  # network: initial attempt + 2 retries
+    assert calls["n"] == 3  # initial attempt + 2 retries
 
 
 def test_load_does_not_retry_permanent_error(monkeypatch):
     monkeypatch.setattr(exp_mod.time, "sleep", lambda s: None)
-    net = {"n": 0}
+    calls = {"n": 0}
 
     def fake_load(**kwargs):
-        if kwargs.get("local_files_only"):
-            raise FileNotFoundError("not cached")
-        net["n"] += 1
+        calls["n"] += 1
         raise _oserror_wrapping_status(404)
 
     monkeypatch.setattr(exp_mod, "_load_exporter_from", fake_load)
     with pytest.raises(T2NErrorRuntime):
         LLMExporter.load("dummy/slug", hf_download_n_retries=5)
-    assert net["n"] == 1  # 404 is not retried
+    assert calls["n"] == 1  # 404 is not retried
 
 
 def test_load_disabled_when_zero_retries(monkeypatch):
     monkeypatch.setattr(exp_mod.time, "sleep", lambda s: None)
-    net = {"n": 0}
+    calls = {"n": 0}
 
     def fake_load(**kwargs):
-        if kwargs.get("local_files_only"):
-            raise FileNotFoundError("not cached")
-        net["n"] += 1
+        calls["n"] += 1
         raise _oserror_wrapping_status(429)
 
     monkeypatch.setattr(exp_mod, "_load_exporter_from", fake_load)
     with pytest.raises(T2NErrorRuntime):
         LLMExporter.load("dummy/slug", hf_download_n_retries=0)
-    assert net["n"] == 1  # no retries when disabled
+    assert calls["n"] == 1  # no retries when disabled

--- a/packages/llm/tests/test_load_retry.py
+++ b/packages/llm/tests/test_load_retry.py
@@ -25,13 +25,9 @@ def _oserror_wrapping_status(status: int) -> OSError:
 
     inner = Exception("http error")
     inner.response = _Resp()  # type: ignore[attr-defined]
-    try:
-        try:
-            raise inner
-        except Exception as e:
-            raise OSError("We couldn't connect to huggingface.co") from e
-    except OSError as oserr:
-        return oserr
+    outer = OSError("We couldn't connect to huggingface.co")
+    outer.__cause__ = inner  # same chain as `raise outer from inner`
+    return outer
 
 
 def test_hf_http_status_walks_cause_chain():

--- a/packages/llm/torch_to_nnef_llm/cli.py
+++ b/packages/llm/torch_to_nnef_llm/cli.py
@@ -21,7 +21,7 @@ from torch_to_nnef_llm.config import (
     OpenELMSlugs,
     PHISlugs,
 )
-from torch_to_nnef_llm.exporter import dump_llm
+from torch_to_nnef_llm.exporter import DEFAULT_HF_DOWNLOAD_N_RETRIES, dump_llm
 
 LOGGER = logging.getLogger(__name__)
 
@@ -147,6 +147,15 @@ def parser_cli(  # pylint: disable=too-many-positional-arguments
             "(if 0 all are kept) "
             "by default for classical inference setting it to 1 is fine, "
             "in case of speculative-decoding it may be more (typically 2 or 3)",
+        )
+
+        parser.add_argument(
+            "--hf-download-n-retries",
+            type=int,
+            default=DEFAULT_HF_DOWNLOAD_N_RETRIES,
+            help="number of retries (exponential backoff) on transient "
+            "Hugging Face download failures (HTTP 429 rate limit / 5xx); "
+            "set 0 to disable",
         )
 
         parser.add_argument(

--- a/packages/llm/torch_to_nnef_llm/exporter.py
+++ b/packages/llm/torch_to_nnef_llm/exporter.py
@@ -150,7 +150,6 @@ def _load_exporter_from(
     num_logits_to_keep: int = 1,
     merge_peft: T.Optional[bool] = None,
     device_map: TYPE_OPTIONAL_DEVICE_MAP = None,
-    local_files_only: bool = False,
 ):
     if (
         is_forced_half_precision_model(force_inputs_dtype, force_module_dtype)
@@ -168,13 +167,11 @@ def _load_exporter_from(
         force_module_dtype=force_module_dtype,
         merge_peft=merge_peft,
         device_map=device_map,
-        local_files_only=local_files_only,
     )
     tokenizer = load_tokenizer(
         hf_model_causal.config,
         hf_model_slug=hf_model_slug,
         local_dir=local_dir,
-        local_files_only=local_files_only,
     )
 
     return LLMExporter(
@@ -391,10 +388,6 @@ class LLMExporter:
         Face failure (HTTP 429 rate limit or a 5xx) is retried with exponential
         backoff before giving up; set 0 to disable. Auth/missing errors are not
         retried, and a gated repo still triggers an interactive login.
-
-        The model is loaded local-first: an already-cached model is loaded
-        without any hub network call (immune to rate limiting); only a cache
-        miss falls back to a network download (which is then retried).
         """
         with torch.no_grad():
             exporter_from_kwargs: T.Dict[str, T.Any] = {
@@ -402,19 +395,6 @@ class LLMExporter:
                 "local_dir": local_dir,
                 **kwargs,
             }
-            try:
-                return _load_exporter_from(
-                    **exporter_from_kwargs, local_files_only=True
-                )
-            # any local-load failure (cache miss, etc.) -> try the network;
-            # a genuine error resurfaces on that path.
-            # pylint: disable-next=broad-exception-caught
-            except Exception as exp:
-                LOGGER.info(
-                    "Local cache miss or load failure (%s); "
-                    "fetching from the Hugging Face hub",
-                    type(exp).__name__,
-                )
             attempt = 0
             while True:
                 try:

--- a/packages/llm/torch_to_nnef_llm/exporter.py
+++ b/packages/llm/torch_to_nnef_llm/exporter.py
@@ -406,7 +406,10 @@ class LLMExporter:
                 return _load_exporter_from(
                     **exporter_from_kwargs, local_files_only=True
                 )
-            except Exception as exp:  # noqa: BLE001 cache miss -> network load
+            # any local-load failure (cache miss, etc.) -> try the network;
+            # a genuine error resurfaces on that path.
+            # pylint: disable-next=broad-exception-caught
+            except Exception as exp:
                 LOGGER.info(
                     "Local cache miss or load failure (%s); "
                     "fetching from the Hugging Face hub",

--- a/packages/llm/torch_to_nnef_llm/exporter.py
+++ b/packages/llm/torch_to_nnef_llm/exporter.py
@@ -150,6 +150,7 @@ def _load_exporter_from(
     num_logits_to_keep: int = 1,
     merge_peft: T.Optional[bool] = None,
     device_map: TYPE_OPTIONAL_DEVICE_MAP = None,
+    local_files_only: bool = False,
 ):
     if (
         is_forced_half_precision_model(force_inputs_dtype, force_module_dtype)
@@ -167,11 +168,13 @@ def _load_exporter_from(
         force_module_dtype=force_module_dtype,
         merge_peft=merge_peft,
         device_map=device_map,
+        local_files_only=local_files_only,
     )
     tokenizer = load_tokenizer(
         hf_model_causal.config,
         hf_model_slug=hf_model_slug,
         local_dir=local_dir,
+        local_files_only=local_files_only,
     )
 
     return LLMExporter(
@@ -388,6 +391,10 @@ class LLMExporter:
         Face failure (HTTP 429 rate limit or a 5xx) is retried with exponential
         backoff before giving up; set 0 to disable. Auth/missing errors are not
         retried, and a gated repo still triggers an interactive login.
+
+        The model is loaded local-first: an already-cached model is loaded
+        without any hub network call (immune to rate limiting); only a cache
+        miss falls back to a network download (which is then retried).
         """
         with torch.no_grad():
             exporter_from_kwargs: T.Dict[str, T.Any] = {
@@ -395,6 +402,16 @@ class LLMExporter:
                 "local_dir": local_dir,
                 **kwargs,
             }
+            try:
+                return _load_exporter_from(
+                    **exporter_from_kwargs, local_files_only=True
+                )
+            except Exception as exp:  # noqa: BLE001 cache miss -> network load
+                LOGGER.info(
+                    "Local cache miss or load failure (%s); "
+                    "fetching from the Hugging Face hub",
+                    type(exp).__name__,
+                )
             attempt = 0
             while True:
                 try:

--- a/packages/llm/torch_to_nnef_llm/exporter.py
+++ b/packages/llm/torch_to_nnef_llm/exporter.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import time
 import typing as T
 from collections import Counter
 from pathlib import Path
@@ -113,6 +114,32 @@ def _normalize_dump_kwargs(kwargs: T.Dict[str, T.Any]) -> T.Dict[str, T.Any]:
             dump_kwargs["tract_check_io_tolerance"]
         )
     return dump_kwargs
+
+
+#: Default number of retries for transient Hugging Face download failures.
+DEFAULT_HF_DOWNLOAD_N_RETRIES = 5
+
+#: HTTP statuses worth retrying: rate limit + transient server errors. Auth or
+#: missing (401/403/404) never recover on retry and are left to fail.
+_TRANSIENT_HF_HTTP = frozenset({429, 500, 502, 503, 504})
+
+
+def _hf_http_status(exc: BaseException) -> T.Optional[int]:
+    """Find an HTTP status anywhere in the exception's cause chain.
+
+    A rate-limited Hugging Face fetch surfaces here as an OSError whose cause
+    chain holds the real HfHubHTTPError, so the status we must branch on (e.g.
+    429) is not on the outermost exception.
+    """
+    seen: T.Set[int] = set()
+    cur: T.Optional[BaseException] = exc
+    while cur is not None and id(cur) not in seen:
+        seen.add(id(cur))
+        status = getattr(getattr(cur, "response", None), "status_code", None)
+        if status is not None:
+            return status
+        cur = cur.__cause__ or cur.__context__
+    return None
 
 
 def _load_exporter_from(
@@ -351,28 +378,53 @@ class LLMExporter:
         model_slug: T.Optional[str] = None,
         local_dir: T.Optional[Path] = None,
         *,
+        hf_download_n_retries: int = DEFAULT_HF_DOWNLOAD_N_RETRIES,
         huggingface_hub: InjectedHuggingFaceHubModule = INJECTED,
         **kwargs,
     ):
-        """Load from either huggingface model slug hub or local_dir."""
+        """Load from either huggingface model slug hub or local_dir.
+
+        ``hf_download_n_retries`` bounds how many times a *transient* Hugging
+        Face failure (HTTP 429 rate limit or a 5xx) is retried with exponential
+        backoff before giving up; set 0 to disable. Auth/missing errors are not
+        retried, and a gated repo still triggers an interactive login.
+        """
         with torch.no_grad():
             exporter_from_kwargs: T.Dict[str, T.Any] = {
                 "hf_model_slug": model_slug,
                 "local_dir": local_dir,
                 **kwargs,
             }
-            try:
-                exporter = _load_exporter_from(**exporter_from_kwargs)
-            except OSError as exp:
-                if "gated repo" in exp.args[0]:
-                    print(exp.args[0])
-                    huggingface_hub.login()
-                    exporter = _load_exporter_from(**exporter_from_kwargs)
-                else:
+            attempt = 0
+            while True:
+                try:
+                    return _load_exporter_from(**exporter_from_kwargs)
+                except OSError as exp:
+                    msg = exp.args[0] if exp.args else ""
+                    if isinstance(msg, str) and "gated repo" in msg:
+                        print(msg)
+                        huggingface_hub.login()
+                        return _load_exporter_from(**exporter_from_kwargs)
+                    status = _hf_http_status(exp)
+                    if (
+                        status in _TRANSIENT_HF_HTTP
+                        and attempt < hf_download_n_retries
+                    ):
+                        attempt += 1
+                        delay = min(2.0 * 2 ** (attempt - 1), 60.0)
+                        LOGGER.warning(
+                            "Hugging Face download failed with HTTP %s; "
+                            "retry %d/%d in %.0fs",
+                            status,
+                            attempt,
+                            hf_download_n_retries,
+                            delay,
+                        )
+                        time.sleep(delay)
+                        continue
                     raise T2NErrorRuntime(
                         "OSError while loading model"
                     ) from exp
-        return exporter
 
     def check_wrapper_io(self):
         """Check the wrapper gives same outputs compared to vanilla model."""
@@ -977,6 +1029,7 @@ def dump_llm(
     merge_peft: T.Optional[bool] = None,
     num_logits_to_keep: int = 1,
     device_map: TYPE_OPTIONAL_DEVICE_MAP = None,
+    hf_download_n_retries: int = DEFAULT_HF_DOWNLOAD_N_RETRIES,
     **kwargs,
 ) -> T.Tuple[T.Union[Path, None], LLMExporter]:
     """Util to export LLM model."""
@@ -988,6 +1041,7 @@ def dump_llm(
         merge_peft=merge_peft,
         num_logits_to_keep=num_logits_to_keep,
         device_map=device_map,
+        hf_download_n_retries=hf_download_n_retries,
     )
     dump_kwargs = _normalize_dump_kwargs(kwargs)
     exporter.dump(**dump_kwargs)

--- a/packages/llm/torch_to_nnef_llm/loader.py
+++ b/packages/llm/torch_to_nnef_llm/loader.py
@@ -69,6 +69,7 @@ def load_tokenizer(
     hf_model_slug: T.Optional[str] = None,
     local_dir: T.Optional[Path] = None,
     *,
+    local_files_only: bool = False,
     transformers: InjectedTransformersModule = INJECTED,
 ):
     os.environ["TOKENIZERS_PARALLELISM"] = "false"
@@ -80,7 +81,9 @@ def load_tokenizer(
     if local_dir is not None:
         local_dir = find_subdir_with_filename_in(local_dir, "tokenizer.json")
     return transformers.AutoTokenizer.from_pretrained(
-        local_dir or tokenizer_slug, trust_remote_code=True
+        local_dir or tokenizer_slug,
+        trust_remote_code=True,
+        local_files_only=local_files_only,
     )
 
 
@@ -171,14 +174,24 @@ def load_peft_model(
 def _from_pretrained(
     slug_or_dir: T.Union[str, Path],
     *,
+    local_files_only: bool = False,
     huggingface_hub: InjectedHuggingFaceHubModule = INJECTED,
     transformers: InjectedTransformersModule = INJECTED,
     **kwargs,
 ):
+    kwargs["local_files_only"] = local_files_only
     if "device_map" in kwargs and kwargs["device_map"] is not None:
         device_map = kwargs.pop("device_map")
         if Path(slug_or_dir).exists():
             weights_location = Path(slug_or_dir)
+        elif local_files_only:
+            # Resolve the already-cached snapshot directory without any hub API
+            # call (list_repo_files would hit the rate-limited /tree endpoint).
+            weights_location = Path(
+                huggingface_hub.snapshot_download(
+                    slug_or_dir, local_files_only=True
+                )
+            )
         else:
             hf_repo_files = huggingface_hub.list_repo_files(slug_or_dir)
             weights_location = Path(
@@ -229,6 +242,7 @@ def load_model(
     force_module_dtype: T.Optional[DtypeStr] = None,
     merge_peft: T.Optional[bool] = None,
     device_map: TYPE_OPTIONAL_DEVICE_MAP = None,
+    local_files_only: bool = False,
     *,
     transformers: InjectedTransformersModule = INJECTED,
 ):
@@ -264,7 +278,9 @@ def load_model(
             dir_path = find_subdir_with_filename_in(local_dir, "config.json")
             assert dir_path.is_dir(), dir_path
             assert_model_safetensors_exists(dir_path)
-            hf_model_causal = _from_pretrained(dir_path, **kwargs)
+            hf_model_causal = _from_pretrained(
+                dir_path, local_files_only=local_files_only, **kwargs
+            )
             LOGGER.info(
                 "load '%s' from local directory: %s",
                 hf_model_causal.config.model_type,
@@ -273,7 +289,9 @@ def load_model(
         except (T2NErrorNotFoundFile, OSError):
             hf_model_causal = load_peft_model(local_dir, kwargs)
     elif hf_model_slug is not None:
-        hf_model_causal = _from_pretrained(hf_model_slug, **kwargs)
+        hf_model_causal = _from_pretrained(
+            hf_model_slug, local_files_only=local_files_only, **kwargs
+        )
         LOGGER.info(
             "load default trained model from huggingface: '%s'", hf_model_slug
         )

--- a/packages/llm/torch_to_nnef_llm/loader.py
+++ b/packages/llm/torch_to_nnef_llm/loader.py
@@ -69,7 +69,6 @@ def load_tokenizer(
     hf_model_slug: T.Optional[str] = None,
     local_dir: T.Optional[Path] = None,
     *,
-    local_files_only: bool = False,
     transformers: InjectedTransformersModule = INJECTED,
 ):
     os.environ["TOKENIZERS_PARALLELISM"] = "false"
@@ -81,9 +80,7 @@ def load_tokenizer(
     if local_dir is not None:
         local_dir = find_subdir_with_filename_in(local_dir, "tokenizer.json")
     return transformers.AutoTokenizer.from_pretrained(
-        local_dir or tokenizer_slug,
-        trust_remote_code=True,
-        local_files_only=local_files_only,
+        local_dir or tokenizer_slug, trust_remote_code=True
     )
 
 
@@ -169,34 +166,39 @@ def load_peft_model(
         return hf_model_causal
 
 
+def _resolve_snapshot_dir(slug: str, huggingface_hub) -> str:
+    """Return the local snapshot dir for ``slug``, cache-first.
+
+    ``list_repo_files`` has no cache mode and hits the rate-limited ``/tree``
+    endpoint even for an already-cached model, so prefer ``snapshot_download``
+    with ``local_files_only=True`` (no hub call when cached) and fall back to a
+    networked ``snapshot_download`` only on a genuine cache miss (whose
+    transient failures the LLMExporter.load retry then covers).
+    """
+    try:
+        return huggingface_hub.snapshot_download(slug, local_files_only=True)
+    # pylint: disable-next=broad-exception-caught
+    except Exception:
+        return huggingface_hub.snapshot_download(slug)
+
+
 @require_extra_decorator(extra=T2NExtra.LLM_TRACT, module="huggingface_hub")
 @require_extra_decorator(extra=T2NExtra.LLM_TRACT, module="transformers")
 def _from_pretrained(
     slug_or_dir: T.Union[str, Path],
     *,
-    local_files_only: bool = False,
     huggingface_hub: InjectedHuggingFaceHubModule = INJECTED,
     transformers: InjectedTransformersModule = INJECTED,
     **kwargs,
 ):
-    kwargs["local_files_only"] = local_files_only
     if "device_map" in kwargs and kwargs["device_map"] is not None:
         device_map = kwargs.pop("device_map")
         if Path(slug_or_dir).exists():
             weights_location = Path(slug_or_dir)
-        elif local_files_only:
-            # Resolve the already-cached snapshot directory without any hub API
-            # call (list_repo_files would hit the rate-limited /tree endpoint).
-            weights_location = Path(
-                huggingface_hub.snapshot_download(
-                    slug_or_dir, local_files_only=True
-                )
-            )
         else:
-            hf_repo_files = huggingface_hub.list_repo_files(slug_or_dir)
             weights_location = Path(
-                huggingface_hub.hf_hub_download(slug_or_dir, hf_repo_files[-1])
-            ).parent
+                _resolve_snapshot_dir(str(slug_or_dir), huggingface_hub)
+            )
 
         with init_empty_weights():
             model = transformers.AutoModelForCausalLM.from_pretrained(
@@ -242,7 +244,6 @@ def load_model(
     force_module_dtype: T.Optional[DtypeStr] = None,
     merge_peft: T.Optional[bool] = None,
     device_map: TYPE_OPTIONAL_DEVICE_MAP = None,
-    local_files_only: bool = False,
     *,
     transformers: InjectedTransformersModule = INJECTED,
 ):
@@ -278,9 +279,7 @@ def load_model(
             dir_path = find_subdir_with_filename_in(local_dir, "config.json")
             assert dir_path.is_dir(), dir_path
             assert_model_safetensors_exists(dir_path)
-            hf_model_causal = _from_pretrained(
-                dir_path, local_files_only=local_files_only, **kwargs
-            )
+            hf_model_causal = _from_pretrained(dir_path, **kwargs)
             LOGGER.info(
                 "load '%s' from local directory: %s",
                 hf_model_causal.config.model_type,
@@ -289,9 +288,7 @@ def load_model(
         except (T2NErrorNotFoundFile, OSError):
             hf_model_causal = load_peft_model(local_dir, kwargs)
     elif hf_model_slug is not None:
-        hf_model_causal = _from_pretrained(
-            hf_model_slug, local_files_only=local_files_only, **kwargs
-        )
+        hf_model_causal = _from_pretrained(hf_model_slug, **kwargs)
         LOGGER.info(
             "load default trained model from huggingface: '%s'", hf_model_slug
         )

--- a/packages/llm/torch_to_nnef_llm/loader.py
+++ b/packages/llm/torch_to_nnef_llm/loader.py
@@ -175,10 +175,14 @@ def _resolve_snapshot_dir(slug: str, huggingface_hub) -> str:
     networked ``snapshot_download`` only on a genuine cache miss (whose
     transient failures the LLMExporter.load retry then covers).
     """
+    # local import: huggingface_hub is an optional extra (injected), so it is
+    # only importable inside this call path which requires it.
+    # pylint: disable-next=import-outside-toplevel
+    from huggingface_hub.errors import LocalEntryNotFoundError
+
     try:
         return huggingface_hub.snapshot_download(slug, local_files_only=True)
-    # pylint: disable-next=broad-exception-caught
-    except Exception:
+    except LocalEntryNotFoundError:
         return huggingface_hub.snapshot_download(slug)
 
 


### PR DESCRIPTION
Makes `LLMExporter.load` resilient to Hugging Face rate limiting (HTTP 429), in product code, so real users benefit, not just CI. Two parts, scoped to what we actually observed.

## 1. Fix the observed warm-cache 429 (device_map path)

The failure we hit in CI: `test_export_from_llmexporter[...,device_map=t2n_offload_disk]` 429'd on `GET /api/models/.../tree/main` **even though the model was already cached** (`[prefetch] ok`). Cause: the offload path in `_from_pretrained` calls `huggingface_hub.list_repo_files`, which has **no cache mode** and hits the rate-limited `/tree` endpoint every time, just to locate the cached weights directory.

Fix: resolve the snapshot directory **cache-first** via `_resolve_snapshot_dir` — `snapshot_download(..., local_files_only=True)` (no hub call when cached), falling back to a networked `snapshot_download` only on a genuine cache miss. This is scoped to the device_map path; the plain `from_pretrained` path is unchanged (it still revalidates against the hub, i.e. picks up upstream updates as before).

## 2. Retry transient failures on the genuine-download path

When a network download is actually needed, transient failures (HTTP 429 / 5xx) are retried with exponential backoff (capped 60s) up to `hf_download_n_retries` (default 5; 0 disables), exposed as CLI `--hf-download-n-retries`. The 429 reaches the exporter wrapped as an `OSError` whose `__cause__` chain holds the `HfHubHTTPError`, so `_hf_http_status` walks the chain. Auth/missing (401/403/404) are not retried; a gated repo still triggers the interactive login.

## Scope note (deliberately not broader)

An earlier draft made *all* loads cache-first. That changed behavior we never saw fail (the plain path revalidating) and would silently use a stale cache when `main` moved upstream. We narrowed it to the path that actually 429'd, plus the retry for genuine downloads.

## Tests

`tests/test_load_retry.py` (network-free): `_resolve_snapshot_dir` cache-hit makes no network call / cache-miss falls back; cause-chain status extraction; retry-then-succeed; give-up-after-N (`T2NErrorRuntime`); no-retry-on-404; disabled (0). Wired into the `cli_transformers_*` tox envs. All 7 pass locally; ruff + pylint clean.