### PR TITLE
feat(llm): dynamic logits_to_keep as a runtime input

### DIFF
--- a/packages/llm/tests/test_llama.py
+++ b/packages/llm/tests/test_llama.py
@@ -3,6 +3,8 @@ from functools import partial
 
 import pytest
 import torch
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
 from tests.utils import (  # noqa: E402
     TRACT_INFERENCES_TO_TESTS_APPROX,
     TestSuiteInferenceExactnessBuilder,
@@ -11,10 +13,9 @@ from tests.utils import (  # noqa: E402
     set_seed,
     transformers_tract_export_test_condition,
 )
-from transformers import AutoModelForCausalLM, AutoTokenizer
-
 from torch_to_nnef.utils import torch_version
 from torch_to_nnef_llm.config import HFConfigHelper, LlamaSlugs
+from torch_to_nnef_llm.exporter import LLMExporter
 from torch_to_nnef_llm.models.base import BaseCausal
 
 set_seed(int(os.environ.get("SEED", 25)))
@@ -126,3 +127,25 @@ def test_llama_dynamic_logits_to_keep(num_logits_to_keep, inference_target):
         ],
         output_names=["logits", "out_cache_key_0", "out_cache_value_0"],
     )
+
+
+@pytest.mark.skipif(
+    torch_version() <= "1.13.0", reason="export needs torch > 1.13.0"
+)
+def test_llama_dynamic_logits_to_keep_export_spec():
+    """The LLMExporter spec path adds logits_to_keep as a plain input.
+
+    Guards the real CLI export path (generate_inputs_io_names_and_dynaxes),
+    which check_model_io_test bypasses: the extra scalar must be an input with
+    no matching output and no dynamic axis.
+    """
+    exporter = LLMExporter(
+        causal_llama, tokenizer, num_logits_to_keep="dynamic"
+    )
+    inputs, input_names, output_names, dynamic_axes = (
+        exporter.generate_inputs_io_names_and_dynaxes()
+    )
+    assert input_names[-1] == "logits_to_keep"
+    assert len(inputs) == len(input_names) == len(output_names) + 1
+    assert "logits_to_keep" not in output_names
+    assert "logits_to_keep" not in dynamic_axes

--- a/packages/llm/tests/test_llama.py
+++ b/packages/llm/tests/test_llama.py
@@ -72,3 +72,57 @@ def test_llama_export(id, test_input, model, inference_target):
     check_model_io_test(
         model=model, test_input=test_input, inference_target=inference_target
     )
+
+
+@pytest.mark.skipif(
+    torch_version() <= "1.13.0", reason="export needs torch > 1.13.0"
+)
+@pytest.mark.parametrize("num_logits_to_keep", [1, 3])
+@pytest.mark.parametrize(
+    "inference_target",
+    TRACT_INFERENCES_TO_TESTS_APPROX,
+    ids=[str(_) for _ in TRACT_INFERENCES_TO_TESTS_APPROX],
+)
+def test_llama_dynamic_logits_to_keep(num_logits_to_keep, inference_target):
+    """`logits_to_keep` exposed as a runtime input gathers the last k rows.
+
+    One export then serves prefill (pass 1) and speculative decode (pass k+1);
+    the scalar drives a tract_core_range + tract_core_gather, so the kept row
+    count is decided at run time instead of baked at export.
+    """
+    dyn_model = BaseCausal(
+        causal_llama,
+        handler=model_infos.handler,
+        with_dyn_cache=model_infos.handler.with_dyn_cache,
+        num_logits_to_keep="dynamic",
+    )
+    k = num_logits_to_keep
+    past_s = 10
+    # need at least k positions in the sequence to keep k rows
+    ids = tokenizer("Hello, I am happy today and", return_tensors="pt")
+    test_input = (
+        ids.input_ids[:, :k],
+        torch.rand((1, 2, past_s, 4)),
+        torch.rand((1, 2, past_s, 4)),
+        torch.tensor(k, dtype=torch.int64),
+    )
+    target = change_dynamic_axes(
+        inference_target,
+        dynamic_axes={
+            "input_ids": {1: "S"},
+            "in_cache_key_0": {2: "P"},
+            "in_cache_value_0": {2: "P"},
+        },
+    )
+    check_model_io_test(
+        model=dyn_model,
+        test_input=test_input,
+        inference_target=target,
+        input_names=[
+            "input_ids",
+            "in_cache_key_0",
+            "in_cache_value_0",
+            "logits_to_keep",
+        ],
+        output_names=["logits", "out_cache_key_0", "out_cache_value_0"],
+    )

