### PR TITLE
ci: add zizmor GitHub Actions security gate + least-privilege workflow permissions

### DIFF
--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -21,12 +21,17 @@ on:
       - ".github/workflows/ci-core.yml"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   prepare:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Create matrix
         id: create_matrix
@@ -51,6 +56,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/ci-llm.yml
+++ b/.github/workflows/ci-llm.yml
@@ -17,12 +17,17 @@ on:
       - ".github/workflows/ci-llm.yml"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   prepare:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Create matrix
         id: create_matrix
@@ -45,6 +50,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/ci-nemo.yml
+++ b/.github/workflows/ci-nemo.yml
@@ -17,12 +17,17 @@ on:
       - ".github/workflows/ci-nemo.yml"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   prepare:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Create matrix
         id: create_matrix
@@ -45,6 +50,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/deps-check.yml
+++ b/.github/workflows/deps-check.yml
@@ -3,8 +3,9 @@ name: deps check
 # Gate for dependency-related changes (Dependabot PRs, manifest/lockfile edits)
 # that the path-filtered ci-*.yml suites would otherwise leave untested.
 # Deliberately lightweight: schema/consistency/pinning checks, no heavy builds.
-# Deep Rust auditing (cargo-deny: advisories/bans/sources/licenses) runs here.
-# Python CVE scanning + SPDX SBOM live in security-scan.yml.
+# Deep Rust auditing (cargo-deny: advisories/bans/sources/licenses) and GitHub
+# Actions auditing (zizmor) run here. Python CVE scanning + SPDX SBOM live in
+# security-scan.yml.
 on:
   pull_request:
     paths:
@@ -16,6 +17,7 @@ on:
       - ".github/dependabot.yml"
       - ".github/workflows/**"
       - ".github/scripts/**"
+      - ".github/zizmor.yml"
   workflow_dispatch:
 
 permissions:
@@ -27,6 +29,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
       - name: Validate .github/dependabot.yml
         run: uv run --no-project --with pyyaml python .github/scripts/check_dependabot.py
@@ -38,6 +42,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
       - name: Workspace lock up to date with pyproject
         run: uv lock --check
@@ -50,6 +56,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - name: cargo verify-project (all example crate roots)
         run: |
           set -euo pipefail
@@ -76,6 +84,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - name: Install cargo-deny
         run: |
           set -euo pipefail
@@ -113,3 +123,21 @@ jobs:
               check advisories bans sources licenses --config examples/deny.toml
             echo "::endgroup::"
           done
+
+  zizmor:
+    name: zizmor (GitHub Actions security audit)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+      # Fail on medium+ findings (excessive permissions, template injection,
+      # credential persistence, ...). Informational advisories (e.g.
+      # use-trusted-publishing) are surfaced but non-blocking. Offline: no GH
+      # token needed since actions are already SHA-pinned. Config in
+      # .github/zizmor.yml; version pinned for reproducibility.
+      - name: Run zizmor
+        run: |
+          uv tool run --from zizmor==1.25.2 zizmor \
+            --min-severity=medium --offline .github/workflows/

--- a/.github/workflows/doc-check.yml
+++ b/.github/workflows/doc-check.yml
@@ -27,6 +27,7 @@ jobs:
         with:
           # mike + git-revision-date plugins want history.
           fetch-depth: 0
+          persist-credentials: false
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.12"

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -35,6 +35,9 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
+          # `mike deploy --push` (below) pushes to gh-pages using this
+          # credential, so it must persist (see .github/zizmor.yml).
+          persist-credentials: true
 
       - name: Configure Git Credentials
         run: |

--- a/.github/workflows/examples-check.yml
+++ b/.github/workflows/examples-check.yml
@@ -21,6 +21,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Bash syntax check (bash -n)
         run: |

