### PR TITLE
docs: target tract 0.23.0 in README and tutorials

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ export_model_to_nnef(
     file_path_export="my_model.nnef.tgz",
     # version pins the tract opset to target; check_io downloads that tract
     # build once and asserts its output matches PyTorch on example_input.
-    inference_target=TractNNEF(version="0.21.13", check_io=True),
+    inference_target=TractNNEF(version="0.23.0", check_io=True),
     input_names=["input"],
     output_names=["output"],
 )

--- a/docs/contributing/add_new_aten_op.md
+++ b/docs/contributing/add_new_aten_op.md
@@ -116,10 +116,10 @@ If you run it as such there should be 2 failed test case. Why 2 ? Because given 
 What if you want to focus on 1 test case ? just run:
 
 ```bash
-T2N_TEST_TRACT_VERSION="0.21.13" py.test tests/test_primitive.py::test_primitive_export
+T2N_TEST_TRACT_VERSION="0.23.0" py.test tests/test_primitive.py::test_primitive_export
 ```
 
-In this case you will test on 0.21.13 version but you can set it to any version
+In this case you will test on 0.23.0 version but you can set it to any version
 released at the time in [tract repository](https://github.com/sonos/tract/releases).
 
 If you are willing to test a specific custom version of tract instead you can directly

--- a/docs/tutos/1_getting_started.md
+++ b/docs/tutos/1_getting_started.md
@@ -98,7 +98,7 @@ export_model_to_nnef( # (1)!
     # inference engine to target
     inference_target=TractNNEF( # (2)!
         # tract version (to ensure compatible operators)
-        version="0.21.13",
+        version="0.23.0",
         # default False
         # (tract cli will be installed on the machine on fly)
         # and correctness of output compared to PyTorch for the
@@ -156,7 +156,7 @@ We will now check with the tract cli that everything is working as expected.
 Let's first display the help of the command line we downloaded when we checked io between tract and PyTorch (in step 2.)
 
 ```bash title="Setup"
-alias tract=$HOME/.cache/svc/tract/0.21.13/tract
+alias tract=$HOME/.cache/svc/tract/0.23.0/tract
 tract --help
 ```
 
@@ -212,7 +212,7 @@ Then we have the list of custom properties that have been exported by `torch_to_
 * torch_to_nnef_version: ,String 0.18.6
 * torch_version: ,String 2.6.0
 * tract_stage: ,String optimized
-* tract_target_version: ,String 0.21.13
+* tract_target_version: ,String 0.23.0
 * transformers_version: ,String 4.49.0
 * user: ,String tuto
 ```

--- a/docs/tutos/2_nnef_archive.md
+++ b/docs/tutos/2_nnef_archive.md
@@ -81,7 +81,7 @@ fragment tract_core_properties(
 ) -> (properties: (string, tensor<scalar>)[])
 {
   properties = [
-    ("tract_target_version", "0.21.13"),
+    ("tract_target_version", "0.23.0"),
     ("torch_to_nnef_version", "0.18.6"),
 //...
     ("export_cmd", "getting_started.py")

--- a/docs/tutos/3_multi_inputs_outputs.md
+++ b/docs/tutos/3_multi_inputs_outputs.md
@@ -72,7 +72,7 @@ export_model_to_nnef(
     args=[inputs[k] for k in input_names],
     file_path_export=file_path_export,
     inference_target=TractNNEF(
-        version="0.21.13",
+        version="0.23.0",
         check_io=True,
     ),
     input_names=input_names,

--- a/docs/tutos/4_dynamic_axes.md
+++ b/docs/tutos/4_dynamic_axes.md
@@ -38,7 +38,7 @@ export_model_to_nnef(
     args=input_data_sample,
     file_path_export=file_path_export,
     inference_target=TractNNEF(
-        version="0.21.13",
+        version="0.23.0",
         check_io=True,
         # here we use the first input_names we define
         # and request the first dimension: 0 to have
@@ -175,7 +175,7 @@ export_model_to_nnef(
         dynamic_axes={
             "melbank": {0: "B", 1: "S"},
         },
-        version="0.21.13",
+        version="0.23.0",
         check_io=True,
     ),
     input_names=["melbank"],
@@ -289,7 +289,7 @@ export_model_to_nnef(
             "attention_mask": {0: "B", 1: "S"},
             "token_type_ids": {0: "B", 1: "S"}
         },
-        version="0.21.13",
+        version="0.23.0",
         check_io=True,
     ),
     input_names=input_names,

--- a/docs/tutos/6_quantization.md
+++ b/docs/tutos/6_quantization.md
@@ -353,7 +353,7 @@ export_model_to_nnef(
     args=input_fp32,
     file_path_export=file_path_export,
     inference_target=TractNNEF(
-        version="0.21.13",
+        version="0.23.0",
         check_io=True,
     ),
     input_names=["input"],


### PR DESCRIPTION
Bumps the targeted tract version in the docs from `0.21.13` to `0.23.0`, matching `TractNNEF.latest_version()` (head of `OFFICIAL_SUPPORTED_VERSIONS = ["0.23.0", "0.22.1"]`).

## Changes
- `README.md`: example `TractNNEF(version=...)` pin
- `docs/tutos/1_getting_started.md`: example pin, CLI cache-path alias, and the exported `tract_target_version` property output (all version-derived, kept consistent)
- `docs/tutos/2_nnef_archive.md`: `tract_target_version` property output
- `docs/tutos/3_multi_inputs_outputs.md`, `docs/tutos/4_dynamic_axes.md`, `docs/tutos/6_quantization.md`: example pins
- `docs/contributing/add_new_aten_op.md`: `T2N_TEST_TRACT_VERSION` env and surrounding prose

## Left untouched (intentionally)
- Feature-gating version comparisons in source (e.g. `< 0.21.7`, `>= 0.22.0`) are factual statements about when ops landed, not target pins.
- `docs/tutos/12_jit_only_models.md` already uses `TractNNEF.latest_version()`; `docs/export_api.md` already shows `0.23.0`.
- The `0.21.13` pins in tests look like deliberate version-specific regression coverage, so they are out of scope here.