### PR TITLE
ci(docs): deploy docs on version tag release instead of every merge to main

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -3,15 +3,11 @@ name: Deploy T2N docs
 # Controls when the action will run.
 on:
   push:
-    branches: [main]
-    # Mirror doc-check.yml's PR trigger so a doc-only merge to main always
-    # redeploys. The "10. Nemo ASR" tutorial is a symlink into examples/, so
-    # an examples/ change can also change a doc page.
-    paths:
-      - "**.md"
-      - "mkdocs.yml"
-      - "docs/**"
-      - "examples/**"
+    # Deploy docs only on a tagged version release, not on every merge to main,
+    # so the published docs track the latest packaged release (see release.yml,
+    # which builds/publishes on the same `v*` tags).
+    tags:
+      - "v*"
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -46,21 +46,13 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
-        with:
-          enable-cache: true
-
+        # No caching: this workflow now runs on `v*` tags (a publishing trigger),
+        # where a restored cache could be poisoned from a lower-privilege run
+        # (zizmor cache-poisoning). release.yml follows the same no-cache pattern.
 
       - name: Install dependencies
         run: |
           uv sync --group dev
-
-      - run: echo "cache_id=$(date --utc '+%V')" >> $GITHUB_ENV
-      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          key: mkdocs-material-${{ env.cache_id }}
-          path: ~/.cache
-          restore-keys: |
-            mkdocs-material-
 
       - name: Deploy to GitHub Pages
         run: |

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -46,9 +46,12 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
-        # No caching: this workflow now runs on `v*` tags (a publishing trigger),
-        # where a restored cache could be poisoned from a lower-privilege run
-        # (zizmor cache-poisoning). release.yml follows the same no-cache pattern.
+        with:
+          # No caching: this workflow now runs on `v*` tags (a publishing
+          # trigger), where a restored cache could be poisoned from a
+          # lower-privilege run (zizmor cache-poisoning). release.yml follows
+          # the same no-cache pattern.
+          enable-cache: false
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
## Problem
`doc.yml` redeployed the mkdocs site on every doc-touching push to `main`. That republishes docs ahead of the packaged release they describe, so the public docs can drift ahead of the latest version on PyPI.

## Change
Trigger the docs deploy on `v*` tag pushes instead of on `main` (same tags that `release.yml` builds and publishes on). `workflow_dispatch` is kept for manual redeploys.

The deploy step is unchanged and already fits this trigger: it derives the version from `git describe --tags` and publishes with `mike deploy --update-aliases <version> latest`, so on a tag push it picks up exactly that release.

## Effect
- Docs now redeploy only when a new version is tagged/released.
- Doc-only merges to `main` no longer republish; they ship with the next release.