### PR TITLE
ci: add CodeQL (SAST) for the Python source

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,35 @@
+name: codeql
+
+# Static analysis (SAST) of the first-party Python code. Complements the
+# dependency / workflow / secret auditing (cargo-deny, Trivy, zizmor,
+# TruffleHog), none of which look at the code we actually write. Free for public
+# repos; findings land in the Security -> Code scanning tab (advisory, not a
+# merge gate).
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "0 4 * * 1" # Mondays 04:00 UTC, re-scan with updated queries
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: codeql analyze (python)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write # upload results to code scanning
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - uses: github/codeql-action/init@c35d1b164463ee62a100735382aaaa525c5d3496 # codeql-bundle-v2.25.6
+        with:
+          languages: python
+          queries: security-extended
+      - uses: github/codeql-action/analyze@c35d1b164463ee62a100735382aaaa525c5d3496 # codeql-bundle-v2.25.6


### PR DESCRIPTION
Adds the missing layer: static analysis of **our own code**. Until now we audit dependencies (cargo-deny, Trivy), workflows (zizmor), and secrets (TruffleHog), but nothing reads the first-party source.

## What

`.github/workflows/codeql.yml` runs CodeQL on the Python code (`torch_to_nnef/` + `packages/`) on PRs, pushes to main, and weekly. `queries: security-extended` for a broader security query set. Findings appear in **Security → Code scanning**.

- **Free** for this public repo (no GitHub Advanced Security needed).
- **Advisory, not a merge gate** for now: it surfaces findings without blocking, so we can triage real-vs-noise first. Can be promoted to a required check later if desired.
- **Zero ongoing toil:** runs itself, alerts land in the Security tab, no SLA.
- Least-privilege (`security-events: write` only where needed), `persist-credentials: false`, SHA-pinned, passes the zizmor gate.

Python only: the shipped product is Python; the Rust is example crates (covered separately by clippy/cargo-deny).