### PR TITLE
ci: add TruffleHog secret scanning

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,0 +1,31 @@
+name: secret scan
+
+# TruffleHog scans for committed secrets: the PR diff on every pull request, and
+# the full git history on the weekly run (so a secret committed then "removed"
+# is still caught). `--only-verified` confirms each candidate is a *live* secret
+# with its provider, so the gate fails on real leaks, not high-entropy noise.
+#
+# This is defense-in-depth, not a substitute for GitHub's native secret scanning
+# + push protection (which should be enabled in Settings -> Security to block a
+# secret at push time, before it ever lands).
+on:
+  pull_request:
+  schedule:
+    - cron: "0 3 * * 1" # Mondays 03:00 UTC, full-history sweep
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  trufflehog:
+    name: trufflehog secret scan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0 # full history; required for the diff/history scan
+          persist-credentials: false
+      - uses: trufflesecurity/trufflehog@d411fff7b8879a62509f3fa98c07f247ac089a51 # v3.95.5
+        with:
+          extra_args: --only-verified


### PR DESCRIPTION
Adds committed-secret scanning, the missing layer alongside dependency (cargo-deny/Trivy) and workflow (zizmor) auditing.

## What

New `secret-scan.yml` runs [TruffleHog](https://github.com/trufflesecurity/trufflehog):
- on every **pull request** (scans the diff), and
- **weekly** + on demand (scans the **full git history**, so a secret committed and later "removed" is still caught).

`--only-verified` makes TruffleHog confirm each candidate is a **live** secret with its provider before reporting, so the gate fails on real leaks rather than high-entropy noise (safe to block on).

## Notes

- This is **defense-in-depth, not a replacement** for GitHub's native **Secret scanning + Push protection** (Settings -> Security), which blocks a secret at `git push` time before it ever lands. Recommend enabling that too.
- Our existing `PYPI_TOKEN` is an encrypted Actions secret (not in the repo), so it isn't flagged — TruffleHog catches *accidental commits*, which is the actual risk.
- Least-privilege (`contents: read`), `persist-credentials: false`, SHA-pinned action — passes the zizmor gate and the SHA-pin check.