### PR TITLE
fix(core): torch.load weights_only-by-default (pickle-RCE hardening, P0 part 2)

### DIFF
--- a/tests/test_torch_safe_load.py
+++ b/tests/test_torch_safe_load.py
@@ -1,0 +1,28 @@
+"""Tests for torch_safe_load (weights_only-by-default torch.load)."""
+
+import torch
+
+from torch_to_nnef.utils import torch_safe_load
+
+
+def test_torch_safe_load_plain_tensor(tmp_path):
+    path = tmp_path / "tensor.pt"
+    torch.save(torch.tensor([1.0, 2.0, 3.0]), path)
+    out = torch_safe_load(path)
+    assert torch.equal(out, torch.tensor([1.0, 2.0, 3.0]))
+
+
+def test_torch_safe_load_state_dict(tmp_path):
+    path = tmp_path / "sd.pt"
+    torch.save(torch.nn.Linear(2, 2).state_dict(), path)
+    out = torch_safe_load(path)
+    assert set(out) == {"weight", "bias"}
+
+
+def test_torch_safe_load_falls_back_for_pickled_module(tmp_path):
+    # A full nn.Module is not loadable with weights_only=True, so the helper
+    # must fall back to full unpickling (and still return the module).
+    path = tmp_path / "module.pt"
+    torch.save(torch.nn.Linear(2, 2), path)
+    out = torch_safe_load(path)
+    assert isinstance(out, torch.nn.Linear)

--- a/torch_to_nnef/export.py
+++ b/torch_to_nnef/export.py
@@ -42,7 +42,12 @@ from torch_to_nnef.torch_graph.ir_naming import (
     DEFAULT_VARNAME_SCHEME,
     VariableNamingScheme,
 )
-from torch_to_nnef.utils import dedup_list, ensure_tuple_io, torch_version
+from torch_to_nnef.utils import (
+    dedup_list,
+    ensure_tuple_io,
+    torch_safe_load,
+    torch_version,
+)
 
 LOGGER = log.getLogger(__name__)
 
@@ -753,7 +758,7 @@ def iter_torch_tensors_from_disk(
     elif any(store_filepath.name.endswith(_) for _ in [".pt", ".pth", ".bin"]):
         # Always load tensors to the requested device (default CPU) to avoid
         # device-specific state and environments lacking CUDA.
-        res = torch.load(store_filepath, map_location=map_location)
+        res = torch_safe_load(store_filepath, map_location=map_location)
         if isinstance(res, torch.nn.Module):
             for key, tensor in res.named_parameters():
                 if filter_key(key):

--- a/torch_to_nnef/tensor/offload.py
+++ b/torch_to_nnef/tensor/offload.py
@@ -43,7 +43,11 @@ from torch.overrides import get_default_nowrap_functions
 from torch_to_nnef.exceptions import T2NErrorMisuse
 from torch_to_nnef.tensor.opaque import OpaqueTensor
 from torch_to_nnef.tensor.updater import ModTensorUpdater
-from torch_to_nnef.utils import select_ctx_disable_torch_fn, torch_version
+from torch_to_nnef.utils import (
+    select_ctx_disable_torch_fn,
+    torch_safe_load,
+    torch_version,
+)
 
 AUTO_DEVICE_MAP_KEY = "t2n_auto"
 ON_DISK_DEVICE_MAP_KEY = "t2n_offload_disk"
@@ -345,7 +349,7 @@ class OffloadedTensor(OpaqueTensor):
             return torch.load(self.offload_path, **load_kwargs).to(
                 self.target_device
             )
-        return torch.load(self.offload_path).to(self.target_device)
+        return torch_safe_load(self.offload_path).to(self.target_device)
 
     def _to_base_tensor(self) -> torch.Tensor:
         return self.reload()
@@ -505,7 +509,9 @@ def load_state_dict(
             dtype casting in memory directly)
     """
     if not checkpoint_file.name.endswith(".safetensors"):
-        return torch.load(checkpoint_file, map_location=torch.device("cpu"))
+        return torch_safe_load(
+            checkpoint_file, map_location=torch.device("cpu")
+        )
     # pylint: disable-next=import-outside-toplevel
     import safetensors
 

--- a/torch_to_nnef/utils.py
+++ b/torch_to_nnef/utils.py
@@ -4,6 +4,7 @@ import importlib
 import inspect
 import logging
 import os
+import pickle
 import re
 import typing as T
 from abc import ABC
@@ -484,6 +485,30 @@ class SemanticVersion:
 def torch_version() -> SemanticVersion:
     """Semantic version for torch."""
     return SemanticVersion.from_str(torch.__version__.split("+")[0])
+
+
+def torch_safe_load(f, **kwargs):
+    """``torch.load`` that avoids arbitrary code execution by default.
+
+    Prefers ``weights_only=True`` (loads tensors and primitives only). A file
+    that genuinely needs full unpickling (a pickled ``nn.Module`` or a custom
+    tensor subclass) falls back to ``weights_only=False`` with a warning, since
+    that path executes pickled code: only load files you trust. On torch < 1.13
+    (no ``weights_only`` support) it behaves like a plain ``torch.load``.
+    """
+    if torch_version() < "1.13.0":
+        return torch.load(f, **kwargs)
+    try:
+        return torch.load(f, weights_only=True, **kwargs)
+    except (pickle.UnpicklingError, RuntimeError) as exp:
+        LOGGER.warning(
+            "torch.load of %s requires full unpickling (weights_only=False), "
+            "which executes pickled code; only do this for files you trust "
+            "(%s)",
+            f,
+            type(exp).__name__,
+        )
+        return torch.load(f, weights_only=False, **kwargs)
 
 
 def select_ctx_disable_torch_fn():


### PR DESCRIPTION
Second half of the P0 trust-boundary work. `torch.load` is pickle-based: loading an untrusted checkpoint executes arbitrary code. Several call sites loaded files without `weights_only=True`, so this makes them safe-by-default while preserving the cases that genuinely need full unpickling.

## What

New helper `torch_to_nnef.utils.torch_safe_load`:
- prefers `weights_only=True` (tensors/primitives only, no code execution);
- falls back to `weights_only=False` **with a warning** only when the file genuinely needs it (a pickled `nn.Module`, a custom tensor subclass);
- on torch < 1.13 (no `weights_only` support) behaves like plain `torch.load`.

Applied at the checkpoint/tensor load sites:
- `export.py` (`_iter_tensors_from_store`, which may load a state_dict **or** a full module),
- `tensor/offload.py` reload of an offloaded tensor, and `load_checkpoint`.

Left intentionally untouched: `offload.py`'s `OffloadedTensor` reload, which **must** use `weights_only=False` (it round-trips a custom tensor subclass that t2n itself wrote). The fallback handles the rest.

## Why a helper, not a blanket flag flip

A blanket `weights_only=True` would break the legitimate full-module / custom-class loads. The try-safe-then-fallback pattern makes the common case (state_dicts, tensors) safe with zero behavior change, and only the genuine full-unpickle case warns. The exception catch is specific (`pickle.UnpicklingError`, `RuntimeError`), not a blind `except`.

## Tests

`tests/test_torch_safe_load.py`: plain tensor and state_dict load via the safe path; a pickled `nn.Module` triggers the fallback and still loads. Green; ruff clean. The existing offload / device_map / zoo suites exercise the real call sites.

Together with #171 (`trust_remote_code`), this closes the P0 "the tool executes untrusted code" gap from the security review.