### PR TITLE
docs: add live WASM demos landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ Export any PyTorch model to [NNEF](https://registry.khronos.org/NNEF/specs/1.0/n
 
 `torch_to_nnef` traces a vanilla `nn.Module` (any internal tensor type, quantized models included) and produces a portable NNEF archive. Unlike the protobuf used by ONNX, the NNEF graph is human-readable text with weights kept aside as separate files, so you can open it and review exactly which ops got serialized. [tract](https://github.com/sonos/tract/), the inference engine developed openly by [SONOS](https://sonos.com), is the primary supported target: it gets extended operator coverage and an optional `check_io` step that compares tract outputs against PyTorch at export time.
 
+> 🚀 **See it run:** [live browser demos](https://sonos.github.io/torch-to-nnef/latest/demos/) (image classifier, pose estimation, voice activity detection, LLM) exported with `torch_to_nnef` and running through tract compiled to WASM, no install required.
+
 ## Quickstart
 
 ```bash
@@ -72,6 +74,7 @@ PyTorch >= 1.10.0 on Linux and macOS, against the last two major tract releases 
 The full documentation has step by step tutorials (from a first image classifier to LLM export), the export API reference, and the list of supported operators:
 
 - [Getting started](https://sonos.github.io/torch-to-nnef/latest/tutos/1_getting_started/) : export, check, and run a real model end to end
+- [Live demos](https://sonos.github.io/torch-to-nnef/latest/demos/) : exported models running in your browser via tract WASM
 - [Export API](https://sonos.github.io/torch-to-nnef/latest/export_api/)
 - [Supported operators](https://sonos.github.io/torch-to-nnef/latest/contributing/supported_operators/)
 - [Why NNEF?](https://sonos.github.io/torch-to-nnef/latest/why_nnef/)

--- a/docs/demos.md
+++ b/docs/demos.md
@@ -48,4 +48,4 @@ Click any card to launch its demo in a new tab (each one only downloads its mode
 
     These models are not trained by SONOS, so prediction quality is the responsibility of their original authors. The WASM builds are unoptimized (no SIMD WASM, no WebGPU kernels), so speed here understates what tract reaches on native targets. They exist to demonstrate portability, not peak performance.
 
-Curious how they are built? Each demo's source lives under the project's [`examples/` directory](https://github.com/sonos/torch-to-nnef/tree/main/examples), and the step-by-step exports are covered in the [tutorials](tutos/1_getting_started.md).
+Curious how they are built? Each demo's source lives under the project's [`examples/` directory](https://github.com/sonos/torch-to-nnef/tree/main/examples), and the step-by-step exports are covered in the [tutorials](tutos/1_getting_started.md). That directory holds many more than the WASM demos above (quantization, text-to-speech, NeMo ASR, Mamba, image generation, multi-input/output models, custom operators, and Rust integration samples), making it the best place to browse end-to-end, runnable usage.

--- a/docs/demos.md
+++ b/docs/demos.md
@@ -1,0 +1,51 @@
+# Live demos
+
+Every model below was exported from PyTorch with `torch_to_nnef`, then runs **entirely in your browser**: no server, no upload, no API call. The inference is powered by [**tract**](https://github.com/sonos/tract/), the neural network engine developed openly by [SONOS](https://sonos.com), compiled to WebAssembly.
+
+!!! tip "Same engine, everywhere"
+
+    The exact NNEF archives driving these demos are the kind you produce by following the [tutorials](tutos/1_getting_started.md). The very same files run on server, desktop, mobile, and embedded targets through tract. WASM here is just one deployment of the portable artifact.
+
+Click any card to launch its demo in a new tab (each one only downloads its model when you open it):
+
+<div class="grid cards" markdown>
+
+- :material-image:{ .lg .middle } __Image classifier__
+
+    ---
+
+    `EfficientNet-B0` labelling an image, fully client-side.
+
+    [:octicons-arrow-right-24: Launch demo](html/demo_image_classifier.html){target=_blank}
+
+- :material-run:{ .lg .middle } __Pose estimator__
+
+    ---
+
+    `YOLO` human pose estimation running on a still image.
+
+    [:octicons-arrow-right-24: Launch demo](html/demo_pose_estimation.html){target=_blank}
+
+- :material-microphone:{ .lg .middle } __Voice activity detection__
+
+    ---
+
+    `FSMN` VAD with dynamic, streamable input over live audio.
+
+    [:octicons-arrow-right-24: Launch demo](html/demo_vad.html){target=_blank}
+
+- :material-text:{ .lg .middle } __Poem generator__
+
+    ---
+
+    A small `LLM` generating text token by token, in-browser.
+
+    [:octicons-arrow-right-24: Launch demo](html/demo_poem_generator.html){target=_blank}
+
+</div>
+
+!!! note "Performance disclaimer"
+
+    These models are not trained by SONOS, so prediction quality is the responsibility of their original authors. The WASM builds are unoptimized (no SIMD WASM, no WebGPU kernels), so speed here understates what tract reaches on native targets. They exist to demonstrate portability, not peak performance.
+
+Curious how they are built? Each demo's source lives under the project's [`examples/` directory](https://github.com/sonos/torch-to-nnef/tree/main/examples), and the step-by-step exports are covered in the [tutorials](tutos/1_getting_started.md).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -117,6 +117,7 @@ theme:
 
 nav:
   - Home: index.md
+  - '🚀 Live demos': demos.md
   - '📖 Tutorials':
     - '1. Getting started': "tutos/1_getting_started.md"
     - '2. NNEF archive': "tutos/2_nnef_archive.md"


### PR DESCRIPTION
## What

Adds a single, attractive landing page (`docs/demos.md`, in the mkdocs nav as **🚀 Live demos**) that gathers all four in-browser WASM demos in one place instead of having them scattered across tutorials 1, 4, and 5.

- Material **grid cards**, one per demo: image classifier (EfficientNet-B0), pose estimator (YOLO), voice activity detection (FSMN), poem generator (small LLM).
- Each card opens its existing standalone demo page in a **new tab**, so the landing page itself loads no WASM, each model downloads only when its card is clicked.
- Icons only for v1 (no thumbnail assets); we can add screenshots/GIFs later.
- Highlights that inference runs through **tract** compiled to WASM (in the intro, a "same engine everywhere" tip, the perf disclaimer, and every card), reinforcing the portability story.

Also linked from `README.md`: a `🚀 See it run` callout under the intro and an entry in "Learn more".

## Notes

- Links rewrite correctly to `../html/demo_*.html` under `use_directory_urls`, verified in the built `site/`.
- Reuses the existing `docs/html/demo_*.html` pages verbatim; no demo code changed.
- Inline iframes in tutorials 1/4/5 are left as-is for now (demos live both inline and on the new page).
- CI `doc-check` is non-strict and only fails on broken internal links; this page has none.