### PR TITLE
Fix offloaded tensor set payload updates

### DIFF
--- a/packages/nemo-asr/pyproject.toml
+++ b/packages/nemo-asr/pyproject.toml
@@ -33,6 +33,7 @@ test = [
     "pytest-cov>=6.0.0,<7",
     "ruff<1.0",
     "matplotlib",
+    "numpy<2.4",
     "coverage[toml]",
 ]
 

--- a/tests/test_offload.py
+++ b/tests/test_offload.py
@@ -108,3 +108,39 @@ def test_offload_change_dtype():
         offloaded_value = offloaded_value.to(torch.float16)
         assert offloaded_value.dtype == torch.float16
         assert offloaded_value.reload().dtype == torch.float16
+
+
+@skipif_limited_offload_support
+def test_offload_set_updates_payload():
+    with tempfile.TemporaryDirectory() as td:
+        offloaded_value = OffloadedTensor.from_original_tensor(
+            torch.ones(2, 3),
+            "my_offloaded_weight",
+            offload_dir=Path(td),
+        )
+        new_value = torch.arange(6).reshape(2, 3).float()
+        offloaded_value.set_(new_value)
+        assert torch.equal(offloaded_value.reload(), new_value)
+
+
+@skipif_unsupported_qtensor
+def test_offload_set_updates_nested_qtensor_payload():
+    with tempfile.TemporaryDirectory() as td:
+        original_weight = torch.arange(64).reshape(2, 32).float()
+        offloaded_value = OffloadedTensor.from_original_tensor(
+            original_weight,
+            "my_offloaded_weight",
+            offload_dir=Path(td),
+        )
+        q_tensor = fp_to_tract_q4_0_with_min_max_calibration(original_weight)
+        offloaded_q_tensor = OffloadedTensor.from_original_tensor(
+            q_tensor,
+            "my_offloaded_qweight",
+            offload_dir=Path(td),
+        )
+
+        offloaded_value.set_(offloaded_q_tensor)
+
+        reloaded = offloaded_value.reload()
+        assert type(reloaded) is type(q_tensor)
+        assert torch.allclose(reloaded.decompress(), q_tensor.decompress())

--- a/torch_to_nnef/tensor/offload.py
+++ b/torch_to_nnef/tensor/offload.py
@@ -293,6 +293,33 @@ class OffloadedTensor(OpaqueTensor):
         self.update_values(new_data, strict_shape=False, strict_dtype=False)
         return self
 
+    def set_(self, source: torch.Tensor, *args, **kwargs):
+        """Implement tensor-style storage replacement for offloaded payloads.
+
+        ``OffloadedTensor`` uses a meta tensor as its in-memory shell, so
+        PyTorch's native ``Tensor.set_`` cannot replace its storage with a CPU
+        tensor. Route the common ``param.set_(new_tensor)`` form through the
+        offload store instead. This is important for quantizers that update a
+        weight in-place before replacing it with a QTensor.
+        """
+        if args or kwargs:
+            raise T2NErrorMisuse(
+                "OffloadedTensor.set_ only supports set_(tensor)"
+            )
+        if not isinstance(source, torch.Tensor):
+            raise T2NErrorMisuse(
+                "OffloadedTensor.set_ expects a tensor source, "
+                f"got {type(source)}"
+            )
+        self.update_values(source, strict_shape=False, strict_dtype=False)
+        return self
+
+    @staticmethod
+    def _unwrap_offloaded_value(values: torch.Tensor) -> torch.Tensor:
+        while isinstance(values, OffloadedTensor):
+            values = values.reload()
+        return values
+
     def update_values(
         self,
         values: torch.Tensor,
@@ -313,6 +340,8 @@ class OffloadedTensor(OpaqueTensor):
                 if True (default) the dtype of the new tensor
                 must be the same as the prior one
         """
+        values = self._unwrap_offloaded_value(values)
+        old_offload_path = self.offload_path
         if strict_shape:
             assert self.elem.shape == values.shape
         if strict_dtype:
@@ -332,7 +361,10 @@ class OffloadedTensor(OpaqueTensor):
                 values.shape, dtype=values.dtype, device="meta"
             )
 
+        self.offloaded_tensor_type = type(values)
         OffloadedTensor._save(values, self.offload_dir, self._name)
+        if old_offload_path != self.offload_path and old_offload_path.exists():
+            old_offload_path.unlink()
         LOGGER.debug("updated values: '%s'", self._name)
 
     @classmethod

--- a/uv.lock
+++ b/uv.lock
@@ -6557,6 +6557,9 @@ dependencies = [
 test = [
     { name = "coverage", extra = ["toml"] },
     { name = "matplotlib" },
+    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple/" }, marker = "python_full_version < '3.13'" },
+    { name = "numpy", version = "2.1.3", source = { registry = "https://pypi.org/simple/" }, marker = "python_full_version >= '3.13' and sys_platform != 'linux'" },
+    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple/" }, marker = "python_full_version >= '3.13' and sys_platform == 'linux'" },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "ruff" },
@@ -6576,6 +6579,7 @@ requires-dist = [
 test = [
     { name = "coverage", extras = ["toml"] },
     { name = "matplotlib" },
+    { name = "numpy", specifier = "<2.4" },
     { name = "pytest", specifier = ">=9.0.3,<10" },
     { name = "pytest-cov", specifier = ">=6.0.0,<7" },
     { name = "ruff", specifier = "<1.0" },


### PR DESCRIPTION
## Summary
- route OffloadedTensor.set_(tensor) through the offload payload store instead of native meta storage replacement
- unwrap nested OffloadedTensor sources so dense and QTensor payloads can replace each other cleanly
- add regression coverage for dense and nested QTensor payload replacement
- constrain the NeMo test dependency group to numpy<2.4 so CI does not preseed an incompatible NumPy for NeMo 2.7.2 resolution

## Tests
- .venv/bin/python -m pytest tests/test_offload.py -q
- uv lock --check
- GitHub Actions: all checks passing on f5a0bf31