### PR TITLE
fix(llm): correct causal mask + position_ids for transformers>4.52.4 export

### DIFF
--- a/packages/llm/tests/test_causal_mask.py
+++ b/packages/llm/tests/test_causal_mask.py
@@ -1,0 +1,71 @@
+"""Non-regression tests for the export wrapper's explicit causal mask.
+
+Covers the ``force_causal_mask`` path (transformers > 4.52.4).
+
+Regression context: the mask was built from ``in_cache_key_0.shape[0]`` (the
+*batch* dim = 1), giving a degenerate ``[1, 1]`` mask that applies no causal
+masking and no past offset. Exported LLMs then attended non-causally during
+prefill -> garbage / empty generation in real (causal) inference, while the
+single-step IO check did not catch it.
+
+The mask must be ``[1, 1, S, S+P]`` (query length S, key length S+P) and
+causal-with-past: query i (absolute position P+i) attends to keys ``0..P+i``.
+"""
+
+from types import SimpleNamespace
+
+import torch
+
+from torch_to_nnef_llm.models.handlers.default import (
+    DefaultArchitectureHandler,
+)
+
+NEG = torch.finfo(torch.float32).min
+
+
+def _build_mask(seq_len, past_len, n_layers=2, heads=2, head_dim=8):
+    input_ids = torch.zeros(1, seq_len, dtype=torch.long)
+    past = []
+    for _ in range(n_layers):
+        # in_cache_key / in_cache_value: [batch, heads, past_len, head_dim]
+        past.append(torch.zeros(1, heads, past_len, head_dim))
+        past.append(torch.zeros(1, heads, past_len, head_dim))
+    inputs = (input_ids, *past)
+    wrapper = SimpleNamespace(force_causal_mask=True, with_dyn_cache=False)
+    out = DefaultArchitectureHandler().build_forward_inputs(
+        inputs=inputs, wrapper=wrapper
+    )
+    return out["attention_mask"]
+
+
+def _assert_causal(mask, seq_len, past_len):
+    assert mask is not None
+    assert tuple(mask.shape) == (1, 1, seq_len, seq_len + past_len), (
+        f"mask shape {tuple(mask.shape)} != "
+        f"{(1, 1, seq_len, seq_len + past_len)}"
+    )
+    m = mask[0, 0]
+    for i in range(seq_len):
+        for j in range(seq_len + past_len):
+            allowed = j <= past_len + i  # query i attends keys 0..P+i
+            if allowed:
+                assert m[i, j].item() == 0.0, (i, j, m[i, j].item())
+            else:
+                assert m[i, j].item() == NEG, (i, j, m[i, j].item())
+
+
+def test_causal_mask_prefill_no_past():
+    """Prefill (P=0): standard lower-triangular causal mask [S, S]."""
+    _assert_causal(_build_mask(seq_len=5, past_len=0), seq_len=5, past_len=0)
+
+
+def test_causal_mask_with_past():
+    """Decode/prefill-with-past (P>0): [S, S+P] with the past offset."""
+    _assert_causal(_build_mask(seq_len=4, past_len=3), seq_len=4, past_len=3)
+
+
+def test_causal_mask_single_token_decode():
+    """Single new token over a long past attends to everything before it."""
+    mask = _build_mask(seq_len=1, past_len=6)
+    assert tuple(mask.shape) == (1, 1, 1, 7)
+    assert (mask[0, 0, 0] == 0.0).all()  # the new token sees all 7 keys

--- a/packages/llm/torch_to_nnef_llm/models/handlers/default.py
+++ b/packages/llm/torch_to_nnef_llm/models/handlers/default.py
@@ -59,27 +59,50 @@ class DefaultArchitectureHandler(ArchitectureHandler):
         wrapper,
     ) -> T.Dict[str, T.Any]:
         attention_mask = None
+        position_ids = None
+        cache_position = None
         if getattr(wrapper, "force_causal_mask", False):
             attn_mask_dtype = torch.float32