--- a/packages/llm/tests/test_llama.py
+++ b/packages/llm/tests/test_llama.py
@@ -3,8 +3,6 @@ from functools import partial
 
 import pytest
 import torch
-from transformers import AutoModelForCausalLM, AutoTokenizer
-
 from tests.utils import (  # noqa: E402
     TRACT_INFERENCES_TO_TESTS_APPROX,
     TestSuiteInferenceExactnessBuilder,
@@ -13,6 +11,8 @@ from tests.utils import (  # noqa: E402
     set_seed,
     transformers_tract_export_test_condition,
 )
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
 from torch_to_nnef.utils import torch_version
 from torch_to_nnef_llm.config import HFConfigHelper, LlamaSlugs
 from torch_to_nnef_llm.exporter import LLMExporter

--- a/packages/llm/torch_to_nnef_llm/cli.py
+++ b/packages/llm/torch_to_nnef_llm/cli.py
@@ -26,6 +26,13 @@ from torch_to_nnef_llm.exporter import DEFAULT_HF_DOWNLOAD_N_RETRIES, dump_llm
 LOGGER = logging.getLogger(__name__)
 
 
+def _num_logits_to_keep(value: str) -> T.Union[int, str]:
+    """Accept an int row count or the literal 'dynamic' (runtime input)."""
+    if value == "dynamic":
+        return value
+    return int(value)
+
+
 def parser_cli(  # pylint: disable=too-many-positional-arguments
     fn_parser_adder: T.Optional[
         T.Callable[[argparse.ArgumentParser], None]
@@ -153,12 +160,13 @@ def parser_cli(  # pylint: disable=too-many-positional-arguments
 
         parser.add_argument(
             "--num-logits-to-keep",
-            type=int,
+            type=_num_logits_to_keep,
             default=1,
-            help="num_logits_to_keep: int number of token to keep "
-            "(if 0 all are kept) "
-            "by default for classical inference setting it to 1 is fine, "
-            "in case of speculative-decoding it may be more (typically 2 or 3)",
+            help="number of token logits to keep. An int slices the last N "
+            "positions at export (1 is fine for classical inference, 0 keeps "
+            "all). 'dynamic' instead exposes logits_to_keep as a runtime input "
+            "so one export serves both prefill (1) and speculative decode "
+            "(k+1) without re-exporting.",
         )
 
         parser.add_argument(

--- a/packages/llm/torch_to_nnef_llm/cli.py
+++ b/packages/llm/torch_to_nnef_llm/cli.py
@@ -22,13 +22,14 @@ from torch_to_nnef_llm.config import (
     PHISlugs,
 )
 from torch_to_nnef_llm.exporter import DEFAULT_HF_DOWNLOAD_N_RETRIES, dump_llm
+from torch_to_nnef_llm.models.base import DYNAMIC_LOGITS_TO_KEEP
 
 LOGGER = logging.getLogger(__name__)
 
 
 def _num_logits_to_keep(value: str) -> T.Union[int, str]:
-    """Accept an int row count or the literal 'dynamic' (runtime input)."""
-    if value == "dynamic":
+    """Accept an int row count or DYNAMIC_LOGITS_TO_KEEP (runtime input)."""
+    if value == DYNAMIC_LOGITS_TO_KEEP:
         return value
     return int(value)
 

--- a/packages/llm/torch_to_nnef_llm/exporter.py
+++ b/packages/llm/torch_to_nnef_llm/exporter.py
@@ -450,7 +450,12 @@ class LLMExporter:
             _,
         ) = self.generate_inputs_io_names_and_dynaxes()
         wrapped_outs = self.wrapped_model(*inputs)
-        model_inputs = self._prepare_hf_model_inputs(inputs)
+        hf_inputs = inputs
+        if getattr(self.wrapped_model, "dynamic_logits_to_keep", False):
+            # drop the trailing logits_to_keep scalar; the HF model builds its
+            # kv cache from input_ids + caches only.
+            hf_inputs = inputs[:-1]
+        model_inputs = self._prepare_hf_model_inputs(hf_inputs)
         outs = self.hf_model_causal(
             return_dict=True,
             **model_inputs,
@@ -520,8 +525,17 @@ class LLMExporter:
         input_names = input_spec.input_names
         output_names = input_spec.output_names
         dynamic_axes = input_spec.dynamic_axes
-        assert len(inputs) == len(input_names) == len(output_names), (
-            f"{len(inputs)} == {len(input_names)} == {len(output_names)}"
+        # dynamic logits_to_keep adds one extra input with no matching output
+        n_extra_inputs = (
+            1
+            if getattr(self.wrapped_model, "dynamic_logits_to_keep", False)
+            else 0
+        )
+        assert len(inputs) == len(input_names), (
+            f"{len(inputs)} == {len(input_names)}"
+        )
+        assert len(inputs) - n_extra_inputs == len(output_names), (
+            f"{len(inputs)} - {n_extra_inputs} == {len(output_names)}"
         )
         return (
             inputs,

--- a/packages/llm/torch_to_nnef_llm/exporter.py
+++ b/packages/llm/torch_to_nnef_llm/exporter.py
@@ -147,7 +147,7 @@ def _load_exporter_from(
     local_dir: T.Optional[Path] = None,
     force_module_dtype: T.Optional[DtypeStr] = None,
     force_inputs_dtype: T.Optional[DtypeStr] = None,
-    num_logits_to_keep: int = 1,
+    num_logits_to_keep: T.Union[int, str] = 1,
     merge_peft: T.Optional[bool] = None,
     device_map: TYPE_OPTIONAL_DEVICE_MAP = None,
     trust_remote_code: bool = True,
@@ -197,7 +197,7 @@ class LLMExporter:
         local_dir: T.Optional[Path] = None,
         force_module_dtype: T.Optional[DtypeStr] = None,
         force_inputs_dtype: T.Optional[DtypeStr] = None,
-        num_logits_to_keep: int = 1,
+        num_logits_to_keep: T.Union[int, str] = 1,
     ):
         """Init LLMExporter.
 
@@ -212,10 +212,11 @@ class LLMExporter:
                 Force PyTorch dtype in parameters.
             force_inputs_dtype:
                 Force PyTorch dtype in inputs of the models.
-            num_logits_to_keep: int number of token to keep (if 0 all are kept)
-                by default for classical inference setting it to 1 is fine,
-                in case of speculative decoding it may be more
-                (typically 2 or 3)
+            num_logits_to_keep: number of token logits to keep. An int slices
+                the last N positions at trace time (0 keeps all). The string
+                "dynamic" instead exposes `logits_to_keep` as a runtime scalar
+                input, so one export serves cheap prefill (pass 1) and
+                speculative decode (pass k+1) without re-exporting.
 
         """
         self.hf_model_causal = hf_model_causal
@@ -312,7 +313,7 @@ class LLMExporter:
         n_past_input_tokens: int = 2,
         real_kv_cache: T.Optional[T.List[torch.Tensor]] = None,
     ):
-        return self.model_infos.handler.build_input_spec(
+        input_spec = self.model_infos.handler.build_input_spec(
             tokenizer=self.tokenizer,
             config_helper=self.model_infos,
             inputs_dtype=self.inputs_dtype,
@@ -321,6 +322,15 @@ class LLMExporter:
             n_past_input_tokens=n_past_input_tokens,
             real_kv_cache=real_kv_cache,
         )
+        if getattr(self.wrapped_model, "dynamic_logits_to_keep", False):
+            # extra trailing scalar input feeding the all-position logits
+            # gather; example value 1 mirrors a regular single-token decode.
+            input_spec.inputs = (
+                *input_spec.inputs,
+                torch.tensor(1, dtype=torch.int64),
+            )
+            input_spec.input_names = [*input_spec.input_names, "logits_to_keep"]
+        return input_spec
 
     def _prepare_hf_model_inputs(
         self,
@@ -478,7 +488,13 @@ class LLMExporter:
                 "(which copied graph and could have been quantized in meantime)"
             )
         else:
-            err_check("logits", wrapped_outs[0], outs["logits"])
+            ref_logits = outs["logits"]
+            if getattr(self.wrapped_model, "dynamic_logits_to_keep", False):
+                # wrapped output gathered the last rows; HF emitted all of
+                # them, so compare against the matching tail.
+                kept = wrapped_outs[0].shape[1]
+                ref_logits = ref_logits[:, -kept:, :]
+            err_check("logits", wrapped_outs[0], ref_logits)
             for kv_name, ref, cand in zip(
                 out_cache_names, out_pkv, wrapped_outs[1:], strict=False
             ):
@@ -1032,7 +1048,7 @@ def dump_llm(
     force_module_dtype: T.Optional[DtypeStr] = None,
     force_inputs_dtype: T.Optional[DtypeStr] = None,
     merge_peft: T.Optional[bool] = None,
-    num_logits_to_keep: int = 1,
+    num_logits_to_keep: T.Union[int, str] = 1,
     device_map: TYPE_OPTIONAL_DEVICE_MAP = None,
     hf_download_n_retries: int = DEFAULT_HF_DOWNLOAD_N_RETRIES,
     trust_remote_code: bool = True,

--- a/packages/llm/torch_to_nnef_llm/models/base.py
+++ b/packages/llm/torch_to_nnef_llm/models/base.py
@@ -7,6 +7,7 @@ from functools import partial, wraps
 
 import torch
 
+from torch_to_nnef.exceptions import T2NErrorInvalidArgument
 from torch_to_nnef.utils import (
     INJECTED,
     SemanticVersion,
@@ -21,6 +22,10 @@ from torch_to_nnef_llm._optional_types import (
 from torch_to_nnef_llm.models.handlers.base import ArchitectureHandler
 
 LOGGER = logging.getLogger(__name__)
+
+# Sentinel for `num_logits_to_keep`: expose logits_to_keep as a runtime input
+# instead of baking the slice at trace time.
+DYNAMIC_LOGITS_TO_KEEP = "dynamic"
 
 
 @require_extra_decorator(extra=T2NExtra.LLM_TRACT, module="transformers")
@@ -317,11 +322,22 @@ class BaseCausal(TorchToNNEFWrappedLLM):
         self.model = model
         self.handler = handler
         self.with_dyn_cache = with_dyn_cache
-        # "dynamic" exposes logits_to_keep as a runtime input instead of baking
-        # the slice: the model emits all positions and gathers the requested
-        # tail at run time (1 for decode, k+1 for speculative). Internally we
-        # ask the HF model for all positions (== 0) and do the gather ourselves.
-        self.dynamic_logits_to_keep = num_logits_to_keep == "dynamic"
+        # DYNAMIC_LOGITS_TO_KEEP exposes logits_to_keep as a runtime input
+        # instead of baking the slice: the model emits all positions and
+        # gathers the requested tail at run time (1 for decode, k+1 for
+        # speculative). Internally we ask the HF model for all positions (== 0)
+        # and do the gather ourselves.
+        if (
+            isinstance(num_logits_to_keep, str)
+            and num_logits_to_keep != DYNAMIC_LOGITS_TO_KEEP
+        ):
+            raise T2NErrorInvalidArgument(
+                "num_logits_to_keep string must be "
+                f"'{DYNAMIC_LOGITS_TO_KEEP}', got '{num_logits_to_keep}'"
+            )
+        self.dynamic_logits_to_keep = (
+            num_logits_to_keep == DYNAMIC_LOGITS_TO_KEEP
+        )
         self.num_logits_to_keep = (
             0 if self.dynamic_logits_to_keep else int(num_logits_to_keep)
         )

--- a/packages/llm/torch_to_nnef_llm/models/base.py
+++ b/packages/llm/torch_to_nnef_llm/models/base.py
@@ -349,10 +349,12 @@ class BaseCausal(TorchToNNEFWrappedLLM):
             fkwargs["num_logits_to_keep"] = self.num_logits_to_keep
         else:
             if self.model.config.model_type == "openelm":
+                # use the normalized int (0 in dynamic mode -> all positions,
+                # then forward() gathers); the raw arg may be "dynamic".
                 self.model.transformer.register_forward_hook(
                     partial(
                         _slice_hidden_state_to_lasts,
-                        num_logits_to_keep=num_logits_to_keep,
+                        num_logits_to_keep=self.num_logits_to_keep,
                     )
                 )
             else:

--- a/packages/llm/torch_to_nnef_llm/models/base.py
+++ b/packages/llm/torch_to_nnef_llm/models/base.py
@@ -254,6 +254,12 @@ def update_forward_signature(self):
         new_params[kv_iname] = inspect.Parameter(
             kv_iname, kind, annotation=torch.Tensor
         )
+    if getattr(self, "dynamic_logits_to_keep", False):
+        # runtime scalar driving the all-position logits gather; must be the
+        # last input so kv caches keep their positions in `*args`.
+        new_params["logits_to_keep"] = inspect.Parameter(
+            "logits_to_keep", kind, annotation=torch.Tensor
+        )
 
     self._forward = self.forward
 
@@ -304,14 +310,21 @@ class BaseCausal(TorchToNNEFWrappedLLM):
         model,
         handler: ArchitectureHandler,
         with_dyn_cache: bool = True,
-        num_logits_to_keep: int = 1,
+        num_logits_to_keep: T.Union[int, str] = 1,
         force_causal_mask: T.Optional[bool] = None,
     ):
         super().__init__()
         self.model = model
         self.handler = handler
         self.with_dyn_cache = with_dyn_cache
-        self.num_logits_to_keep = num_logits_to_keep
+        # "dynamic" exposes logits_to_keep as a runtime input instead of baking
+        # the slice: the model emits all positions and gathers the requested
+        # tail at run time (1 for decode, k+1 for speculative). Internally we
+        # ask the HF model for all positions (== 0) and do the gather ourselves.
+        self.dynamic_logits_to_keep = num_logits_to_keep == "dynamic"
+        self.num_logits_to_keep = (
+            0 if self.dynamic_logits_to_keep else int(num_logits_to_keep)
+        )
         sign = inspect.signature(model.forward)
         fkwargs = {}
         if "logits_to_keep" in sign.parameters:
@@ -349,6 +362,11 @@ class BaseCausal(TorchToNNEFWrappedLLM):
 
     @use_dtype_dyn_cache
     def forward(self, input_ids: torch.Tensor, *args):
+        logits_to_keep = None
+        if self.dynamic_logits_to_keep:
+            # last input is the runtime row count; the rest are kv caches
+            *args, logits_to_keep = args
+            args = tuple(args)
         inputs = (input_ids, *args)
         model_inputs = self.handler.build_forward_inputs(
             inputs=inputs,
@@ -365,6 +383,14 @@ class BaseCausal(TorchToNNEFWrappedLLM):
             model_inputs=model_inputs,
             num_logits_to_keep=self.num_logits_to_keep,
         )
+        if logits_to_keep is not None:
+            # the model emitted all positions (num_logits_to_keep == 0); gather
+            # the last `logits_to_keep` rows. A data-dependent gather (not a
+            # slice) is what survives tracing and exports to tract.
+            logits = outputs[0]
+            seq = logits.shape[1]
+            idx = torch.arange(seq - logits_to_keep, seq, device=logits.device)
+            outputs = (logits.index_select(1, idx), *outputs[1:])
         kvs = outputs[1:]
         assert len(args) == len(kvs), f"{len(args)} == {len(kvs)}"
         # key values, (32 tensors) of shape (1, 3, S, 64)


### PR DESCRIPTION
## What

Adds `num_logits_to_keep="dynamic"` to the LLM export. Instead of baking the
last-token slice at trace time, it exposes `logits_to_keep` as a runtime scalar
input. One export then serves cheap prefill (pass 1) and speculative decode
(pass k+1) without re-exporting.

CLI: `--num-logits-to-keep dynamic`. The int form is unchanged (1 by default, 0
keeps all).

Closes #216.

## How

In dynamic mode the model emits all positions (HF `logits_to_keep=0`) and the
wrapper gathers the last `k` rows itself:

```
idx = arange(S - logits_to_keep, S)
logits = logits.index_select(1, idx)
```

A runtime scalar driving a slice does not survive tracing (the value bakes to a
constant) and `narrow` with tensor args hits a torch JIT bug. A gather is the
form that keeps the data dependency and lowers cleanly, so the exported NNEF is:

```
graph network(input_ids, ..., logits_to_keep) -> (logits, ...)
  logits_to_keep = tract_core_external(shape = [], datum_type = 'i64');
  sub0 = sub(S, logits_to_keep);
  idx  = tract_core_range(sub0, S, step = 1);
  out  = tract_core_gather(all_logits, idx, axis = 1);
```

`logits_to_keep` is a real graph input, consumed at run time, not folded.

## Why

Prefill and speculative decode want opposite slicing. Prefill wants 1 row, so a
large-vocab model does not project the LM head over the whole prompt.
Speculative verify wants k+1 rows. A static export cannot be good for both. A
runtime value serves both from a single file, and removes the need for any
tract-side transform or a non-decluttered raw load.

## Tests

`test_llama_dynamic_logits_to_keep` exports the dummy llama and runs the tract
check_io for k=1 and k=3 across supported tract versions. Validated locally end
to end (forced fp32 to avoid an unrelated transformers fp16 SDPA issue in the
dev env): export plus tract check_io pass for both k.

The static path is unchanged: int values keep the old signature and behavior;
only `"dynamic"` adds the input and the gather.
