### PR TITLE
chore: add CODEOWNERS for security-critical config

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,14 @@
+# Code owners for security-critical configuration.
+#
+# Changes to these paths require review from a code owner. This only becomes a
+# hard gate once "Require review from Code Owners" is enabled in branch
+# protection; repo admins bypass it (per repo policy), which also means the sole
+# owner is never blocked on their own PRs.
+#
+# Scope is deliberately narrow: only the machinery that protects everything else
+# (CI workflows + the gate configs). Regular code under torch_to_nnef/ and
+# packages/ uses normal review.
+
+/.github/             @JulienBalianSonos
+/examples/deny.toml   @JulienBalianSonos
+/SECURITY.md          @JulienBalianSonos


### PR DESCRIPTION
Adds `.github/CODEOWNERS` so changes to the **security machinery** require a code owner's review, scoped narrowly.

## Scope (deliberately narrow)

Only the configs that protect everything else:
- `/.github/` — CI workflows + the gate configs (zizmor, dependabot, ...)
- `/examples/deny.toml` — the cargo-deny policy
- `/SECURITY.md`

Regular code (`torch_to_nnef/`, `packages/`) keeps normal review — this isn't meant to gate everyday contributions, only to stop the security controls from being weakened without owner sign-off.

## How it behaves

- **External contributors / read-only collaborators** can still open PRs touching these paths; they just can't *merge* (no write access), and a code owner must approve. Fork PRs already run with no secrets + need maintainer approval to run CI, so this is the merge-time layer on top.
- **It only becomes a hard gate** once "Require review from Code Owners" is enabled in branch protection (separate settings step).
- With `enforce_admins: false` (repo policy), **admins bypass** — so the sole owner is never deadlocked on their own PRs.

Owner is `@JulienBalianSonos`; add more handles/a team anytime.