### PR TITLE
ci: run security gates on every PR (so they can be required checks)

### DIFF
--- a/.github/workflows/deps-check.yml
+++ b/.github/workflows/deps-check.yml
@@ -7,17 +7,10 @@ name: deps check
 # Actions auditing (zizmor) run here. Python CVE scanning + SPDX SBOM live in
 # security-scan.yml.
 on:
+  # Runs on every PR (no path filter) so its jobs can be required status checks
+  # without freezing PRs that happen not to touch dependency files. The jobs are
+  # cheap and no-op cleanly when nothing relevant changed.
   pull_request:
-    paths:
-      - "**/uv.lock"
-      - "**/requirements*.txt"
-      - "**/Cargo.toml"
-      - "**/Cargo.lock"
-      - "**/deny.toml"
-      - ".github/dependabot.yml"
-      - ".github/workflows/**"
-      - ".github/scripts/**"
-      - ".github/zizmor.yml"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -18,13 +18,9 @@ name: security scan
 # otherwise changed. Acknowledged/unfixable findings go in `.trivyignore` (read
 # automatically) with a rationale, the same audit-trail pattern as cargo-deny.
 on:
+  # Runs on every PR (no path filter) so the CVE gate can be a required status
+  # check without freezing PRs that don't touch dependency files.
   pull_request:
-    paths:
-      - "**/uv.lock"
-      - "**/pyproject.toml"
-      - "**/requirements*.txt"
-      - ".trivyignore"
-      - ".github/workflows/security-scan.yml"
   schedule:
     - cron: "0 6 * * 1" # Mondays 06:00 UTC
   workflow_dispatch:


### PR DESCRIPTION
Prep for making the security gates **required status checks**. Right now they're path-filtered, which would freeze any PR that doesn't touch the filtered paths if marked required (a required check that never runs stays "pending" forever). This drops the path filters on the two security workflows so they run on **every** PR and can be safely required.

## Change

- `deps-check.yml` (dependabot-config + action-pinning + uv-lock + cargo verify + **cargo-deny** + **zizmor**) and `security-scan.yml` (**Trivy** CVE gate + SBOM) now trigger on every `pull_request` instead of a path subset.
- `secret-scan.yml` (TruffleHog, #166) already runs on every PR.

## Trade-off

Each PR now also runs these gate jobs even when it doesn't touch deps (e.g. a docs PR). They're the *cheap* jobs (seconds to a couple of minutes), not the test matrices — those stay path-filtered and unaffected. For a security-focused repo this is the right trade: the gates are only meaningful if they run.

## Next (settings, after this + #166 merge)

Mark these contexts as **required status checks** on `main` (keeps `enforce_admins: false` so admins still merge without review):
`dependabot config + action pinning`, `uv lockfiles consistent`, `example Cargo manifests valid`, `cargo-deny (advisories/bans/sources/licenses)`, `zizmor (GitHub Actions security audit)`, `trivy CVE gate + SPDX SBOM`, `trufflehog secret scan`.