### PR TITLE
fix: apply symbol renames to user-provided tract extensions

### DIFF
--- a/tests/test_remodeler_adapter.py
+++ b/tests/test_remodeler_adapter.py
@@ -1,5 +1,8 @@
+import types
+
 import torch
 
+from torch_to_nnef.remodeler import prepare_subnet_export
 from torch_to_nnef.remodeler.adapter import BoundaryAdapter
 
 
@@ -276,3 +279,49 @@ def test_outputs_keep_raw_container_name_returns_nothing():
     result = ba(torch.zeros(2, 4))
     assert isinstance(result, tuple)
     assert len(result) == 1
+
+
+# ---------------------------------------------------------------------------
+# Extension symbol-rename tests
+# ---------------------------------------------------------------------------
+
+
+def _fake_registry(*, renamed, extensions):
+    """Minimal stand-in exposing the attributes prepare_subnet_export reads."""
+    return types.SimpleNamespace(
+        eval_symbols_per_input={},
+        renamed_symbols_per_subnet=renamed,
+        outputs_keep_per_subnet={},
+        input_collapse_dims={},
+        bind_to_dim={},
+        output_collapse_dims={},
+        extensions_per_subnet=extensions,
+    )
+
+
+def test_user_extensions_get_symbol_renames_applied():
+    """User-provided extensions must honor ``renamed_symbols`` (regression).
+
+    A shape config that renames AUDIO_SIGNAL__TIME -> S while also declaring
+    ``extensions: [tract_assert AUDIO_SIGNAL__TIME<=39993]`` used to emit the
+    assertion with the un-renamed symbol, referencing a symbol tract never
+    declares.
+    """
+    reg = _fake_registry(
+        renamed={"encoder": {"S": ["AUDIO_SIGNAL__TIME"]}},
+        extensions={"encoder": ["tract_assert AUDIO_SIGNAL__TIME<=39993"]},
+    )
+    prepared = prepare_subnet_export(
+        model=torch.nn.Identity(),
+        test_input=[torch.zeros(1, 128, 16)],
+        input_names=["audio_signal"],
+        output_names=["outputs"],
+        subnet_name="encoder",
+        dyn={"audio_signal": {2: "AUDIO_SIGNAL__TIME"}},
+        custom_extensions=["tract_assert AUDIO_SIGNAL__TIME >= 1"],
+        axis_registry=reg,
+    )
+    exts = prepared.custom_extensions
+    assert "tract_assert S<=39993" in exts
+    assert "tract_assert S >= 1" in exts
+    assert not any("AUDIO_SIGNAL__TIME" in e for e in exts)

--- a/torch_to_nnef/remodeler/__init__.py
+++ b/torch_to_nnef/remodeler/__init__.py
@@ -243,8 +243,14 @@ def prepare_subnet_export(
         )
     )
     if axis_registry is not None:
+        # User/derived/slug extensions may reference source symbols that were
+        # renamed via ``renamed_symbols`` (e.g. AUDIO_SIGNAL__TIME -> S), so
+        # they must go through the same rewrite as the auto-generated ones.
         custom_ext.update(
-            axis_registry.extensions_per_subnet.get(subnet_name, [])
+            rewrite_assertions_with_renames(
+                axis_registry.extensions_per_subnet.get(subnet_name, []),
+                rename_map,
+            )
         )
 
     if axis_registry is not None and axis_registry.eval_symbols_per_input:


### PR DESCRIPTION
## Problem

Exporting with a `renamed_symbols` block only renamed *part* of the emitted tract assertions. Reported on parakeet with:

```yaml
encoder:
  renamed_symbols:
    S: [AUDIO_SIGNAL__TIME]
```

producing NNEF where the auto-generated bound was renamed but the user/derived one was not:

```
extension tract_symbol S;
extension tract_assert S >= 1;
extension tract_assert AUDIO_SIGNAL__TIME<=39993;   # references an undeclared symbol
```

## Root cause

In `prepare_subnet_export` (`torch_to_nnef/remodeler/__init__.py`), assertions come from two sources:

- **auto-generated** `tract_assert <sym> >= 1` bounds, passed as `custom_extensions`, which went through `rewrite_and_filter_assertions(..., rename_map, dyn)` and were correctly renamed;
- **user / slug / architecture-derived** extensions carried on `axis_registry.extensions_per_subnet`, which were merged in via `set.update(...)` **raw**, never seeing `rename_map`.

So `renamed_symbols` never reached the second source.

## Fix

Route `extensions_per_subnet` through `rewrite_assertions_with_renames(..., rename_map)` before merging. The rename-only variant (not the `dyn`-filtering one) is used deliberately: hand-written extensions may legitimately reference a non-dynamic symbol (a bound scalar, a constant), and those must not be silently dropped.

The rewriter is token-based (`\b[A-Za-z_][A-Za-z0-9_]*\b` + exact map lookup), so it is substring/prefix-safe: renaming `TIME` does not touch `AUDIO_SIGNAL__TIME`, and renaming `S` does not touch `S_TIME`.

## Test

`tests/test_remodeler_adapter.py::test_user_extensions_get_symbol_renames_applied` reproduces the report against a minimal registry. Verified it fails without the fix (`['tract_assert S >= 1', 'tract_assert AUDIO_SIGNAL__TIME<=39993']`) and passes with it. All core remodeler tests and the nemo-asr extension tests stay green; ruff check/format clean.