### PR TITLE
chore(tract): support 0.23.0, set oldest supported to 0.22.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,11 @@
 - **`examples/vad/silero-jit/`**: end-to-end demo of the JIT-only export path on a real artifact, gated in CI via the `silero_vad_demo` tox env.
 - **Tutorial**: `docs/tutos/12_jit_only_models.md` covers both the auto-detection path and the manual chain.
 
+### Changed
+- Officially supported tract versions bumped to 0.23.0 and 0.22.1 (0.21.15 dropped).
+
 ### Fixed
+- Reified `scaled_dot_product_attention` (`tract_transformers_sdpa`) now tiles a size-1 query axis on the attention mask up to the query length. tract 0.23.0's `FlashSDPA` does not broadcast that axis at eval time, so key-padding masks (e.g. torchaudio Conformer) raised an incompatible-shape error.
 - Parser bugs surfaced by JIT-only export (each was latent in main):
   - `slice_` recognizes `prim::Constant[NoneType]` for begin/end (Python's `t[:]`).
   - `div` wraps scalar division result in a 0-d tensor before `.to(dtype)`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 
 ### Fixed
 - Reified `scaled_dot_product_attention` (`tract_transformers_sdpa`) now tiles a size-1 query axis on the attention mask up to the query length. tract 0.23.0's `FlashSDPA` does not broadcast that axis at eval time, so key-padding masks (e.g. torchaudio Conformer) raised an incompatible-shape error.
+- Nearest 2-D upsample with static shapes now lowers via the rank-generic reshape/tile path instead of `deconv`. The deconv lowering emits a broadcast `Mul` that tract 0.23.0's `OptMatMul` fuse pass mis-substitutes when an adjacent conv consumes the upsample output (e.g. VAE-style decoder). The deconv path is kept for the dynamic-axes case.
 - Parser bugs surfaced by JIT-only export (each was latent in main):
   - `slice_` recognizes `prim::Constant[NoneType]` for begin/end (Python's `t[:]`).
   - `div` wraps scalar division result in a 0-d tensor before `.to(dtype)`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -33,7 +33,7 @@ Minimal dependencies are kept in this package (to allow easy integration in othe
 
 ### Support
 
-PyTorch >= 1.10.0 with the last 2 major releases of tract (>= 0.20.22 to date) over Linux and MacOS systems is officially supported, and the package is maintained/tested for Python versions that are [not end of life, nor pre-release](https://devguide.python.org/versions/).
+PyTorch >= 1.10.0 with the last 2 major releases of tract (>= 0.22.1 to date) over Linux and MacOS systems is officially supported, and the package is maintained/tested for Python versions that are [not end of life, nor pre-release](https://devguide.python.org/versions/).
 Only pre-compiled PyTorch wheels and dependencies available on [pypi](https://pypi.org/project/torch/) are used in CI, so this support evolves over time. Latest package versions ensure better opset coverage and unlock all features.
 
 

--- a/torch_to_nnef/inference_target/tract.py
+++ b/torch_to_nnef/inference_target/tract.py
@@ -86,8 +86,8 @@ class TractNNEF(InferenceTarget):
     OFFICIAL_SUPPORTED_VERSIONS = [
         SemanticVersion.from_str(version)
         for version in [
+            "0.23.0",
             "0.22.1",
-            "0.21.15",
         ]
     ]
 

--- a/torch_to_nnef/op/aten/attn.py
+++ b/torch_to_nnef/op/aten/attn.py
@@ -24,6 +24,40 @@ def reify_with_tract_transformers_sdpa(i: InferenceTarget) -> bool:
     )
 
 
+def _broadcast_mask_query_axis(
+    op_helper, attn_mask_node, attn_mask_tensor, query_node
+):
+    """Expand an additive attention mask along the query axis.
+
+    PyTorch broadcasts the attention mask against the `(.., L, S)` score
+    matrix, so masks derived from a key-padding mask carry a size-1 query
+    axis (e.g. `[B, H, 1, S]`). tract's `tract_transformers_sdpa`
+    (FlashSDPA) does not broadcast that axis at eval time and raises an
+    incompatible-shape error, so tile the mask up to the query length when
+    both dims are statically known.
+    """
+    mask_shape = attn_mask_node.shape
+    if mask_shape is None or len(mask_shape) < 2:
+        return attn_mask_tensor
+    mask_q = mask_shape[-2]
+    query_len = query_node.shape[-2]
+    if not (isinstance(mask_q, int) and isinstance(query_len, int)):
+        return attn_mask_tensor
+    if mask_q != 1 or query_len <= 1:
+        return attn_mask_tensor
+    repeats = [1] * len(mask_shape)
+    repeats[-2] = query_len
+    new_shape = list(mask_shape)
+    new_shape[-2] = query_len
+    return op_helper.add_intermediate_op(
+        src=attn_mask_tensor,
+        op_type="tile",
+        attrs={"repeats": repeats},
+        new_shape=new_shape,
+        suffix="sdpa_mask_qbroadcast",
+    )
+
+
 @OP_REGISTRY.register()
 def scaled_dot_product_attention(
     g, node, name_to_tensor, inference_target, **kwargs
@@ -89,6 +123,13 @@ def scaled_dot_product_attention(
         attn_mask_tensor = get_or_add_tensor_variable_in_nnef(
             g, attn_mask_node, name_to_tensor
         )
+        if reify_tract_spda:
+            attn_mask_tensor = _broadcast_mask_query_axis(
+                kwargs["op_helper"],
+                attn_mask_node,
+                attn_mask_tensor,
+                query_node,
+            )
         inputs.append(attn_mask_tensor)
     else:
         assert attn_mask_node.data is None

--- a/torch_to_nnef/op/aten/pool.py
+++ b/torch_to_nnef/op/aten/pool.py
@@ -363,13 +363,21 @@ def upsample_nearest_nd(node, op_helper, **kwargs):
             },
         )
         return []
-    if spatial_rank != 2:
+    static_shapes = not (
+        isinstance(op_helper.inference_target, TractNNEF)
+        and op_helper.inference_target.has_dynamic_axes
+    )
+    if spatial_rank != 2 or static_shapes:
         # Rank-generic nearest upsample: insert a size-1 axis after
         # each spatial axis, tile it by the scale, then collapse back.
         # `(..., d, 1) -> tile by s -> (..., d, s) -> reshape (..., d*s)`
         # is the standard reshape/tile trick for nearest-neighbour
         # replication; works on any rank and bypasses the rank-4
-        # restriction of the deconv path.
+        # restriction of the deconv path. It needs static spatial dims,
+        # so the deconv path below still handles the dynamic-axes case.
+        # Preferred over deconv: the deconv lowering emits a broadcast
+        # `Mul` that tract 0.23.0's `OptMatMul` fuse pass mis-substitutes
+        # when an adjacent conv consumes the upsample output.
         in_shape = [int(d) for d in input_node.shape]
         expanded = list(in_shape[:leading])
         for axis_i in range(spatial_rank):


### PR DESCRIPTION
## What

Bump the officially supported tract versions:

- newest: `0.23.0` (now `TractNNEF.latest()`)
- oldest: `0.22.1` (was `0.21.15`, dropped)

## Why

Track tract's latest stable release and keep the support window to the last two majors. `0.23.0` ships the `isnan`/`isinf` ops that tests were already gated against, and `reify_sdpa_operator` auto-enables (version > `0.22.0`).

## Notes

- `TractBinaryDownloader` already falls back to the `v`-prefixed tag, so the `v0.23.0` release asset downloads cleanly and the CLI reports `0.23.0`.
- Test matrix derives from `OFFICIAL_SUPPORTED_VERSIONS`, so both versions are exercised automatically.
- Updated the support statement in `docs/index.md` and added a CHANGELOG entry.

## Verification

- `pytest tests/test_primitive.py -k test_primitive_export`: 867 passed across both supported versions.
- `ruff format --check` and `ruff check`: clean.