--- a/.github/workflows/examples-run.yml
+++ b/.github/workflows/examples-run.yml
@@ -51,6 +51,8 @@ jobs:
           - getting_started_rs
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.11"
@@ -103,6 +105,8 @@ jobs:
     continue-on-error: ${{ matrix.allow_failure || false }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.11"

--- a/.github/workflows/locked-workspace.yml
+++ b/.github/workflows/locked-workspace.yml
@@ -30,6 +30,8 @@ jobs:
       PYTHONWARNINGS: "ignore"
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
       - name: Cache uv
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,11 @@ on:
       - 'v*'
   workflow_dispatch:
 
+# Only the release job needs write, to create the GitHub release (PyPI upload
+# uses PYPI_TOKEN, not OIDC, so no id-token).
+permissions:
+  contents: write
+
 jobs:
   release:
     name: Create Release
@@ -21,6 +26,8 @@ jobs:
         shell: bash
 
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Get Changelog Entry
         id: changelog_reader

--- a/.github/workflows/rustc-freshness.yml
+++ b/.github/workflows/rustc-freshness.yml
@@ -28,6 +28,8 @@ jobs:
       TITLE: "Bump examples rust-toolchain to latest stable rustc"
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - name: Compare pinned toolchain to latest stable
         run: |
           set -euo pipefail

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -38,6 +38,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
       - name: Install Trivy
         run: |

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,12 @@
+# zizmor configuration (https://docs.zizmor.sh/configuration/).
+#
+# The CI gate (deps-check.yml) runs `zizmor --min-severity=medium`, so
+# informational advisories (e.g. use-trusted-publishing on release.yml, which
+# needs a PyPI trusted-publisher set up first) are surfaced but non-blocking.
+rules:
+  artipacked:
+    ignore:
+      # doc.yml's checkout credential is required: `mike deploy --push` pushes
+      # the built docs to the gh-pages branch with it. persist-credentials is
+      # set true explicitly there.
+      - doc.yml


### PR DESCRIPTION
Adds [zizmor](https://docs.zizmor.sh/) (GitHub Actions static security auditor) as a CI gate and fixes everything it flagged at medium severity, hardening every workflow to least privilege.

## What zizmor found and this PR fixes (29 medium findings → 0)

- **excessive-permissions (10):** `ci-core`, `ci-llm`, `ci-nemo` and `release` had **no `permissions:` block**, so they inherited the repo's broad default `GITHUB_TOKEN`. Added explicit least-privilege blocks: `contents: read` for the three test workflows, `contents: write` for `release` (it creates the GitHub release; PyPI upload uses `PYPI_TOKEN`, not OIDC, so no `id-token`).
- **artipacked (19):** every `actions/checkout` persisted its credential into `.git/config` (exfiltration risk if the workspace is ever uploaded as an artifact). Added `persist-credentials: false` everywhere it's safe.
  - **Exception:** `doc.yml` keeps the credential (set `true` explicitly) because `mike deploy --push` pushes the built docs to `gh-pages` with it; documented and ignored via `.github/zizmor.yml`.

## The gate

A `zizmor` job in `deps-check.yml` runs `zizmor --min-severity=medium --offline .github/workflows/` (version-pinned to 1.25.2). It fails on medium+ findings (excessive permissions, template injection, credential persistence, ...). Offline because our actions are already SHA-pinned, so no GH token is needed. Informational advisories stay visible but non-blocking.

## Remaining (informational, non-blocking)

- `use-trusted-publishing` (×3) on `release.yml`: switching PyPI auth from `PYPI_TOKEN` to OIDC trusted publishing would drop a long-lived secret, but it requires configuring a trusted publisher on PyPI first (account-side). Tracked as a follow-up.
- `superfluous-actions` (×1): `softprops/action-gh-release` could be `gh release` in a script step. Minor; left as-is.

## Validation

`zizmor --min-severity=medium` reports "No findings to report" (exit 0) locally; all workflow YAML parses; the existing SHA-pin check still passes.