### PR TITLE
fix(image_gen): export SD1.5 VAE decoder with tract check tolerance super

### DIFF
--- a/examples/image_gen/sd15/vae_decoder.py
+++ b/examples/image_gen/sd15/vae_decoder.py
@@ -20,6 +20,7 @@ from diffusers import AutoencoderKL
 from torch import nn
 
 from torch_to_nnef import TractNNEF, export_model_to_nnef
+from torch_to_nnef.inference_target.tract import TractCheckTolerance
 
 HF_REPO = "stable-diffusion-v1-5/stable-diffusion-v1-5"
 
@@ -75,7 +76,15 @@ def main():
         model=pipeline,
         args=latents,
         file_path_export=args.out,
-        inference_target=TractNNEF(version=tract_version, check_io=check_io),
+        # The VAE decoder agrees with tract pervasively to ~1e-3, but across so
+        # many of its 786432 outputs that the default "approximate" bound trips.
+        # "super" is the project convention for large models (cf. the parakeet
+        # export in examples/nemo_asr).
+        inference_target=TractNNEF(
+            version=tract_version,
+            check_io=check_io,
+            check_io_tolerance=TractCheckTolerance.SUPER,
+        ),
         input_names=["latents"],
         output_names=["image"],
         debug_bundle_path=Path("./debug_vae_decoder.tgz"),


### PR DESCRIPTION
## What

Fixes the pre-existing red `tier2: image_gen` job (failing on `main`, e.g. the 2026-06-08 scheduled run and the 2026-06-11 dispatch). Unlike `nemo_asr`, this job is not `allow_failure`, so it fails the weekly tier2 workflow.

## Root cause

`sd15/vae_decoder.py` exports with the default `check_io_tolerance=APPROXIMATE`. The SD1.5 VAE decoder agrees with tract pervasively but only to ~1e-3, and across enough of its 786432 outputs that the bound trips:

```
[ERROR tract] Checking output 0
Mismatch. First outlier (Approximate F32) ~0.0274 != ~0.0277. Outliers: ~69000 / 786432 = ~0.088 > 0.0
```

## Fix

Export the VAE decoder with `check_io_tolerance=TractCheckTolerance.SUPER`, the project's convention for large models (same level the parakeet export in `examples/nemo_asr` uses). The I/O check still runs; it just uses the looser bound appropriate for a model this size.

## Notes

- Import path matches existing usage (`packages/nemo-asr`, `packages/llm`).
- `unet.py` in the same example already runs with `--skip-io-check`, so only the VAE decoder needed this.
- Independent of #195 (nemo RCE) and #196 (nemo_asr ndarray).