### PR TITLE
feat(llm): opt-in --upcast-quant to dequantize native fp8/fp4/mxfp4 models before export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 <!-- markdownlint-disable-file MD001 MD013 MD024 -->
 # Changelog
 
+## [Unreleased]
+
+### Added
+- LLM export: opt-in **`--upcast-quant`** (loader `upcast_quant=`) to dequantize a natively-quantized model (fp8, fp4 / mxfp4, nf4, …) to dense float before export, since tract cannot ingest those formats. Selectable per quant method (e.g. `mxfp4`, `mxfp4,fp8`) or `any`. Routes by mechanism — load-time `dequantize=True` for mxfp4/fp8/metal, post-load `model.dequantize()` for bnb/higgs — and verifies the result is fully dense. Compose with `-dt` (float target) and `-c` (re-quantize to a tract scheme).
+
 ## [0.24.0] - 2026-06-11
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 ## [Unreleased]
 
 ### Added
-- LLM export: opt-in **`--upcast-quant`** (loader `upcast_quant=`) to dequantize a natively-quantized model (fp8, fp4 / mxfp4, nf4, ...) to dense float before export, since tract cannot ingest those formats. Selectable per quant method (e.g. `mxfp4`, `mxfp4,fp8`) or `any`. Routes by mechanism: load-time `dequantize=True` for mxfp4/fp8/metal, post-load `model.dequantize()` for bnb/higgs, then verifies the result is fully dense. Compose with `-dt` (float target) and `-c` (re-quantize to a tract scheme).
+- LLM export: opt-in **`--upcast-quant`** (loader `upcast_quant=`) to dequantize a natively-quantized model (mxfp4, fp8, bitsandbytes, ...) to dense float before export, since tract cannot ingest those formats. Selectable per quant method (names from transformers' `QuantizationMethod`, e.g. `mxfp4`, `mxfp4,fp8`) or `any`, validated up-front (requires transformers >= 4.38). Routes by mechanism: load-time `dequantize=True` for mxfp4/fp8/metal, post-load `model.dequantize()` for bnb/higgs, then verifies the result is fully dense (a format transformers cannot dequantize fails with a clear error). Compose with `-dt` (float target) and `-c` (re-quantize to a tract scheme).
 
 ## [0.24.0] - 2026-06-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 ## [Unreleased]
 
 ### Added
-- LLM export: opt-in **`--upcast-quant`** (loader `upcast_quant=`) to dequantize a natively-quantized model (fp8, fp4 / mxfp4, nf4, …) to dense float before export, since tract cannot ingest those formats. Selectable per quant method (e.g. `mxfp4`, `mxfp4,fp8`) or `any`. Routes by mechanism — load-time `dequantize=True` for mxfp4/fp8/metal, post-load `model.dequantize()` for bnb/higgs — and verifies the result is fully dense. Compose with `-dt` (float target) and `-c` (re-quantize to a tract scheme).
+- LLM export: opt-in **`--upcast-quant`** (loader `upcast_quant=`) to dequantize a natively-quantized model (fp8, fp4 / mxfp4, nf4, ...) to dense float before export, since tract cannot ingest those formats. Selectable per quant method (e.g. `mxfp4`, `mxfp4,fp8`) or `any`. Routes by mechanism: load-time `dequantize=True` for mxfp4/fp8/metal, post-load `model.dequantize()` for bnb/higgs, then verifies the result is fully dense. Compose with `-dt` (float target) and `-c` (re-quantize to a tract scheme).
 
 ## [0.24.0] - 2026-06-11
 

--- a/packages/llm/pyproject.toml
+++ b/packages/llm/pyproject.toml
@@ -103,25 +103,25 @@ basepython = ["python3.12", "python3.13"]
 dependency_groups = ["test"]
 constrain_package_deps = false
 deps = ["transformers==4.50.0"]
-commands = [["pytest", "-s", "tests/test_llm_cli.py", "tests/test_load_retry.py"]]
+commands = [["pytest", "-s", "tests/test_llm_cli.py", "tests/test_load_retry.py", "tests/test_upcast_quant.py"]]
 
 [tool.tox.env.cli_transformers_4_52_0]
 basepython = ["python3.12", "python3.13"]
 dependency_groups = ["test"]
 constrain_package_deps = false
 deps = ["transformers==4.52.0"]
-commands = [["pytest", "-s", "tests/test_llm_cli.py", "tests/test_load_retry.py"]]
+commands = [["pytest", "-s", "tests/test_llm_cli.py", "tests/test_load_retry.py", "tests/test_upcast_quant.py"]]
 
 [tool.tox.env.cli_transformers_5_0_0]
 basepython = ["python3.12", "python3.13"]
 dependency_groups = ["test"]
 constrain_package_deps = false
 deps = ["transformers==5.0.0"]
-commands = [["pytest", "-s", "tests/test_llm_cli.py", "tests/test_load_retry.py"]]
+commands = [["pytest", "-s", "tests/test_llm_cli.py", "tests/test_load_retry.py", "tests/test_upcast_quant.py"]]
 
 [tool.tox.env.cli_transformers_5_5_0]
 basepython = ["python3.12", "python3.13"]
 dependency_groups = ["test"]
 constrain_package_deps = false
 deps = ["transformers==5.5.0"]
-commands = [["pytest", "-s", "tests/test_llm_cli.py", "tests/test_load_retry.py"]]
+commands = [["pytest", "-s", "tests/test_llm_cli.py", "tests/test_load_retry.py", "tests/test_upcast_quant.py"]]

--- a/packages/llm/tests/test_upcast_quant.py
+++ b/packages/llm/tests/test_upcast_quant.py
@@ -20,8 +20,10 @@ from torch_to_nnef_llm.loader import (
 
 
 class _LoadTimeConfig:
-    """A quant config that supports load-time dequant (has a ``dequantize`` flag),
-    like Mxfp4Config / FineGrainedFP8Config."""
+    """A quant config with a load-time ``dequantize`` flag.
+
+    Like Mxfp4Config / FineGrainedFP8Config.
+    """
 
     def __init__(self, method):
         self.quant_method = method
@@ -96,12 +98,13 @@ def test_plan_quantized_but_other_method_requested_errors():
 
 def test_assert_dense_passes_when_dense():
     assert_upcast_dense(_Model(), ["any"])  # no quant config, no quantizer
-    assert_upcast_dense(_Model(_LoadTimeConfig("mxfp4")), None)  # not requested → skip
+    # not requested → skip
+    assert_upcast_dense(_Model(_LoadTimeConfig("mxfp4")), None)
 
 
 def test_assert_dense_raises_on_residual_quant():
     # still reports a native method after up-cast → partial dequant
-    with pytest.raises(T2NErrorMisuse, match="partially-quantized|did not fully"):
+    with pytest.raises(T2NErrorMisuse, match="did not fully"):
         assert_upcast_dense(_Model(_LoadTimeConfig("mxfp4")), ["any"])
     # or a lingering hf_quantizer even if config was cleared
     with pytest.raises(T2NErrorMisuse):

--- a/packages/llm/tests/test_upcast_quant.py
+++ b/packages/llm/tests/test_upcast_quant.py
@@ -12,6 +12,7 @@ from torch_to_nnef.exceptions import T2NErrorMisuse
 from torch_to_nnef_llm.loader import (
     UPCAST_ANY,
     _native_quant_method,
+    _normalize_upcast_request,
     _quant_method_of,
     assert_upcast_dense,
     plan_upcast,
@@ -62,6 +63,18 @@ def test_quant_method_normalization():
     assert _quant_method_of(None) is None
     assert _native_quant_method(_Model()) is None
     assert _native_quant_method(_Model(_LoadTimeConfig("mxfp4"))) == "mxfp4"
+
+
+def test_normalize_upcast_request():
+    # nothing requested -> None
+    assert _normalize_upcast_request(None) is None
+    assert _normalize_upcast_request([]) is None
+    # valid methods + the "any" sentinel pass through, lowercased
+    assert _normalize_upcast_request(["MXFP4", "fp8"]) == ["mxfp4", "fp8"]
+    assert _normalize_upcast_request(["any"]) == [UPCAST_ANY]
+    # a typo fails up-front, with the valid list in the message
+    with pytest.raises(T2NErrorMisuse, match="unknown upcast_quant"):
+        _normalize_upcast_request(["mxpf4"])
 
 
 def test_should_upcast_matrix():

--- a/packages/llm/tests/test_upcast_quant.py
+++ b/packages/llm/tests/test_upcast_quant.py
@@ -1,0 +1,86 @@
+"""Unit tests for the native-quant up-cast selection logic.
+
+The actual dequantization (``model.dequantize()``) needs real quantized weights
+and GPU kernels (mxfp4/fp8), so only the pure selection / branching is covered
+here; the dequant call itself is delegated to transformers.
+"""
+
+import pytest
+
+from torch_to_nnef.exceptions import T2NErrorMisuse
+from torch_to_nnef_llm.loader import (
+    UPCAST_ANY,
+    _native_quant_method,
+    maybe_upcast_native_quant,
+    should_upcast,
+)
+
+
+class _QConf:
+    def __init__(self, method):
+        self.quant_method = method
+
+
+class _Cfg:
+    def __init__(self, method=None):
+        if method is not None:
+            self.quantization_config = _QConf(method)
+
+
+class _Model:
+    """Minimal stand-in. ``dequantize()`` flips a flag and returns a dense twin."""
+
+    def __init__(self, method=None):
+        self.config = _Cfg(method)
+        self.dequantized = False
+
+    def dequantize(self):
+        dense = _Model(method=None)  # dense: no quantization_config
+        dense.dequantized = True
+        return dense
+
+
+def test_native_quant_method_detection():
+    assert _native_quant_method(_Model("mxfp4")) == "mxfp4"
+    assert _native_quant_method(_Model(None)) is None
+    # enum-like value with a .value attribute is normalized + lowercased
+    class _E:
+        value = "FbgemmFp8"
+    m = _Model("x")
+    m.config.quantization_config.quant_method = _E()
+    assert _native_quant_method(m) == "fbgemmfp8"
+
+
+def test_should_upcast_matrix():
+    assert should_upcast("mxfp4", ["mxfp4"]) is True
+    assert should_upcast("mxfp4", ["fp8", "mxfp4"]) is True
+    assert should_upcast("mxfp4", [UPCAST_ANY]) is True
+    assert should_upcast("mxfp4", ["fp8"]) is False
+    assert should_upcast("mxfp4", None) is False
+    assert should_upcast("mxfp4", []) is False
+    assert should_upcast(None, ["any"]) is False  # not quantized
+
+
+def test_dense_model_is_untouched():
+    m = _Model(None)
+    assert maybe_upcast_native_quant(m, ["any"]) is m
+
+
+def test_quantized_but_not_requested_is_kept_with_warning(caplog):
+    m = _Model("mxfp4")
+    out = maybe_upcast_native_quant(m, None)  # opt-in: not requested
+    assert out is m  # unchanged, not dequantized
+    assert any("native 'mxfp4'" in r.message for r in caplog.records)
+
+
+def test_quantized_and_requested_is_dequantized():
+    m = _Model("mxfp4")
+    out = maybe_upcast_native_quant(m, ["mxfp4"])
+    assert out is not m and out.dequantized is True
+    assert _native_quant_method(out) is None  # now dense
+
+
+def test_quantized_with_other_method_requested_errors():
+    m = _Model("mxfp4")
+    with pytest.raises(T2NErrorMisuse, match="mxfp4"):
+        maybe_upcast_native_quant(m, ["fp8"])

--- a/packages/llm/tests/test_upcast_quant.py
+++ b/packages/llm/tests/test_upcast_quant.py
@@ -80,6 +80,8 @@ def test_normalize_upcast_request():
         "gptq",
     ]
     assert _normalize_upcast_request(["any"]) == [UPCAST_ANY]
+    # a bare string is treated as one method, not iterated per-character
+    assert _normalize_upcast_request("gptq") == ["gptq"]
     # a typo fails up-front, with the valid list in the message
     with pytest.raises(T2NErrorMisuse, match="unknown upcast_quant"):
         _normalize_upcast_request(["definitely-not-a-real-method"])
@@ -206,6 +208,41 @@ def test_finish_upcast_post_unsupported_raises_clean_error():
     # the B1 fix: NotImplementedError becomes a clear T2NErrorMisuse
     with pytest.raises(T2NErrorMisuse, match="cannot be dequantized by"):
         _finish_upcast(_PostUnsupportedModel(), ("post", "gptq"), ["any"])
+
+
+class _FakeAutoConfig:
+    def __init__(self, quantization_config):
+        self.quantization_config = quantization_config
+
+
+class _FakeTransformers:
+    """Minimal stand-in exposing only what `_peek_quant_config` touches."""
+
+    def __init__(self, quantization_config):
+        self._qc = quantization_config
+
+    class _AutoConfig:
+        pass
+
+    @property
+    def AutoConfig(self):  # noqa: N802 (mirrors transformers.AutoConfig)
+        qc = self._qc
+        ns = type("AutoConfig", (), {})
+
+        def from_pretrained(*_a, **_k):
+            return _FakeAutoConfig(qc)
+
+        ns.from_pretrained = staticmethod(from_pretrained)
+        return ns
+
+
+def test_peek_quant_config_resilient_to_unknown_method():
+    from torch_to_nnef_llm.loader import _peek_quant_config
+
+    # a quant_method this transformers version doesn't know makes
+    # AutoQuantizationConfig.from_dict raise; the peek must swallow it -> None
+    tf = _FakeTransformers({"quant_method": "not-a-real-quant-method"})
+    assert _peek_quant_config("some/slug", True, tf) is None
 
 
 def test_finish_upcast_warns_when_quantized_but_not_requested(caplog):

--- a/packages/llm/tests/test_upcast_quant.py
+++ b/packages/llm/tests/test_upcast_quant.py
@@ -9,10 +9,13 @@ covered here.
 import pytest
 
 from torch_to_nnef.exceptions import T2NErrorMisuse
+from torch_to_nnef_llm import loader
 from torch_to_nnef_llm.loader import (
     UPCAST_ANY,
+    _finish_upcast,
     _native_quant_method,
     _normalize_upcast_request,
+    _plan_and_inject_upcast,
     _quant_method_of,
     assert_upcast_dense,
     plan_upcast,
@@ -69,12 +72,17 @@ def test_normalize_upcast_request():
     # nothing requested -> None
     assert _normalize_upcast_request(None) is None
     assert _normalize_upcast_request([]) is None
-    # valid methods + the "any" sentinel pass through, lowercased
-    assert _normalize_upcast_request(["MXFP4", "fp8"]) == ["mxfp4", "fp8"]
+    # valid methods + the "any" sentinel pass through, lowercased. Use methods
+    # present across the whole supported transformers range (>= 4.35), so this
+    # holds on every cli_transformers_* env (mxfp4/fp8 are 5.x-only).
+    assert _normalize_upcast_request(["BitsAndBytes", "gptq"]) == [
+        "bitsandbytes",
+        "gptq",
+    ]
     assert _normalize_upcast_request(["any"]) == [UPCAST_ANY]
     # a typo fails up-front, with the valid list in the message
     with pytest.raises(T2NErrorMisuse, match="unknown upcast_quant"):
-        _normalize_upcast_request(["mxpf4"])
+        _normalize_upcast_request(["definitely-not-a-real-method"])
 
 
 def test_normalize_upcast_request_requires_transformers_4_38(monkeypatch):
@@ -128,6 +136,83 @@ def test_assert_dense_raises_on_residual_quant():
     # still reports a native method after up-cast → partial dequant
     with pytest.raises(T2NErrorMisuse, match="did not fully"):
         assert_upcast_dense(_Model(_LoadTimeConfig("mxfp4")), ["any"])
-    # or a lingering hf_quantizer even if config was cleared
-    with pytest.raises(T2NErrorMisuse):
+    # a lingering hf_quantizer even if config was cleared: message reads
+    # "active quantizer", not "native 'None'"
+    with pytest.raises(T2NErrorMisuse, match="active quantizer"):
         assert_upcast_dense(_Model(hf_quantizer=object()), ["any"])
+
+
+# --- integration helpers: _plan_and_inject_upcast / _finish_upcast ---
+
+
+class _PostCapableModel:
+    """A post-load-dequantizable model (bnb/higgs style)."""
+
+    def __init__(self):
+        self.config = _Cfg(_PostLoadConfig("bitsandbytes"))
+
+    def dequantize(self):
+        return _Model()  # dense twin (no quantization_config)
+
+
+class _PostUnsupportedModel:
+    """A model whose quantizer has no post-load dequantize (gptq/awq/...)."""
+
+    def __init__(self):
+        self.config = _Cfg(_PostLoadConfig("gptq"))
+
+    def dequantize(self):
+        raise NotImplementedError("gptq has no implementation of dequantize")
+
+
+def test_plan_and_inject_load_time(monkeypatch):
+    qc = _LoadTimeConfig("mxfp4")
+    monkeypatch.setattr(loader, "_peek_quant_config", lambda *a, **k: qc)
+    kwargs = {}
+    plan = _plan_and_inject_upcast("org/m", ["mxfp4"], kwargs, True, object())
+    assert plan == ("load", qc)
+    assert kwargs["quantization_config"] is qc and qc.dequantize is True
+
+
+def test_plan_and_inject_post_and_none(monkeypatch):
+    monkeypatch.setattr(
+        loader,
+        "_peek_quant_config",
+        lambda *a, **k: _PostLoadConfig("bitsandbytes"),
+    )
+    kwargs = {}
+    assert _plan_and_inject_upcast("m", ["any"], kwargs, True, object()) == (
+        "post",
+        "bitsandbytes",
+    )
+    assert "quantization_config" not in kwargs  # post path injects nothing
+    # no request / no source short-circuits without peeking
+    assert _plan_and_inject_upcast(None, ["mxfp4"], {}, True, object()) == (
+        "none",
+        None,
+    )
+    assert _plan_and_inject_upcast("m", None, {}, True, object()) == (
+        "none",
+        None,
+    )
+
+
+def test_finish_upcast_post_success():
+    out = _finish_upcast(_PostCapableModel(), ("post", "bitsandbytes"), ["any"])
+    assert _native_quant_method(out) is None
+
+
+def test_finish_upcast_post_unsupported_raises_clean_error():
+    # the B1 fix: NotImplementedError becomes a clear T2NErrorMisuse
+    with pytest.raises(T2NErrorMisuse, match="cannot be dequantized by"):
+        _finish_upcast(_PostUnsupportedModel(), ("post", "gptq"), ["any"])
+
+
+def test_finish_upcast_warns_when_quantized_but_not_requested(caplog):
+    import logging
+
+    model = _Model(_LoadTimeConfig("mxfp4"))
+    with caplog.at_level(logging.WARNING):
+        out = _finish_upcast(model, ("none", None), None)
+    assert out is model  # left as-is (opt-in)
+    assert any("upcast_quant was not" in r.message for r in caplog.records)

--- a/packages/llm/tests/test_upcast_quant.py
+++ b/packages/llm/tests/test_upcast_quant.py
@@ -77,6 +77,15 @@ def test_normalize_upcast_request():
         _normalize_upcast_request(["mxpf4"])
 
 
+def test_normalize_upcast_request_requires_transformers_4_38(monkeypatch):
+    import transformers
+
+    # too-old transformers (no quantizer dequant API) fails up-front, clearly
+    monkeypatch.setattr(transformers, "__version__", "4.37.0")
+    with pytest.raises(T2NErrorMisuse, match="requires transformers >= 4.38"):
+        _normalize_upcast_request(["mxfp4"])
+
+
 def test_should_upcast_matrix():
     assert should_upcast("mxfp4", ["mxfp4"]) is True
     assert should_upcast("mxfp4", ["fp8", "mxfp4"]) is True

--- a/packages/llm/tests/test_upcast_quant.py
+++ b/packages/llm/tests/test_upcast_quant.py
@@ -1,8 +1,9 @@
-"""Unit tests for the native-quant up-cast selection logic.
+"""Unit tests for the native-quant up-cast decision logic.
 
-The actual dequantization (``model.dequantize()``) needs real quantized weights
-and GPU kernels (mxfp4/fp8), so only the pure selection / branching is covered
-here; the dequant call itself is delegated to transformers.
+The actual dequantization (load-time ``dequantize=True`` for mxfp4/fp8, or
+post-load ``model.dequantize()`` for bnb/higgs) needs real quantized weights and
+GPU kernels, so only the pure planning / selection / dense-verification is
+covered here.
 """
 
 import pytest
@@ -11,44 +12,54 @@ from torch_to_nnef.exceptions import T2NErrorMisuse
 from torch_to_nnef_llm.loader import (
     UPCAST_ANY,
     _native_quant_method,
-    maybe_upcast_native_quant,
+    _quant_method_of,
+    assert_upcast_dense,
+    plan_upcast,
     should_upcast,
 )
 
 
-class _QConf:
+class _LoadTimeConfig:
+    """A quant config that supports load-time dequant (has a ``dequantize`` flag),
+    like Mxfp4Config / FineGrainedFP8Config."""
+
+    def __init__(self, method):
+        self.quant_method = method
+        self.dequantize = False
+
+
+class _PostLoadConfig:
+    """A quant config with no ``dequantize`` flag (bnb/higgs style)."""
+
+    __slots__ = ("quant_method",)
+
     def __init__(self, method):
         self.quant_method = method
 
 
 class _Cfg:
-    def __init__(self, method=None):
-        if method is not None:
-            self.quantization_config = _QConf(method)
+    def __init__(self, quant_config=None):
+        if quant_config is not None:
+            self.quantization_config = quant_config
 
 
 class _Model:
-    """Minimal stand-in. ``dequantize()`` flips a flag and returns a dense twin."""
-
-    def __init__(self, method=None):
-        self.config = _Cfg(method)
-        self.dequantized = False
-
-    def dequantize(self):
-        dense = _Model(method=None)  # dense: no quantization_config
-        dense.dequantized = True
-        return dense
+    def __init__(self, quant_config=None, hf_quantizer=None):
+        self.config = _Cfg(quant_config)
+        if hf_quantizer is not None:
+            self.hf_quantizer = hf_quantizer
 
 
-def test_native_quant_method_detection():
-    assert _native_quant_method(_Model("mxfp4")) == "mxfp4"
-    assert _native_quant_method(_Model(None)) is None
-    # enum-like value with a .value attribute is normalized + lowercased
+def test_quant_method_normalization():
+    assert _quant_method_of(_LoadTimeConfig("mxfp4")) == "mxfp4"
+
     class _E:
         value = "FbgemmFp8"
-    m = _Model("x")
-    m.config.quantization_config.quant_method = _E()
-    assert _native_quant_method(m) == "fbgemmfp8"
+
+    assert _quant_method_of(_PostLoadConfig(_E())) == "fbgemmfp8"
+    assert _quant_method_of(None) is None
+    assert _native_quant_method(_Model()) is None
+    assert _native_quant_method(_Model(_LoadTimeConfig("mxfp4"))) == "mxfp4"
 
 
 def test_should_upcast_matrix():
@@ -57,30 +68,41 @@ def test_should_upcast_matrix():
     assert should_upcast("mxfp4", [UPCAST_ANY]) is True
     assert should_upcast("mxfp4", ["fp8"]) is False
     assert should_upcast("mxfp4", None) is False
-    assert should_upcast("mxfp4", []) is False
-    assert should_upcast(None, ["any"]) is False  # not quantized
+    assert should_upcast(None, ["any"]) is False
 
 
-def test_dense_model_is_untouched():
-    m = _Model(None)
-    assert maybe_upcast_native_quant(m, ["any"]) is m
+def test_plan_not_quantized_or_not_requested():
+    assert plan_upcast(None, ["any"]) == ("none", None)
+    assert plan_upcast(_LoadTimeConfig("mxfp4"), None) == ("none", None)
+    assert plan_upcast(_LoadTimeConfig("mxfp4"), []) == ("none", None)
 
 
-def test_quantized_but_not_requested_is_kept_with_warning(caplog):
-    m = _Model("mxfp4")
-    out = maybe_upcast_native_quant(m, None)  # opt-in: not requested
-    assert out is m  # unchanged, not dequantized
-    assert any("native 'mxfp4'" in r.message for r in caplog.records)
+def test_plan_load_time_format_sets_flag():
+    qc = _LoadTimeConfig("mxfp4")
+    kind, out = plan_upcast(qc, ["mxfp4"])
+    assert kind == "load"
+    assert out is qc and qc.dequantize is True  # flag set for from_pretrained
 
 
-def test_quantized_and_requested_is_dequantized():
-    m = _Model("mxfp4")
-    out = maybe_upcast_native_quant(m, ["mxfp4"])
-    assert out is not m and out.dequantized is True
-    assert _native_quant_method(out) is None  # now dense
+def test_plan_post_load_format():
+    kind, method = plan_upcast(_PostLoadConfig("bitsandbytes"), ["any"])
+    assert kind == "post" and method == "bitsandbytes"
 
 
-def test_quantized_with_other_method_requested_errors():
-    m = _Model("mxfp4")
+def test_plan_quantized_but_other_method_requested_errors():
     with pytest.raises(T2NErrorMisuse, match="mxfp4"):
-        maybe_upcast_native_quant(m, ["fp8"])
+        plan_upcast(_LoadTimeConfig("mxfp4"), ["fp8"])
+
+
+def test_assert_dense_passes_when_dense():
+    assert_upcast_dense(_Model(), ["any"])  # no quant config, no quantizer
+    assert_upcast_dense(_Model(_LoadTimeConfig("mxfp4")), None)  # not requested → skip
+
+
+def test_assert_dense_raises_on_residual_quant():
+    # still reports a native method after up-cast → partial dequant
+    with pytest.raises(T2NErrorMisuse, match="partially-quantized|did not fully"):
+        assert_upcast_dense(_Model(_LoadTimeConfig("mxfp4")), ["any"])
+    # or a lingering hf_quantizer even if config was cleared
+    with pytest.raises(T2NErrorMisuse):
+        assert_upcast_dense(_Model(hf_quantizer=object()), ["any"])

--- a/packages/llm/tests/test_upcast_quant_gpu.py
+++ b/packages/llm/tests/test_upcast_quant_gpu.py
@@ -1,21 +1,29 @@
-"""GPU-only, opt-in end-to-end check for native-quant up-cast.
+"""GPU-only, opt-in end-to-end checks for native-quant up-cast.
 
-This exercises the *real* dequant path (not the pure decision logic covered by
-``test_upcast_quant.py``): mint a tiny MXFP4 model, then load it through
-``load_model(..., upcast_quant=["mxfp4"])`` and assert it comes back dense.
+These exercise the *real* dequant paths (not the pure decision logic covered by
+``test_upcast_quant.py``): mint a tiny quantized model, load it through
+``load_model(..., upcast_quant=[...])``, and assert it comes back dense.
 
-It is triple-gated so CI never runs it by accident:
-  1. lives in its own file, which the LLM ``tox`` CI does not collect (that CI
-     only runs ``test_llm_cli.py`` / ``test_load_retry.py``);
-  2. marked ``ci_skip`` so the ``-m "not ci_skip"`` lane deselects it;
-  3. skipped unless ``T2N_RUN_GPU_TESTS=1`` is explicitly set AND CUDA is
-     available — so even a GPU runner won't run it without deliberate opt-in.
+Both quantizer mechanisms are covered:
+  - **post-load** (bnb 4-bit → ``model.dequantize()``): any CUDA GPU.
+  - **load-time** (fp8 → ``dequantize=True`` at load): needs compute ≥ 8.9
+    (e.g. 4090/H100); skips on older GPUs, which auto-dequantize fp8 anyway.
 
-Run it manually on a CUDA box with:
+(mxfp4 is the headline format but a *tiny* mxfp4 model can't be serialized —
+transformers' mxfp4 packing assumes gpt-oss-scale dims — so the load-time branch
+is exercised here via fp8, which shares the exact same code path.)
+
+Triple-gated so CI never runs them by accident:
+  1. own file, not collected by the LLM ``tox`` CI;
+  2. ``ci_skip`` marker → deselected by the ``-m "not ci_skip"`` lane;
+  3. skipped unless ``T2N_RUN_GPU_TESTS=1`` AND CUDA is available.
+
+Run manually on a CUDA box with:
     T2N_RUN_GPU_TESTS=1 pytest tests/test_upcast_quant_gpu.py -v
 """
 
 import os
+from pathlib import Path
 
 import pytest
 
@@ -35,53 +43,97 @@ def _cuda_available() -> bool:
         return False
 
 
-@pytest.mark.skipif(
-    not _OPT_IN,
-    reason="opt-in GPU e2e test; set T2N_RUN_GPU_TESTS=1 to run",
-)
-@pytest.mark.skipif(not _cuda_available(), reason="requires CUDA")
-def test_load_model_upcasts_mxfp4_to_dense(tmp_path):
-    """Mint a tiny MXFP4 gpt-oss, then up-cast it to dense float on load."""
-    import torch
-    from transformers import AutoModelForCausalLM, GptOssConfig
-    from transformers.utils.quantization_config import Mxfp4Config
+def _cuda_ge_8_9() -> bool:
+    try:
+        import torch
 
-    # tiny gpt-oss (~0.4M params): 2 layers, 4 MoE experts, small dims.
-    cfg = GptOssConfig(
-        hidden_size=64,
-        intermediate_size=128,
+        if not torch.cuda.is_available():
+            return False
+        major, minor = torch.cuda.get_device_capability()
+        return (major, minor) >= (8, 9)
+    except Exception:
+        return False
+
+
+def _tiny_llama_dir(tmp_path: Path) -> Path:
+    from transformers import AutoModelForCausalLM, LlamaConfig
+
+    cfg = LlamaConfig(
+        hidden_size=256,
+        intermediate_size=512,
         num_hidden_layers=2,
-        num_attention_heads=4,
-        num_key_value_heads=2,
-        num_local_experts=4,
-        num_experts_per_tok=2,
+        num_attention_heads=8,
+        num_key_value_heads=8,
         vocab_size=512,
         max_position_embeddings=128,
     )
-    dense_dir = tmp_path / "dense"
-    AutoModelForCausalLM.from_config(cfg).save_pretrained(dense_dir)
+    d = tmp_path / "dense"
+    AutoModelForCausalLM.from_config(cfg).save_pretrained(d)
+    return d
 
-    # mint: quantize to MXFP4 (needs CUDA + triton kernels) and save.
-    quant_dir = tmp_path / "mxfp4"
-    quantized = AutoModelForCausalLM.from_pretrained(
-        dense_dir, quantization_config=Mxfp4Config(), device_map="cuda"
-    )
-    assert _native_quant_method(quantized) == "mxfp4"
-    quantized.save_pretrained(quant_dir)
-    del quantized
-    torch.cuda.empty_cache()
 
-    # the actual up-cast under test: load with the load-time dequant flag.
-    model = load_model(
-        local_dir=quant_dir,
-        upcast_quant=["mxfp4"],
-        force_module_dtype="bf16",
-    )
+def _assert_dense_and_runs(model, vocab_size=512):
+    import torch
 
-    # it must come back fully dense (no native quant, no lingering quantizer).
     assert _native_quant_method(model) is None
     assert getattr(model, "hf_quantizer", None) is None
-    # and still run a forward pass (dense, exportable).
-    model = model.to("cpu")
-    out = model(torch.tensor([[1, 2, 3]]))
-    assert out.logits.shape[-1] == cfg.vocab_size
+    out = model.to("cpu")(torch.tensor([[1, 2, 3]]))
+    assert out.logits.shape[-1] == vocab_size
+
+
+pytestmark_opt = pytest.mark.skipif(
+    not _OPT_IN, reason="opt-in GPU e2e; set T2N_RUN_GPU_TESTS=1"
+)
+
+
+@pytestmark_opt
+@pytest.mark.skipif(not _cuda_available(), reason="requires CUDA")
+def test_upcast_bnb_4bit_post_load(tmp_path):
+    """Post-load dequant branch: bnb-4bit → model.dequantize() → dense."""
+    import torch
+    from transformers import AutoModelForCausalLM, BitsAndBytesConfig
+
+    pytest.importorskip("bitsandbytes")
+    src = _tiny_llama_dir(tmp_path)
+    q = AutoModelForCausalLM.from_pretrained(
+        src,
+        quantization_config=BitsAndBytesConfig(load_in_4bit=True),
+        device_map="cuda",
+    )
+    assert _native_quant_method(q) == "bitsandbytes"
+    qdir = tmp_path / "bnb"
+    q.save_pretrained(qdir)
+    del q
+    torch.cuda.empty_cache()
+
+    model = load_model(
+        local_dir=qdir, upcast_quant=["bitsandbytes"], force_module_dtype="bf16"
+    )
+    _assert_dense_and_runs(model)
+
+
+@pytestmark_opt
+@pytest.mark.skipif(
+    not _cuda_ge_8_9(),
+    reason="fp8 needs compute >= 8.9 (older GPUs auto-dequantize fp8)",
+)
+def test_upcast_fp8_load_time(tmp_path):
+    """Load-time dequant branch: fp8 → dequantize=True at load → dense."""
+    import torch
+    from transformers import AutoModelForCausalLM
+    from transformers.utils.quantization_config import FineGrainedFP8Config
+
+    src = _tiny_llama_dir(tmp_path)
+    q = AutoModelForCausalLM.from_pretrained(
+        src, quantization_config=FineGrainedFP8Config(), device_map="cuda"
+    )
+    assert _native_quant_method(q) == "fp8"
+    qdir = tmp_path / "fp8"
+    q.save_pretrained(qdir)
+    del q
+    torch.cuda.empty_cache()
+
+    model = load_model(
+        local_dir=qdir, upcast_quant=["fp8"], force_module_dtype="bf16"
+    )
+    _assert_dense_and_runs(model)

--- a/packages/llm/tests/test_upcast_quant_gpu.py
+++ b/packages/llm/tests/test_upcast_quant_gpu.py
@@ -9,8 +9,8 @@ Both quantizer mechanisms are covered:
   - **load-time** (fp8 → ``dequantize=True`` at load): needs compute ≥ 8.9
     (e.g. 4090/H100); skips on older GPUs, which auto-dequantize fp8 anyway.
 
-(mxfp4 is the headline format but a *tiny* mxfp4 model can't be serialized —
-transformers' mxfp4 packing assumes gpt-oss-scale dims — so the load-time branch
+(mxfp4 is the headline format but a *tiny* mxfp4 model can't be serialized:
+transformers' mxfp4 packing assumes gpt-oss-scale dims, so the load-time branch
 is exercised here via fp8, which shares the exact same code path.)
 
 Triple-gated so CI never runs them by accident:

--- a/packages/llm/tests/test_upcast_quant_gpu.py
+++ b/packages/llm/tests/test_upcast_quant_gpu.py
@@ -1,0 +1,87 @@
+"""GPU-only, opt-in end-to-end check for native-quant up-cast.
+
+This exercises the *real* dequant path (not the pure decision logic covered by
+``test_upcast_quant.py``): mint a tiny MXFP4 model, then load it through
+``load_model(..., upcast_quant=["mxfp4"])`` and assert it comes back dense.
+
+It is triple-gated so CI never runs it by accident:
+  1. lives in its own file, which the LLM ``tox`` CI does not collect (that CI
+     only runs ``test_llm_cli.py`` / ``test_load_retry.py``);
+  2. marked ``ci_skip`` so the ``-m "not ci_skip"`` lane deselects it;
+  3. skipped unless ``T2N_RUN_GPU_TESTS=1`` is explicitly set AND CUDA is
+     available — so even a GPU runner won't run it without deliberate opt-in.
+
+Run it manually on a CUDA box with:
+    T2N_RUN_GPU_TESTS=1 pytest tests/test_upcast_quant_gpu.py -v
+"""
+
+import os
+
+import pytest
+
+from torch_to_nnef_llm.loader import _native_quant_method, load_model
+
+pytestmark = pytest.mark.ci_skip
+
+_OPT_IN = os.environ.get("T2N_RUN_GPU_TESTS") == "1"
+
+
+def _cuda_available() -> bool:
+    try:
+        import torch
+
+        return torch.cuda.is_available()
+    except Exception:
+        return False
+
+
+@pytest.mark.skipif(
+    not _OPT_IN,
+    reason="opt-in GPU e2e test; set T2N_RUN_GPU_TESTS=1 to run",
+)
+@pytest.mark.skipif(not _cuda_available(), reason="requires CUDA")
+def test_load_model_upcasts_mxfp4_to_dense(tmp_path):
+    """Mint a tiny MXFP4 gpt-oss, then up-cast it to dense float on load."""
+    import torch
+    from transformers import AutoModelForCausalLM, GptOssConfig
+    from transformers.utils.quantization_config import Mxfp4Config
+
+    # tiny gpt-oss (~0.4M params): 2 layers, 4 MoE experts, small dims.
+    cfg = GptOssConfig(
+        hidden_size=64,
+        intermediate_size=128,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        num_local_experts=4,
+        num_experts_per_tok=2,
+        vocab_size=512,
+        max_position_embeddings=128,
+    )
+    dense_dir = tmp_path / "dense"
+    AutoModelForCausalLM.from_config(cfg).save_pretrained(dense_dir)
+
+    # mint: quantize to MXFP4 (needs CUDA + triton kernels) and save.
+    quant_dir = tmp_path / "mxfp4"
+    quantized = AutoModelForCausalLM.from_pretrained(
+        dense_dir, quantization_config=Mxfp4Config(), device_map="cuda"
+    )
+    assert _native_quant_method(quantized) == "mxfp4"
+    quantized.save_pretrained(quant_dir)
+    del quantized
+    torch.cuda.empty_cache()
+
+    # the actual up-cast under test: load with the load-time dequant flag.
+    model = load_model(
+        local_dir=quant_dir,
+        upcast_quant=["mxfp4"],
+        force_module_dtype="bf16",
+    )
+
+    # it must come back fully dense (no native quant, no lingering quantizer).
+    assert _native_quant_method(model) is None
+    assert getattr(model, "hf_quantizer", None) is None
+    # and still run a forward pass (dense, exportable).
+    model = model.to("cpu")
+    out = model(torch.tensor([[1, 2, 3]]))
+    assert out.logits.shape[-1] == cfg.vocab_size

--- a/packages/llm/torch_to_nnef_llm/cli.py
+++ b/packages/llm/torch_to_nnef_llm/cli.py
@@ -145,7 +145,7 @@ def parser_cli(  # pylint: disable=too-many-positional-arguments
             help="opt-in: dequantize a natively-quantized model (fp8, fp4 / "
             "mxfp4, nf4, ...) to dense float before export, since tract cannot "
             "ingest those formats. Comma-separated quant methods to up-cast "
-            "(e.g. 'mxfp4', 'mxfp4,fp8') or 'any' for whatever the model ships. "
+            "(e.g. 'mxfp4', 'mxfp4,fp8') or 'any' for what the model ships. "
             "Combine with -dt to pick the float target, and optionally -c to "
             "then re-quantize to a tract-supported scheme.",
         )

--- a/packages/llm/torch_to_nnef_llm/cli.py
+++ b/packages/llm/torch_to_nnef_llm/cli.py
@@ -142,12 +142,13 @@ def parser_cli(  # pylint: disable=too-many-positional-arguments
         parser.add_argument(
             "--upcast-quant",
             default=None,
-            help="opt-in: dequantize a natively-quantized model (fp8, fp4 / "
-            "mxfp4, nf4, ...) to dense float before export, since tract cannot "
-            "ingest those formats. Comma-separated quant methods to up-cast "
-            "(e.g. 'mxfp4', 'mxfp4,fp8') or 'any' for what the model ships. "
-            "Combine with -dt to pick the float target, and optionally -c to "
-            "then re-quantize to a tract-supported scheme.",
+            help="opt-in: dequantize a natively-quantized model (mxfp4, fp8, "
+            "bitsandbytes, ...) to dense float before export, since tract "
+            "cannot ingest those formats. Comma-separated transformers quant "
+            "methods to up-cast (e.g. 'mxfp4', 'mxfp4,fp8') or 'any' for what "
+            "the model ships; values are the names from transformers' "
+            "QuantizationMethod. Combine with -dt to pick the float target, "
+            "and optionally -c to re-quantize to a tract-supported scheme.",
         )
 
         parser.add_argument(

--- a/packages/llm/torch_to_nnef_llm/cli.py
+++ b/packages/llm/torch_to_nnef_llm/cli.py
@@ -140,6 +140,17 @@ def parser_cli(  # pylint: disable=too-many-positional-arguments
         )
 
         parser.add_argument(
+            "--upcast-quant",
+            default=None,
+            help="opt-in: dequantize a natively-quantized model (fp8, fp4 / "
+            "mxfp4, nf4, ...) to dense float before export, since tract cannot "
+            "ingest those formats. Comma-separated quant methods to up-cast "
+            "(e.g. 'mxfp4', 'mxfp4,fp8') or 'any' for whatever the model ships. "
+            "Combine with -dt to pick the float target, and optionally -c to "
+            "then re-quantize to a tract-supported scheme.",
+        )
+
+        parser.add_argument(
             "--num-logits-to-keep",
             type=int,
             default=1,
@@ -313,6 +324,11 @@ def main():
     del kwargs["verbose"]
     if kwargs["device_map"] is not None and "{" in kwargs["device_map"]:
         kwargs["device_map"] = json.loads(kwargs["device_map"])
+    # comma-separated CLI string -> list of quant methods for the loader
+    if kwargs.get("upcast_quant"):
+        kwargs["upcast_quant"] = [
+            m.strip() for m in kwargs["upcast_quant"].split(",") if m.strip()
+        ]
     dump_llm(
         **kwargs,
         log_level=log_level,

--- a/packages/llm/torch_to_nnef_llm/exporter.py
+++ b/packages/llm/torch_to_nnef_llm/exporter.py
@@ -151,6 +151,7 @@ def _load_exporter_from(
     merge_peft: T.Optional[bool] = None,
     device_map: TYPE_OPTIONAL_DEVICE_MAP = None,
     trust_remote_code: bool = True,
+    upcast_quant: T.Optional[T.Sequence[str]] = None,
 ):
     if (
         is_forced_half_precision_model(force_inputs_dtype, force_module_dtype)
@@ -169,6 +170,7 @@ def _load_exporter_from(
         merge_peft=merge_peft,
         device_map=device_map,
         trust_remote_code=trust_remote_code,
+        upcast_quant=upcast_quant,
     )
     tokenizer = load_tokenizer(
         hf_model_causal.config,
@@ -1034,6 +1036,7 @@ def dump_llm(
     device_map: TYPE_OPTIONAL_DEVICE_MAP = None,
     hf_download_n_retries: int = DEFAULT_HF_DOWNLOAD_N_RETRIES,
     trust_remote_code: bool = True,
+    upcast_quant: T.Optional[T.Sequence[str]] = None,
     **kwargs,
 ) -> T.Tuple[T.Union[Path, None], LLMExporter]:
     """Util to export LLM model."""
@@ -1047,6 +1050,7 @@ def dump_llm(
         device_map=device_map,
         hf_download_n_retries=hf_download_n_retries,
         trust_remote_code=trust_remote_code,
+        upcast_quant=upcast_quant,
     )
     dump_kwargs = _normalize_dump_kwargs(kwargs)
     exporter.dump(**dump_kwargs)

--- a/packages/llm/torch_to_nnef_llm/loader.py
+++ b/packages/llm/torch_to_nnef_llm/loader.py
@@ -197,11 +197,15 @@ def assert_upcast_dense(model, requested: T.Optional[T.Sequence[str]]) -> None:
     remaining = _native_quant_method(model)
     has_quantizer = getattr(model, "hf_quantizer", None) is not None
     if remaining is not None or has_quantizer:
+        detail = (
+            f"native '{remaining}' quantization"
+            if remaining is not None
+            else "an active quantizer"
+        )
         raise T2NErrorMisuse(
-            "up-cast did not fully dequantize the model: it still reports "
-            f"native '{remaining}' quantization. tract cannot export a "
-            "partially-quantized model; this format may need a different "
-            "dequantization path."
+            f"up-cast did not fully dequantize the model: it still reports "
+            f"{detail}. tract cannot export a partially-quantized model; this "
+            "format may need a different dequantization path."
         )
 
 
@@ -214,6 +218,15 @@ def _peek_quant_config(config_source, trust_remote_code, transformers):
     """
     if config_source is None:
         return None
+    # For a local dir, resolve the same subdir the loader will use (config.json
+    # may be nested), so the peek doesn't miss the plan on those layouts.
+    if isinstance(config_source, Path):
+        try:
+            config_source = find_subdir_with_filename_in(
+                config_source, "config.json"
+            )
+        except T2NErrorNotFoundFile:
+            return None
     try:
         cfg = transformers.AutoConfig.from_pretrained(
             config_source, trust_remote_code=trust_remote_code
@@ -258,7 +271,18 @@ def _finish_upcast(model, plan, requested):
     """
     if plan[0] == "post":
         LOGGER.info("up-casting native '%s' post-load", plan[1])
-        model = model.dequantize()
+        # Only some quantizers (bnb, higgs) implement post-load dequantization;
+        # others raise NotImplementedError. Surface that as a clear T2NError
+        # rather than a cryptic crash from deep inside transformers.
+        try:
+            model = model.dequantize()
+        except NotImplementedError as exc:
+            raise T2NErrorMisuse(
+                f"native '{plan[1]}' quantization cannot be dequantized by "
+                "transformers (no dequantize support), so it cannot be "
+                "exported to tract. Use a checkpoint in a dequantizable format "
+                "(e.g. mxfp4, fp8, bitsandbytes) or an unquantized model."
+            ) from exc
     elif not requested and _native_quant_method(model) is not None:
         method = _native_quant_method(model)
         LOGGER.warning(

--- a/packages/llm/torch_to_nnef_llm/loader.py
+++ b/packages/llm/torch_to_nnef_llm/loader.py
@@ -391,6 +391,9 @@ def load_model(
     models you trust, or pass ``trust_remote_code=False`` (CLI
     ``--no-trust-remote-code``) to refuse it.
     """
+    # accept a str path from direct callers (the dump_llm path coerces upstream)
+    if local_dir is not None:
+        local_dir = Path(local_dir)
     if trust_remote_code:
         LOGGER.warning(
             "trust_remote_code is enabled: loading '%s' may execute arbitrary "

--- a/packages/llm/torch_to_nnef_llm/loader.py
+++ b/packages/llm/torch_to_nnef_llm/loader.py
@@ -52,17 +52,38 @@ TYPE_OPTIONAL_DEVICE_MAP = T.Optional[
 UPCAST_ANY = "any"
 
 
-def _native_quant_method(model) -> T.Optional[str]:
-    """The model's native quantization method as a lowercase string
-    (e.g. ``"mxfp4"``, ``"fp8"``, ``"fbgemm_fp8"``), or ``None`` if the model is
-    not pre-quantized. Reads ``config.quantization_config.quant_method``."""
-    qcfg = getattr(getattr(model, "config", None), "quantization_config", None)
-    if qcfg is None:
+def _as_quant_config(raw):
+    """Normalize a model/config's ``quantization_config`` to a config *object*.
+
+    ``AutoConfig`` may surface it as a plain dict; parse that into the proper
+    ``*Config`` subclass (which carries ``quant_method`` and, for load-time
+    dequant formats, a ``dequantize`` attribute). Returns ``None`` if absent.
+    """
+    if raw is None:
         return None
-    qm = getattr(qcfg, "quant_method", None)
+    if isinstance(raw, dict):
+        # pylint: disable-next=import-outside-toplevel
+        from transformers.quantizers.auto import AutoQuantizationConfig
+
+        return AutoQuantizationConfig.from_dict(raw)
+    return raw
+
+
+def _quant_method_of(quant_config) -> T.Optional[str]:
+    """Lowercased ``quant_method`` of a quantization config object, or ``None``."""
+    if quant_config is None:
+        return None
+    qm = getattr(quant_config, "quant_method", None)
     if qm is None:
         return None
     return str(getattr(qm, "value", qm)).lower()
+
+
+def _native_quant_method(model) -> T.Optional[str]:
+    """The model's native quantization method as a lowercase string, or ``None``
+    if it is not (or no longer) quantized."""
+    raw = getattr(getattr(model, "config", None), "quantization_config", None)
+    return _quant_method_of(_as_quant_config(raw))
 
 
 def should_upcast(quant_method: T.Optional[str], requested: T.Optional[T.Sequence[str]]) -> bool:
@@ -78,48 +99,73 @@ def should_upcast(quant_method: T.Optional[str], requested: T.Optional[T.Sequenc
     return UPCAST_ANY in wanted or quant_method in wanted
 
 
-def maybe_upcast_native_quant(model, requested: T.Optional[T.Sequence[str]]):
-    """Dequantize a natively-quantized model to dense float so tract can ingest
-    it — opt-in via ``requested``.
+# How a given quantizer can be dequantized in transformers:
+#   - "load"     : only via the config's ``dequantize=True`` flag, applied
+#                  during ``from_pretrained`` (e.g. mxfp4, fp8, metal).
+#   - "post"     : via ``model.dequantize()`` after load (e.g. bnb, higgs).
+# A config object exposing a ``dequantize`` attribute is load-time; otherwise we
+# attempt the post-load path (and verify the result is actually dense).
+def plan_upcast(quant_config, requested: T.Optional[T.Sequence[str]]):
+    """Decide *whether and how* to up-cast, before the real load. Pure.
 
-    Up-casting is **decompression** (the inverse of tract-side quantization): it
-    turns a model whose weights ship in a tract-unsupported format (fp8, fp4 /
-    mxfp4, nf4, …) into a plain float model. It is needed both to export such a
-    model directly (e.g. to f16) *and* before re-quantizing it to a
-    tract-supported scheme. The actual per-format dequant is delegated to
-    transformers' ``model.dequantize()`` (dispatched to the active quantizer),
-    so this stays generic across formats.
-
-    - not pre-quantized            → returned unchanged.
-    - quantized + method requested → dequantized to dense float.
-    - quantized + not requested    → returned unchanged, with a warning (tract
-      export will likely fail — opt-in means we never dequantize silently).
-    - quantized + a *different*
-      method requested              → error (the user asked to up-cast other
-      formats; this one would still break export, so fail loudly).
+    Returns one of:
+      - ``("none", None)``          — not quantized, or quantized but not
+        requested (caller should warn in the latter case).
+      - ``("load", quant_config)``  — load-time dequant; ``quant_config`` has had
+        ``dequantize=True`` set and should be passed to ``from_pretrained``.
+      - ``("post", method)``        — dequantize via ``model.dequantize()`` after
+        load.
+    Raises ``T2NErrorMisuse`` if the model is quantized in a format the caller
+    did *not* select (it would still break tract export — fail loudly).
     """
-    quant_method = _native_quant_method(model)
-    if quant_method is None:
-        return model  # dense already; nothing to do
+    method = _quant_method_of(quant_config)
+    if method is None:
+        return ("none", None)
     if not requested:
-        LOGGER.warning(
-            "model ships native '%s' quantization but --upcast was not "
-            "requested; tract export will likely fail. Pass upcast_quant=['%s'] "
-            "(or ['any']) to dequantize it to float first.",
-            quant_method,
-            quant_method,
-        )
-        return model
-    if not should_upcast(quant_method, requested):
+        return ("none", None)  # opt-in; caller warns that export will likely fail
+    if not should_upcast(method, requested):
         raise T2NErrorMisuse(
-            f"model is natively quantized as '{quant_method}', which tract "
-            f"cannot export, but up-cast was only requested for {list(requested)}. "
-            f"Add '{quant_method}' (or 'any') to upcast_quant to dequantize it."
+            f"model is natively quantized as '{method}', which tract cannot "
+            f"export, but up-cast was only requested for {list(requested)}. "
+            f"Add '{method}' (or 'any') to upcast_quant to dequantize it."
         )
-    LOGGER.info("up-casting native '%s' quantization to dense float", quant_method)
-    # transformers owns the per-format dequant; this returns a dense float model.
-    model = model.dequantize()
-    return model
+    if hasattr(quant_config, "dequantize"):
+        quant_config.dequantize = True
+        return ("load", quant_config)
+    return ("post", method)
+
+
+def assert_upcast_dense(model, requested: T.Optional[T.Sequence[str]]) -> None:
+    """After an up-cast was requested, fail loudly if the model is still (even
+    partially) natively quantized — so a format that only dequantized some
+    weights surfaces here, not as an opaque tract error downstream."""
+    if not requested:
+        return
+    remaining = _native_quant_method(model)
+    if remaining is not None or getattr(model, "hf_quantizer", None) is not None:
+        raise T2NErrorMisuse(
+            "up-cast did not fully dequantize the model: it still reports native "
+            f"'{remaining}' quantization after dequantization. tract cannot "
+            "export a partially-quantized model. This format may need a "
+            "different dequantization path."
+        )
+
+
+def _peek_quant_config(config_source, trust_remote_code, transformers):
+    """Read a model's ``quantization_config`` (as a config object) *before*
+    loading the weights, so a load-time dequant flag can be injected into
+    ``from_pretrained``. Returns ``None`` if the source has no quant config or
+    can't be read (the caller then proceeds without load-time up-cast)."""
+    if config_source is None:
+        return None
+    try:
+        cfg = transformers.AutoConfig.from_pretrained(
+            config_source, trust_remote_code=trust_remote_code
+        )
+    except Exception as exp:  # pragma: no cover - network/path dependent
+        LOGGER.warning("could not read config to plan up-cast: %s", exp)
+        return None
+    return _as_quant_config(getattr(cfg, "quantization_config", None))
 
 
 def find_subdir_with_filename_in(dirpath: Path, filename: str) -> Path:
@@ -363,6 +409,27 @@ def load_model(
         kwargs["device_map"] = device_map
 
     custom_config = CUSTOM_CONFIGS.get(hf_model_slug or "")
+
+    # Plan native-quant up-cast (fp8/fp4/mxfp4/… -> dense float) BEFORE loading,
+    # because some formats (mxfp4, fp8, metal) can only be dequantized via the
+    # config's `dequantize=True` flag at `from_pretrained` time, while others
+    # (bnb, higgs) dequantize post-load. Custom (un-initialized) configs are
+    # never pre-quantized, so skip the peek there.
+    upcast_plan = ("none", None)
+    if upcast_quant and custom_config is None:
+        config_source = local_dir if local_dir is not None else hf_model_slug
+        quant_config = _peek_quant_config(
+            config_source, trust_remote_code, transformers
+        )
+        method = _quant_method_of(quant_config)
+        if method is None:
+            LOGGER.info("up-cast requested but model is not natively quantized")
+        else:
+            upcast_plan = plan_upcast(quant_config, upcast_quant)
+            if upcast_plan[0] == "load":
+                LOGGER.info("up-casting native '%s' at load time", method)
+                kwargs["quantization_config"] = upcast_plan[1]
+
     if custom_config is not None:
         hf_model_causal = transformers.AutoModelForCausalLM.from_config(
             custom_config, **kwargs
@@ -405,9 +472,25 @@ def load_model(
                 hf_model_causal.__class__,
             )
 
-    # Dequantize a natively-quantized model (fp8/mxfp4/…) to dense float BEFORE
-    # the dtype cast below — `.to(dtype)` does not dequantize quantized params.
-    hf_model_causal = maybe_upcast_native_quant(hf_model_causal, upcast_quant)
+    # Native-quant up-cast to dense float, completed BEFORE the dtype cast below
+    # (`.to(dtype)` does not dequantize quantized params):
+    #   - "load" formats were already dequantized during from_pretrained above;
+    #   - "post" formats (bnb/higgs) dequantize here via model.dequantize();
+    #   - then verify the model is actually dense (catches partial dequant).
+    # A model that is quantized but for which up-cast was NOT requested is left
+    # as-is with a warning (opt-in: never dequantize silently).
+    if upcast_plan[0] == "post":
+        LOGGER.info("up-casting native '%s' post-load", upcast_plan[1])
+        hf_model_causal = hf_model_causal.dequantize()
+    elif not upcast_quant and _native_quant_method(hf_model_causal) is not None:
+        LOGGER.warning(
+            "model ships native '%s' quantization but upcast_quant was not "
+            "requested; tract export will likely fail. Pass upcast_quant=['%s'] "
+            "(or ['any']) to dequantize it to float first.",
+            _native_quant_method(hf_model_causal),
+            _native_quant_method(hf_model_causal),
+        )
+    assert_upcast_dense(hf_model_causal, upcast_quant)
 
     if force_module_dtype is not None:
         force_dtype = DtypeStr(force_module_dtype).torch_dtype

--- a/packages/llm/torch_to_nnef_llm/loader.py
+++ b/packages/llm/torch_to_nnef_llm/loader.py
@@ -109,11 +109,26 @@ def _normalize_upcast_request(
     (validated through transformers' own ``QuantizationMethod`` enum, the single
     source of truth, so it stays in sync across versions). Returns the
     lowercased canonical values, or ``None`` when nothing was requested. Raises
-    ``T2NErrorMisuse`` on an unknown method, before any download or model load.
+    ``T2NErrorMisuse`` on an unknown method or a too-old transformers, before
+    any download or model load.
     """
     if not requested:
         return None
     # lazy import: transformers is an optional extra of this package
+    # pylint: disable-next=import-outside-toplevel
+    import transformers
+
+    # up-cast relies on the quantizer dequantization API
+    # (`AutoQuantizationConfig` / `model.dequantize()`), introduced with the
+    # HfQuantizer refactor in transformers 4.38.0. Older versions lack
+    # `transformers.quantizers`, so fail here with a clear message instead of a
+    # cryptic ModuleNotFoundError later.
+    if SemanticVersion.from_str(transformers.__version__) < "4.38.0":
+        raise T2NErrorMisuse(
+            "upcast_quant requires transformers >= 4.38.0 (quantizer "
+            f"dequantization API); installed: {transformers.__version__}. "
+            "Upgrade transformers, or drop upcast_quant."
+        )
     # pylint: disable-next=import-outside-toplevel
     from transformers.utils.quantization_config import QuantizationMethod
 

--- a/packages/llm/torch_to_nnef_llm/loader.py
+++ b/packages/llm/torch_to_nnef_llm/loader.py
@@ -47,6 +47,81 @@ TYPE_OPTIONAL_DEVICE_MAP = T.Optional[
 ]
 
 
+# sentinel accepted by `upcast_quant` to dequantize whatever native format the
+# model ships, without naming it.
+UPCAST_ANY = "any"
+
+
+def _native_quant_method(model) -> T.Optional[str]:
+    """The model's native quantization method as a lowercase string
+    (e.g. ``"mxfp4"``, ``"fp8"``, ``"fbgemm_fp8"``), or ``None`` if the model is
+    not pre-quantized. Reads ``config.quantization_config.quant_method``."""
+    qcfg = getattr(getattr(model, "config", None), "quantization_config", None)
+    if qcfg is None:
+        return None
+    qm = getattr(qcfg, "quant_method", None)
+    if qm is None:
+        return None
+    return str(getattr(qm, "value", qm)).lower()
+
+
+def should_upcast(quant_method: T.Optional[str], requested: T.Optional[T.Sequence[str]]) -> bool:
+    """Whether a model quantized with ``quant_method`` should be dequantized
+    given the user's ``requested`` selection.
+
+    Pure decision (no model needed) so it is unit-testable. ``requested`` is the
+    opt-in list of methods to up-cast; the ``"any"`` sentinel matches all.
+    """
+    if quant_method is None or not requested:
+        return False
+    wanted = {str(r).lower() for r in requested}
+    return UPCAST_ANY in wanted or quant_method in wanted
+
+
+def maybe_upcast_native_quant(model, requested: T.Optional[T.Sequence[str]]):
+    """Dequantize a natively-quantized model to dense float so tract can ingest
+    it — opt-in via ``requested``.
+
+    Up-casting is **decompression** (the inverse of tract-side quantization): it
+    turns a model whose weights ship in a tract-unsupported format (fp8, fp4 /
+    mxfp4, nf4, …) into a plain float model. It is needed both to export such a
+    model directly (e.g. to f16) *and* before re-quantizing it to a
+    tract-supported scheme. The actual per-format dequant is delegated to
+    transformers' ``model.dequantize()`` (dispatched to the active quantizer),
+    so this stays generic across formats.
+
+    - not pre-quantized            → returned unchanged.
+    - quantized + method requested → dequantized to dense float.
+    - quantized + not requested    → returned unchanged, with a warning (tract
+      export will likely fail — opt-in means we never dequantize silently).
+    - quantized + a *different*
+      method requested              → error (the user asked to up-cast other
+      formats; this one would still break export, so fail loudly).
+    """
+    quant_method = _native_quant_method(model)
+    if quant_method is None:
+        return model  # dense already; nothing to do
+    if not requested:
+        LOGGER.warning(
+            "model ships native '%s' quantization but --upcast was not "
+            "requested; tract export will likely fail. Pass upcast_quant=['%s'] "
+            "(or ['any']) to dequantize it to float first.",
+            quant_method,
+            quant_method,
+        )
+        return model
+    if not should_upcast(quant_method, requested):
+        raise T2NErrorMisuse(
+            f"model is natively quantized as '{quant_method}', which tract "
+            f"cannot export, but up-cast was only requested for {list(requested)}. "
+            f"Add '{quant_method}' (or 'any') to upcast_quant to dequantize it."
+        )
+    LOGGER.info("up-casting native '%s' quantization to dense float", quant_method)
+    # transformers owns the per-format dequant; this returns a dense float model.
+    model = model.dequantize()
+    return model
+
+
 def find_subdir_with_filename_in(dirpath: Path, filename: str) -> Path:
     """Find a subdir with filename in it."""
     found_dirs = {p.parent for p in dirpath.glob(f"**/{filename}")}
@@ -250,6 +325,7 @@ def load_model(
     merge_peft: T.Optional[bool] = None,
     device_map: TYPE_OPTIONAL_DEVICE_MAP = None,
     trust_remote_code: bool = True,
+    upcast_quant: T.Optional[T.Sequence[str]] = None,
     *,
     transformers: InjectedTransformersModule = INJECTED,
 ):
@@ -328,6 +404,10 @@ def load_model(
                 "no 'Peft' model found: %s (so no merge applied)",
                 hf_model_causal.__class__,
             )
+
+    # Dequantize a natively-quantized model (fp8/mxfp4/…) to dense float BEFORE
+    # the dtype cast below — `.to(dtype)` does not dequantize quantized params.
+    hf_model_causal = maybe_upcast_native_quant(hf_model_causal, upcast_quant)
 
     if force_module_dtype is not None:
         force_dtype = DtypeStr(force_module_dtype).torch_dtype

--- a/packages/llm/torch_to_nnef_llm/loader.py
+++ b/packages/llm/torch_to_nnef_llm/loader.py
@@ -100,6 +100,40 @@ def should_upcast(
     return UPCAST_ANY in wanted or quant_method in wanted
 
 
+def _normalize_upcast_request(
+    requested: T.Optional[T.Sequence[str]],
+) -> T.Optional[T.List[str]]:
+    """Validate + normalize the requested up-cast methods, up-front.
+
+    Each entry must be the ``"any"`` sentinel or a method transformers knows
+    (validated through transformers' own ``QuantizationMethod`` enum, the single
+    source of truth, so it stays in sync across versions). Returns the
+    lowercased canonical values, or ``None`` when nothing was requested. Raises
+    ``T2NErrorMisuse`` on an unknown method, before any download or model load.
+    """
+    if not requested:
+        return None
+    # lazy import: transformers is an optional extra of this package
+    # pylint: disable-next=import-outside-toplevel
+    from transformers.utils.quantization_config import QuantizationMethod
+
+    normalized: T.List[str] = []
+    for raw in requested:
+        value = str(raw).lower()
+        if value == UPCAST_ANY:
+            normalized.append(value)
+            continue
+        try:
+            normalized.append(QuantizationMethod(value).value)
+        except ValueError as exc:
+            valid = [m.value for m in QuantizationMethod] + [UPCAST_ANY]
+            raise T2NErrorMisuse(
+                f"unknown upcast_quant method '{value}'; valid methods are "
+                f"{valid}"
+            ) from exc
+    return normalized
+
+
 # How a given quantizer can be dequantized in transformers:
 #   - "load": only via the config's ``dequantize=True`` flag, applied during
 #             ``from_pretrained`` (e.g. mxfp4, fp8, metal).
@@ -438,6 +472,8 @@ def load_model(
     models you trust, or pass ``trust_remote_code=False`` (CLI
     ``--no-trust-remote-code``) to refuse it.
     """
+    # validate requested up-cast methods up-front, before any download/load
+    upcast_quant = _normalize_upcast_request(upcast_quant)
     # accept a str path from direct callers (the dump_llm path coerces upstream)
     if local_dir is not None:
         local_dir = Path(local_dir)

--- a/packages/llm/torch_to_nnef_llm/loader.py
+++ b/packages/llm/torch_to_nnef_llm/loader.py
@@ -70,7 +70,7 @@ def _as_quant_config(raw):
 
 
 def _quant_method_of(quant_config) -> T.Optional[str]:
-    """Lowercased ``quant_method`` of a quantization config object, or ``None``."""
+    """Lowercased ``quant_method`` of a quant config object, or ``None``."""
     if quant_config is None:
         return None
     qm = getattr(quant_config, "quant_method", None)
@@ -80,15 +80,16 @@ def _quant_method_of(quant_config) -> T.Optional[str]:
 
 
 def _native_quant_method(model) -> T.Optional[str]:
-    """The model's native quantization method as a lowercase string, or ``None``
-    if it is not (or no longer) quantized."""
+    """Native quant method of a model, or ``None`` if (no longer) quantized."""
     raw = getattr(getattr(model, "config", None), "quantization_config", None)
     return _quant_method_of(_as_quant_config(raw))
 
 
-def should_upcast(quant_method: T.Optional[str], requested: T.Optional[T.Sequence[str]]) -> bool:
-    """Whether a model quantized with ``quant_method`` should be dequantized
-    given the user's ``requested`` selection.
+def should_upcast(
+    quant_method: T.Optional[str],
+    requested: T.Optional[T.Sequence[str]],
+) -> bool:
+    """Whether a ``quant_method`` model should be dequantized for ``requested``.
 
     Pure decision (no model needed) so it is unit-testable. ``requested`` is the
     opt-in list of methods to up-cast; the ``"any"`` sentinel matches all.
@@ -100,21 +101,22 @@ def should_upcast(quant_method: T.Optional[str], requested: T.Optional[T.Sequenc
 
 
 # How a given quantizer can be dequantized in transformers:
-#   - "load"     : only via the config's ``dequantize=True`` flag, applied
-#                  during ``from_pretrained`` (e.g. mxfp4, fp8, metal).
-#   - "post"     : via ``model.dequantize()`` after load (e.g. bnb, higgs).
+#   - "load": only via the config's ``dequantize=True`` flag, applied during
+#             ``from_pretrained`` (e.g. mxfp4, fp8, metal).
+#   - "post": via ``model.dequantize()`` after load (e.g. bnb, higgs).
 # A config object exposing a ``dequantize`` attribute is load-time; otherwise we
 # attempt the post-load path (and verify the result is actually dense).
 def plan_upcast(quant_config, requested: T.Optional[T.Sequence[str]]):
     """Decide *whether and how* to up-cast, before the real load. Pure.
 
     Returns one of:
-      - ``("none", None)``          — not quantized, or quantized but not
+      - ``("none", None)``         — not quantized, or quantized but not
         requested (caller should warn in the latter case).
-      - ``("load", quant_config)``  — load-time dequant; ``quant_config`` has had
-        ``dequantize=True`` set and should be passed to ``from_pretrained``.
-      - ``("post", method)``        — dequantize via ``model.dequantize()`` after
+      - ``("load", quant_config)`` — load-time dequant; ``quant_config`` has had
+        ``dequantize=True`` set, to pass to ``from_pretrained``.
+      - ``("post", method)``       — dequantize via ``model.dequantize()`` after
         load.
+
     Raises ``T2NErrorMisuse`` if the model is quantized in a format the caller
     did *not* select (it would still break tract export — fail loudly).
     """
@@ -122,7 +124,8 @@ def plan_upcast(quant_config, requested: T.Optional[T.Sequence[str]]):
     if method is None:
         return ("none", None)
     if not requested:
-        return ("none", None)  # opt-in; caller warns that export will likely fail
+        # opt-in; the caller warns that export will likely fail
+        return ("none", None)
     if not should_upcast(method, requested):
         raise T2NErrorMisuse(
             f"model is natively quantized as '{method}', which tract cannot "
@@ -135,27 +138,34 @@ def plan_upcast(quant_config, requested: T.Optional[T.Sequence[str]]):
     return ("post", method)
 
 
-def assert_upcast_dense(model, requested: T.Optional[T.Sequence[str]]) -> None:
-    """After an up-cast was requested, fail loudly if the model is still (even
-    partially) natively quantized — so a format that only dequantized some
-    weights surfaces here, not as an opaque tract error downstream."""
+def assert_upcast_dense(
+    model, requested: T.Optional[T.Sequence[str]]
+) -> None:
+    """Fail loudly if an up-casted model is still (even partially) quantized.
+
+    Catches a format that only dequantized some weights here, rather than as an
+    opaque tract error downstream. No-op when up-cast was not requested.
+    """
     if not requested:
         return
     remaining = _native_quant_method(model)
-    if remaining is not None or getattr(model, "hf_quantizer", None) is not None:
+    has_quantizer = getattr(model, "hf_quantizer", None) is not None
+    if remaining is not None or has_quantizer:
         raise T2NErrorMisuse(
-            "up-cast did not fully dequantize the model: it still reports native "
-            f"'{remaining}' quantization after dequantization. tract cannot "
-            "export a partially-quantized model. This format may need a "
-            "different dequantization path."
+            "up-cast did not fully dequantize the model: it still reports "
+            f"native '{remaining}' quantization. tract cannot export a "
+            "partially-quantized model; this format may need a different "
+            "dequantization path."
         )
 
 
 def _peek_quant_config(config_source, trust_remote_code, transformers):
-    """Read a model's ``quantization_config`` (as a config object) *before*
-    loading the weights, so a load-time dequant flag can be injected into
-    ``from_pretrained``. Returns ``None`` if the source has no quant config or
-    can't be read (the caller then proceeds without load-time up-cast)."""
+    """Read a model's ``quantization_config`` (as a config object) before load.
+
+    Lets a load-time dequant flag be injected into ``from_pretrained``. Returns
+    ``None`` if the source has no quant config or can't be read (the caller then
+    proceeds without load-time up-cast).
+    """
     if config_source is None:
         return None
     try:
@@ -485,8 +495,8 @@ def load_model(
     elif not upcast_quant and _native_quant_method(hf_model_causal) is not None:
         LOGGER.warning(
             "model ships native '%s' quantization but upcast_quant was not "
-            "requested; tract export will likely fail. Pass upcast_quant=['%s'] "
-            "(or ['any']) to dequantize it to float first.",
+            "requested; tract export will likely fail. Pass upcast_quant=['%s']"
+            " (or ['any']) to dequantize it to float first.",
             _native_quant_method(hf_model_causal),
             _native_quant_method(hf_model_causal),
         )

--- a/packages/llm/torch_to_nnef_llm/loader.py
+++ b/packages/llm/torch_to_nnef_llm/loader.py
@@ -110,15 +110,14 @@ def plan_upcast(quant_config, requested: T.Optional[T.Sequence[str]]):
     """Decide *whether and how* to up-cast, before the real load. Pure.
 
     Returns one of:
-      - ``("none", None)``         — not quantized, or quantized but not
-        requested (caller should warn in the latter case).
-      - ``("load", quant_config)`` — load-time dequant; ``quant_config`` has had
+      - ``("none", None)``: not quantized, or quantized but not requested
+        (caller should warn in the latter case).
+      - ``("load", quant_config)``: load-time dequant; ``quant_config`` has had
         ``dequantize=True`` set, to pass to ``from_pretrained``.
-      - ``("post", method)``       — dequantize via ``model.dequantize()`` after
-        load.
+      - ``("post", method)``: dequantize via ``model.dequantize()`` after load.
 
     Raises ``T2NErrorMisuse`` if the model is quantized in a format the caller
-    did *not* select (it would still break tract export — fail loudly).
+    did *not* select (it would still break tract export, so fail loudly).
     """
     method = _quant_method_of(quant_config)
     if method is None:
@@ -170,10 +169,58 @@ def _peek_quant_config(config_source, trust_remote_code, transformers):
         cfg = transformers.AutoConfig.from_pretrained(
             config_source, trust_remote_code=trust_remote_code
         )
-    except Exception as exp:  # pragma: no cover - network/path dependent
+    # best-effort: any failure to read the config just means "no load-time plan"
+    except (OSError, ValueError, ImportError, KeyError) as exp:
         LOGGER.warning("could not read config to plan up-cast: %s", exp)
         return None
     return _as_quant_config(getattr(cfg, "quantization_config", None))
+
+
+def _plan_and_inject_upcast(
+    config_source, requested, kwargs, trust_remote_code, transformers
+):
+    """Plan a native-quant up-cast before load; inject the load-time flag.
+
+    For load-time formats (mxfp4/fp8/metal) sets ``quantization_config`` (with
+    ``dequantize=True``) in ``kwargs``. Returns the plan for the post-load step.
+    """
+    if not requested or config_source is None:
+        return ("none", None)
+    quant_config = _peek_quant_config(
+        config_source, trust_remote_code, transformers
+    )
+    method = _quant_method_of(quant_config)
+    if method is None:
+        LOGGER.info("up-cast requested but model is not natively quantized")
+        return ("none", None)
+    plan = plan_upcast(quant_config, requested)
+    if plan[0] == "load":
+        LOGGER.info("up-casting native '%s' at load time", method)
+        kwargs["quantization_config"] = plan[1]
+    return plan
+
+
+def _finish_upcast(model, plan, requested):
+    """Complete the up-cast after load and verify the model is dense.
+
+    "load" formats were already dequantized during ``from_pretrained``; "post"
+    formats (bnb/higgs) dequantize here. A quantized model for which up-cast was
+    not requested is left as-is with a warning (opt-in: never silent).
+    """
+    if plan[0] == "post":
+        LOGGER.info("up-casting native '%s' post-load", plan[1])
+        model = model.dequantize()
+    elif not requested and _native_quant_method(model) is not None:
+        method = _native_quant_method(model)
+        LOGGER.warning(
+            "model ships native '%s' quantization but upcast_quant was not "
+            "requested; tract export will likely fail. Pass upcast_quant=['%s']"
+            " (or ['any']) to dequantize it to float first.",
+            method,
+            method,
+        )
+    assert_upcast_dense(model, requested)
+    return model
 
 
 def find_subdir_with_filename_in(dirpath: Path, filename: str) -> Path:
@@ -421,25 +468,16 @@ def load_model(
 
     custom_config = CUSTOM_CONFIGS.get(hf_model_slug or "")
 
-    # Plan native-quant up-cast (fp8/fp4/mxfp4/… -> dense float) BEFORE loading,
-    # because some formats (mxfp4, fp8, metal) can only be dequantized via the
-    # config's `dequantize=True` flag at `from_pretrained` time, while others
-    # (bnb, higgs) dequantize post-load. Custom (un-initialized) configs are
-    # never pre-quantized, so skip the peek there.
-    upcast_plan = ("none", None)
-    if upcast_quant and custom_config is None:
-        config_source = local_dir if local_dir is not None else hf_model_slug
-        quant_config = _peek_quant_config(
-            config_source, trust_remote_code, transformers
-        )
-        method = _quant_method_of(quant_config)
-        if method is None:
-            LOGGER.info("up-cast requested but model is not natively quantized")
-        else:
-            upcast_plan = plan_upcast(quant_config, upcast_quant)
-            if upcast_plan[0] == "load":
-                LOGGER.info("up-casting native '%s' at load time", method)
-                kwargs["quantization_config"] = upcast_plan[1]
+    # Plan native-quant up-cast (fp8/fp4/mxfp4/... to dense float) before load,
+    # and inject the load-time dequant flag into kwargs when applicable.
+    config_source = local_dir if local_dir is not None else hf_model_slug
+    upcast_plan = _plan_and_inject_upcast(
+        config_source if custom_config is None else None,
+        upcast_quant,
+        kwargs,
+        trust_remote_code,
+        transformers,
+    )
 
     if custom_config is not None:
         hf_model_causal = transformers.AutoModelForCausalLM.from_config(
@@ -483,25 +521,9 @@ def load_model(
                 hf_model_causal.__class__,
             )
 
-    # Native-quant up-cast to dense float, completed BEFORE the dtype cast below
-    # (`.to(dtype)` does not dequantize quantized params):
-    #   - "load" formats were already dequantized during from_pretrained above;
-    #   - "post" formats (bnb/higgs) dequantize here via model.dequantize();
-    #   - then verify the model is actually dense (catches partial dequant).
-    # A model that is quantized but for which up-cast was NOT requested is left
-    # as-is with a warning (opt-in: never dequantize silently).
-    if upcast_plan[0] == "post":
-        LOGGER.info("up-casting native '%s' post-load", upcast_plan[1])
-        hf_model_causal = hf_model_causal.dequantize()
-    elif not upcast_quant and _native_quant_method(hf_model_causal) is not None:
-        LOGGER.warning(
-            "model ships native '%s' quantization but upcast_quant was not "
-            "requested; tract export will likely fail. Pass upcast_quant=['%s']"
-            " (or ['any']) to dequantize it to float first.",
-            _native_quant_method(hf_model_causal),
-            _native_quant_method(hf_model_causal),
-        )
-    assert_upcast_dense(hf_model_causal, upcast_quant)
+    # Finish the up-cast (post-load dequant + dense verification) before the
+    # dtype cast below, since `.to(dtype)` does not dequantize quantized params.
+    hf_model_causal = _finish_upcast(hf_model_causal, upcast_plan, upcast_quant)
 
     if force_module_dtype is not None:
         force_dtype = DtypeStr(force_module_dtype).torch_dtype

--- a/packages/llm/torch_to_nnef_llm/loader.py
+++ b/packages/llm/torch_to_nnef_llm/loader.py
@@ -138,9 +138,7 @@ def plan_upcast(quant_config, requested: T.Optional[T.Sequence[str]]):
     return ("post", method)
 
 
-def assert_upcast_dense(
-    model, requested: T.Optional[T.Sequence[str]]
-) -> None:
+def assert_upcast_dense(model, requested: T.Optional[T.Sequence[str]]) -> None:
     """Fail loudly if an up-casted model is still (even partially) quantized.
 
     Catches a format that only dequantized some weights here, rather than as an

--- a/packages/llm/torch_to_nnef_llm/loader.py
+++ b/packages/llm/torch_to_nnef_llm/loader.py
@@ -114,6 +114,10 @@ def _normalize_upcast_request(
     """
     if not requested:
         return None
+    # a bare string is a common caller mistake; treat it as a single method
+    # rather than iterating it per-character.
+    if isinstance(requested, str):
+        requested = [requested]
     # lazy import: transformers is an optional extra of this package
     # pylint: disable-next=import-outside-toplevel
     import transformers
@@ -227,15 +231,17 @@ def _peek_quant_config(config_source, trust_remote_code, transformers):
             )
         except T2NErrorNotFoundFile:
             return None
+    # best-effort: any failure to read/parse the config (incl. a quant_method
+    # this transformers version doesn't know, which makes `from_dict` raise)
+    # just means "no load-time plan" rather than an error.
     try:
         cfg = transformers.AutoConfig.from_pretrained(
             config_source, trust_remote_code=trust_remote_code
         )
-    # best-effort: any failure to read the config just means "no load-time plan"
+        return _as_quant_config(getattr(cfg, "quantization_config", None))
     except (OSError, ValueError, ImportError, KeyError) as exp:
         LOGGER.warning("could not read config to plan up-cast: %s", exp)
         return None
-    return _as_quant_config(getattr(cfg, "quantization_config", None))
 
 
 def _plan_and_inject_upcast(
@@ -271,12 +277,13 @@ def _finish_upcast(model, plan, requested):
     """
     if plan[0] == "post":
         LOGGER.info("up-casting native '%s' post-load", plan[1])
-        # Only some quantizers (bnb, higgs) implement post-load dequantization;
-        # others raise NotImplementedError. Surface that as a clear T2NError
-        # rather than a cryptic crash from deep inside transformers.
+        # Only some quantizers (bnb, higgs) implement post-load dequant; others
+        # raise NotImplementedError, and transformers raises ValueError if the
+        # model turned out not to carry a live quantizer. Surface either as a
+        # clear T2NError instead of a cryptic crash from inside transformers.
         try:
             model = model.dequantize()
-        except NotImplementedError as exc:
+        except (NotImplementedError, ValueError) as exc:
             raise T2NErrorMisuse(
                 f"native '{plan[1]}' quantization cannot be dequantized by "
                 "transformers (no dequantize support), so it cannot be "


### PR DESCRIPTION
## What

Adds an **opt-in** step to dequantize ("up-cast") a natively-quantized LLM to dense float before export, so models shipped in formats tract cannot ingest (mxfp4, fp8, bitsandbytes, ...) become exportable.

Up-cast is the inverse of the compression registry: it *decompresses* the source format. It is a **load-time** concern (the weights are materialized by transformers as custom quantized params that `.to(dtype)` will not dequantize), distinct from `-c/--compression-method`, which *compresses* a dense model to a tract scheme. The two compose: up-cast first, then optionally re-quantize.

## How

Opt-in and selective via `upcast_quant` (threaded `dump_llm` -> `LLMExporter.load` -> `_load_exporter_from` -> `load_model`), surfaced as the CLI flag `--upcast-quant` (comma-separated methods, or `any`):

- **Up-front validation** (`_normalize_upcast_request`), before any download: each value is validated through transformers' own `QuantizationMethod` enum (single source of truth, stays in sync across versions), plus the `any` sentinel. A bare string is accepted as one method. A typo fails immediately with the valid list. The feature requires transformers >= 4.38 (the quantizer dequantization API landed in 4.38.0, bisected); older versions raise a clear error instead of a cryptic `ModuleNotFoundError`.
- **Routing by mechanism** (`plan_upcast`), since transformers has two disjoint dequant paths:
  - **load-time** (`quantization_config.dequantize=True` passed to `from_pretrained`): mxfp4, fp8, metal.
  - **post-load** (`model.dequantize()` after load): bitsandbytes, higgs.
  - A config object exposing a `dequantize` attribute is load-time; otherwise post-load.
- **Failure modes are explicit:** a model quantized in a non-selected format errors loudly; a format transformers cannot dequantize raises a clear `T2NErrorMisuse` (not a bare `NotImplementedError`); after up-cast the model is verified fully dense (`assert_upcast_dense`) so a partial dequant is caught before tract sees it.
- A quantized model for which up-cast was not requested is left as-is with a warning (opt-in: never dequantize silently).

Two use cases:

```sh
# direct float export
t2n_export_llm_to_tract -s openai/gpt-oss-20b --upcast-quant mxfp4 -dt bf16 -e ./out
# prep for re-quantization to a tract scheme
t2n_export_llm_to_tract -s openai/gpt-oss-20b --upcast-quant mxfp4 -dt bf16 -c <tract_q4> -e ./out
```

## Tests

- `tests/test_upcast_quant.py`: 16 unit tests covering the pure decision logic (`should_upcast`, `plan_upcast`, `assert_upcast_dense`), `_normalize_upcast_request` (validation, version gate, bare-string), the resilience of `_peek_quant_config` to an unknown method, and the integration helpers (`_plan_and_inject_upcast`, `_finish_upcast`, including the clean error on a non-dequantizable format). Wired into the four `cli_transformers_*` tox envs, so they run across transformers 4.50/4.52/5.0/5.5.
- `tests/test_upcast_quant_gpu.py`: opt-in GPU end-to-end (bnb post-load on any CUDA GPU; fp8 load-time on compute >= 8.9). Triple-gated so CI never runs it (own file not in the tox command list; `ci_skip`; requires `T2N_RUN_GPU_TESTS=1` + CUDA).

## Validation status / caveats

- **Post-load branch validated end-to-end on GPU** (A10G): bnb-4bit quantize -> save -> `load_model(upcast_quant=["bitsandbytes"])` -> dense -> forward. PASSED.
- **Load-time branch (mxfp4/fp8)** is unit-tested and dispatch-tested; the real-weights e2e runs only on an Ada/Hopper GPU (>= 8.9), so it is not exercised on the A10G. A full gpt-oss-20b export is the next step once this merges.
- A *tiny* mxfp4 model cannot be serialized (transformers' mxfp4 packing assumes gpt-oss-scale dims), so the load-time branch is exercised via fp8, which shares the same code path.
