### PR TITLE
feat(llm): make trust_remote_code controllable + warned (P0 trust boundary)

### DIFF
--- a/packages/llm/tests/test_load_retry.py
+++ b/packages/llm/tests/test_load_retry.py
@@ -134,3 +134,17 @@ def test_load_disabled_when_zero_retries(monkeypatch):
     with pytest.raises(T2NErrorRuntime):
         LLMExporter.load("dummy/slug", hf_download_n_retries=0)
     assert calls["n"] == 1  # no retries when disabled
+
+
+@pytest.mark.parametrize("trust", [True, False])
+def test_load_forwards_trust_remote_code(monkeypatch, trust):
+    """LLMExporter.load threads trust_remote_code down to the loader."""
+    captured: dict = {}
+
+    def fake(**kwargs):
+        captured.update(kwargs)
+        return object()
+
+    monkeypatch.setattr(exp_mod, "_load_exporter_from", fake)
+    LLMExporter.load("dummy/slug", trust_remote_code=trust)
+    assert captured["trust_remote_code"] is trust

--- a/packages/llm/torch_to_nnef_llm/cli.py
+++ b/packages/llm/torch_to_nnef_llm/cli.py
@@ -159,6 +159,17 @@ def parser_cli(  # pylint: disable=too-many-positional-arguments
         )
 
         parser.add_argument(
+            "--trust-remote-code",
+            action=argparse.BooleanOptionalAction,
+            default=True,
+            help="forward trust_remote_code to transformers. When enabled "
+            "(default, required by models whose architecture ships custom "
+            "code on the Hub), loading a model EXECUTES ARBITRARY CODE from "
+            "its repository. Pass --no-trust-remote-code to refuse it "
+            "(standard architectures load fine without it).",
+        )
+
+        parser.add_argument(
             "--device-map",
             help="**device_map** as in huggingface library 'accelerate'."
             " This allow to place different parts of a model, "

--- a/packages/llm/torch_to_nnef_llm/config.py
+++ b/packages/llm/torch_to_nnef_llm/config.py
@@ -140,13 +140,15 @@ def register_raw_model_from_slug(model_id, trust_remote_code: bool = True):
     return new_model_id
 
 
-def get_tokenizer_from_slug(mdl_slug):
+def get_tokenizer_from_slug(mdl_slug, trust_remote_code: bool = True):
     tok_slug = mdl_slug
     if mdl_slug in CUSTOM_CONFIGS:
         tok_slug = REMAP_MODEL_TYPE_TO_TOKENIZER_SLUG.get(
             CUSTOM_CONFIGS[mdl_slug].model_type, mdl_slug
         )
-    return AutoTokenizer.from_pretrained(tok_slug, trust_remote_code=True)
+    return AutoTokenizer.from_pretrained(
+        tok_slug, trust_remote_code=trust_remote_code
+    )
 
 
 class HFConfigHelper:

--- a/packages/llm/torch_to_nnef_llm/exporter.py
+++ b/packages/llm/torch_to_nnef_llm/exporter.py
@@ -150,6 +150,7 @@ def _load_exporter_from(
     num_logits_to_keep: int = 1,
     merge_peft: T.Optional[bool] = None,
     device_map: TYPE_OPTIONAL_DEVICE_MAP = None,
+    trust_remote_code: bool = True,
 ):
     if (
         is_forced_half_precision_model(force_inputs_dtype, force_module_dtype)
@@ -167,11 +168,13 @@ def _load_exporter_from(
         force_module_dtype=force_module_dtype,
         merge_peft=merge_peft,
         device_map=device_map,
+        trust_remote_code=trust_remote_code,
     )
     tokenizer = load_tokenizer(
         hf_model_causal.config,
         hf_model_slug=hf_model_slug,
         local_dir=local_dir,
+        trust_remote_code=trust_remote_code,
     )
 
     return LLMExporter(
@@ -1030,6 +1033,7 @@ def dump_llm(
     num_logits_to_keep: int = 1,
     device_map: TYPE_OPTIONAL_DEVICE_MAP = None,
     hf_download_n_retries: int = DEFAULT_HF_DOWNLOAD_N_RETRIES,
+    trust_remote_code: bool = True,
     **kwargs,
 ) -> T.Tuple[T.Union[Path, None], LLMExporter]:
     """Util to export LLM model."""
@@ -1042,6 +1046,7 @@ def dump_llm(
         num_logits_to_keep=num_logits_to_keep,
         device_map=device_map,
         hf_download_n_retries=hf_download_n_retries,
+        trust_remote_code=trust_remote_code,
     )
     dump_kwargs = _normalize_dump_kwargs(kwargs)
     exporter.dump(**dump_kwargs)

--- a/packages/llm/torch_to_nnef_llm/loader.py
+++ b/packages/llm/torch_to_nnef_llm/loader.py
@@ -69,6 +69,7 @@ def load_tokenizer(
     hf_model_slug: T.Optional[str] = None,
     local_dir: T.Optional[Path] = None,
     *,
+    trust_remote_code: bool = True,
     transformers: InjectedTransformersModule = INJECTED,
 ):
     os.environ["TOKENIZERS_PARALLELISM"] = "false"
@@ -80,7 +81,7 @@ def load_tokenizer(
     if local_dir is not None:
         local_dir = find_subdir_with_filename_in(local_dir, "tokenizer.json")
     return transformers.AutoTokenizer.from_pretrained(
-        local_dir or tokenizer_slug, trust_remote_code=True
+        local_dir or tokenizer_slug, trust_remote_code=trust_remote_code
     )
 
 
@@ -248,11 +249,26 @@ def load_model(
     force_module_dtype: T.Optional[DtypeStr] = None,
     merge_peft: T.Optional[bool] = None,
     device_map: TYPE_OPTIONAL_DEVICE_MAP = None,
+    trust_remote_code: bool = True,
     *,
     transformers: InjectedTransformersModule = INJECTED,
 ):
-    """Load a model from a slug, local checkpoint, or custom config."""
-    kwargs: T.Dict[str, T.Any] = {"trust_remote_code": True}
+    """Load a model from a slug, local checkpoint, or custom config.
+
+    ``trust_remote_code`` is forwarded to transformers. When True (the default,
+    needed by models whose architecture ships custom code on the Hub), loading
+    a model **executes arbitrary Python from its repository**: only export
+    models you trust, or pass ``trust_remote_code=False`` (CLI
+    ``--no-trust-remote-code``) to refuse it.
+    """
+    if trust_remote_code:
+        LOGGER.warning(
+            "trust_remote_code is enabled: loading '%s' may execute arbitrary "
+            "code from the model repository. Pass --no-trust-remote-code to "
+            "refuse it (standard architectures load fine without it).",
+            hf_model_slug or local_dir,
+        )
+    kwargs: T.Dict[str, T.Any] = {"trust_remote_code": trust_remote_code}
     # transformers 5.x defaults to a fused SDPA attention path that (a) passes
     # mixed-dtype q/k/v (bf16 query vs float key/value) which the SDPA kernel
     # rejects during the export forward, and (b) exports to the fused


### PR DESCRIPTION
First half of the P0 hardening: the LLM export path **executed arbitrary code from any model repo with no warning and no way to refuse it** (`trust_remote_code=True` was hardcoded in `load_model`, `load_tokenizer`, and `get_tokenizer_from_slug`). This makes that explicit, controllable, and documented.

## What

- `trust_remote_code` is now a parameter threaded all the way through: CLI `--trust-remote-code` / `--no-trust-remote-code` -> `dump_llm` -> `LLMExporter.load` -> `_load_exporter_from` -> `load_model` + `load_tokenizer` (+ `get_tokenizer_from_slug`).
- When enabled, `load_model` emits a **warning** that loading the model may execute arbitrary code from its repository, and how to refuse it.
- The CLI flag uses `argparse.BooleanOptionalAction`, so `--no-trust-remote-code` opts out.

## Default is unchanged (True), on purpose

Flipping the default to False would break exporting models whose architecture ships custom code on the Hub (a legitimate, common case for a model-conversion tool). So the default stays `True` (no behavior change), but it is now **visible** (warning), **controllable** (flag), and **documented**. Standard architectures (llama, mistral, qwen, ...) load fine with `--no-trust-remote-code`.

If you'd prefer **secure-by-default** (default False, with transformers' own clear "requires trust_remote_code" error pointing users to the flag), that's a one-line change on top — say the word. I kept it non-breaking by default since you review this.

## Tests

`test_load_forwards_trust_remote_code` (parametrized True/False) asserts the flag threads down to the loader. Full `test_load_retry.py` suite (10) green; ruff clean.

## Follow-up (P0 part 2)

The `torch.load` pickle-RCE surface is the other half. It's nuanced (some paths legitimately load full `nn.Module`s / custom `OpaqueTensor`s, so a blanket `weights_only=True` would break them), so it gets its own PR with a try-safe-then-fallback-with-warning approach. SECURITY.md already documents the overall "only export models you trust" boundary.