-            seq_length = inputs[1].shape[0]
+            neg = torch.finfo(attn_mask_dtype).min
+            # Query length S (new tokens) from input_ids, past length P from
+            # the first KV cache tensor [batch, heads, P, head_dim].
+            seq_length = inputs[0].shape[1]
+            past_length = inputs[1].shape[2]
+            total_length = seq_length + past_length
+            # Absolute positions of the new tokens: P, P+1, ..., P+S-1. These
+            # drive RoPE; without them transformers (>4.52.4) infers positions
+            # that ignore the past, so decode RoPE is wrong and generation
+            # degenerates into repetition.
+            cache_position = torch.arange(
+                past_length, total_length, device=inputs[0].device
+            )
+            position_ids = cache_position.unsqueeze(0)
+            # Build the [S, S+P] causal-with-past additive mask from token
+            # POSITIONS (not a fixed-diagonal triu): query i sits at absolute
+            # position P+i and may attend to keys 0..P+i. Doing it via arange
+            # comparisons keeps it correct for any (S, P) at inference time;
+            # a baked triu diagonal (or the previous shape[0]=batch bug) made
+            # the mask degenerate and attention non-causal.
+            q_pos = cache_position.unsqueeze(1)
+            k_pos = torch.arange(total_length).unsqueeze(0)
+            future = (k_pos > q_pos).to(attn_mask_dtype)  # 1.0 where masked
             attention_mask = (
-                torch.triu(
-                    torch.full(
-                        [seq_length, seq_length],
-                        torch.finfo(attn_mask_dtype).min,
-                    ),
-                    diagonal=1,
-                )
+                (torch.full([seq_length, total_length], neg) * future)
                 .unsqueeze(0)
                 .unsqueeze(0)
-            ).to(attn_mask_dtype)
+                .to(attn_mask_dtype)
+            )
         if wrapper.with_dyn_cache:
             past_key_values = build_past_kv_dyn_cache(inputs[1:])
         else:
             past_key_values = build_past_kv_list(inputs[1:])
-        return {
+        model_inputs = {
             "input_ids": inputs[0],
             "past_key_values": past_key_values,
             "use_cache": True,
             "attention_mask": attention_mask,
         }
+        if position_ids is not None:
+            model_inputs["position_ids"] = position_ids
+            model_inputs["cache_position"] = cache_position
+        return model_inputs


### PR DESCRIPTION
## Problem

On the `force_causal_mask` path (used for transformers > 4.52.4), the export
wrapper built the attention mask from `inputs[1].shape[0]`. `inputs[1]` is the
first KV cache tensor `[batch, heads, P, head_dim]`, so `shape[0]` is the
**batch dim = 1**, not a sequence length. The mask came out as a degenerate
`[1, 1]`: no causal masking and no past offset.

Two consequences, neither caught by the single-step IO check (which only runs
one forward at one fixed shape):

1. Exported LLMs attended **non-causally** during prefill, so real (causal)
   generation produced garbage / empty output.
2. `position_ids` / `cache_position` were never passed. transformers 5.x then
   infers positions that ignore the past, so decode RoPE is wrong and
   generation degenerates into repetition.

This affected **all** current LLM exports (dense and MoE), independent of the
MoE work.

## Fix

`DefaultArchitectureHandler.build_forward_inputs` now:

- derives query length `S` from `input_ids` and past length `P` from the KV
  cache's sequence axis (`inputs[1].shape[2]`);
- builds the `[1, 1, S, S+P]` additive mask from token **positions** (arange
  comparisons), so it is causal-with-past and correct for any `(S, P)` rather
  than a baked-diagonal triu;
- passes `position_ids` / `cache_position` (`arange(P, P+S)`) so decode RoPE
  uses absolute positions.

## Tests

Adds `packages/llm/tests/test_causal_mask.py` with non-regression coverage:
prefill (P=0), prefill/decode with past (P>0), and single-token decode. They
assert the `[1, 1, S, S+P]` shape and per-cell causality (query i attends keys
`0..P+i`). The tests fail against the old code (degenerate `[1, 1]` mask) and
pass with the fix.

## Validation

End-to-end: a small MoE model (Granite-3.0-1B-A400M) exported with this fix
generates coherently in real inference ("The capital of France is Paris.",
coherent haiku/color list) where the pre-fix export produced garbage.