### PR TITLE
fix: avoid materializing parameter views as constants

### DIFF
--- a/tests/test_ir_derived_constants.py
+++ b/tests/test_ir_derived_constants.py
@@ -1,0 +1,48 @@
+import torch
+import torch.nn.functional as F
+
+from torch_to_nnef.torch_graph.ir_graph import module_tracer_into_ir_graph
+from torch_to_nnef.torch_graph.ir_module_tracer import TorchModuleTracer
+from torch_to_nnef.torch_graph.torch_const import ATEN_LINEAR, ATEN_SELECT
+
+
+class PackedExpertLinear(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.weight = torch.nn.Parameter(torch.randn(3, 4, 5))
+
+    def forward(self, x):
+        chunks = x.split([1, 1, 1], dim=0)
+        outputs = []
+        for expert in range(3):
+            outputs.append(F.linear(chunks[expert], self.weight[expert]))
+        return torch.cat(outputs, dim=0)
+
+
+def test_parameter_select_outputs_are_not_materialized_as_constants():
+    mod = PackedExpertLinear().eval()
+    x = torch.randn(3, 5)
+
+    graph = module_tracer_into_ir_graph(TorchModuleTracer(mod, args=(x,)))
+
+    select_ops = [
+        op
+        for op in graph.op_nodes
+        if op.kind == ATEN_SELECT and op.inputs[0].data is mod.weight
+    ]
+    assert len(select_ops) == 3
+    assert all(op.outputs[0].data is None for op in select_ops)
+
+    linear_weight_nodes = [
+        op.inputs[1] for op in graph.op_nodes if op.kind == ATEN_LINEAR
+    ]
+    assert len(linear_weight_nodes) == 3
+    assert all(weight.data is None for weight in linear_weight_nodes)
+
+    packed_weight_nodes = [
+        node
+        for node in graph.data_nodes
+        if getattr(node, "data", None) is mod.weight
+    ]
+    assert len(packed_weight_nodes) == 1
+    assert packed_weight_nodes[0].module_attr

--- a/torch_to_nnef/torch_graph/ir_data.py
+++ b/torch_to_nnef/torch_graph/ir_data.py
@@ -165,6 +165,7 @@ class TensorVariable(Data):
 
     quant: T.Optional[T.Dict[str, T.Any]] = None
     _traced_data: T.Optional[torch.Tensor] = None
+    module_attr: bool = False
 
     def set_data(  # pylint: disable=arguments-differ
         self, data, *args, force_shape=False, force_dtype=False, **kwargs

--- a/torch_to_nnef/torch_graph/ir_helpers.py
+++ b/torch_to_nnef/torch_graph/ir_helpers.py
@@ -294,6 +294,7 @@ def _parse_getattr_tensor(node: torch._C.Node, module, data_nodes):
                 shape=list(attr.shape),
                 dtype=attr.dtype,
                 data=attr,
+                module_attr=True,
             )
         )
         return

--- a/torch_to_nnef/torch_graph/ir_op.py
+++ b/torch_to_nnef/torch_graph/ir_op.py
@@ -491,6 +491,26 @@ def _build_empty_tensor_from_infer_trace(
     return torch.empty(infered_shape, dtype=inputs[0].dtype)
 
 
+def _tensors_share_storage(left: torch.Tensor, right: torch.Tensor) -> bool:
+    """Return True when tensors alias the same underlying storage."""
+    if left.device.type == "meta" or right.device.type == "meta":
+        return False
+    try:
+        left_storage = (
+            left.untyped_storage()
+            if hasattr(left, "untyped_storage")
+            else left.storage()
+        )
+        right_storage = (
+            right.untyped_storage()
+            if hasattr(right, "untyped_storage")
+            else right.storage()
+        )
+        return left_storage.data_ptr() == right_storage.data_ptr()
+    except (AttributeError, RuntimeError):
+        return False
+
+
 @dataclass(frozen=True)
 class InferRule:
     fn: T.Optional[T.Callable[T.Any, torch.Size]]
@@ -733,6 +753,24 @@ class TorchOp:
             return False
         return True
 
+    def output_aliases_constant_input(self, result: torch.Tensor) -> bool:
+        """Detect view-like results derived from constant inputs.
+
+        These outputs should keep shape/dtype metadata, but should not be
+        recorded as new constants. Otherwise a graph like Granite MoE's packed
+        expert weight `select`s serializes every expert slice as an independent
+        tensor in addition to the original packed parameter.
+        """
+        for input_node in self.inputs:
+            input_data = getattr(input_node, "data", None)
+            if not getattr(input_node, "module_attr", False):
+                continue
+            if isinstance(input_data, torch.Tensor) and (
+                _tensors_share_storage(result, input_data)
+            ):
+                return True
+        return False
+
     @property
     def args(self) -> T.Tuple[T.Any, ...]:
         return tuple(_.tracing_data for _ in self.inputs)
@@ -817,7 +855,10 @@ class TorchOp:
                 f"for {self.op_ref}"
             )
         for data_node, result in zip(output_nodes, output_values, strict=False):
-            if self.has_constant_inputs:
+            result_aliases_constant_input = isinstance(
+                result, torch.Tensor
+            ) and self.output_aliases_constant_input(result)
+            if self.has_constant_inputs and not result_aliases_constant_input:
                 try:
                     if data_node.data is None or not (
                         data_node.data.shape == result.shape


### PR DESCRIPTION
## Summary
- prevent IR shape inference from recording view-like outputs as new constants when they alias an existing constant tensor
- keeps shape/dtype metadata, but leaves select/slice outputs as graph values so packed MoE weights are serialized once
- add a regression test for a packed expert linear pattern matching Granite MoE's expert weight selects

## Validation
- uv run ruff check torch_to_nnef/torch_graph/ir_op.py tests/test_ir_derived_constants.py
- uv run pytest tests/test_ir_derived_constants.py tests/test_grouped_mm_infer.py tests/test_infer_shape.py
- Full Granite f16 export completed successfully with the patched local t2n branch; produced a 2.5G model.nnef.tgz artifact

## Notes
Before this change each GraniteMoeParallelExperts trace materialized every selected expert weight as an independent constant. One MoE block reported ~6.3GB of logical constants; after the patch it reports ~96MB, matching the real packed tensors.