### PR TITLE
fix(examples): request token_type_ids for albert export on transformers 5.x

### DIFF
--- a/examples/dynamic_axes/export_albert_fixed.py
+++ b/examples/dynamic_axes/export_albert_fixed.py
@@ -5,8 +5,12 @@ from transformers import AlbertModel, AlbertTokenizer
 from torch_to_nnef import TractNNEF, export_model_to_nnef
 
 tokenizer = AlbertTokenizer.from_pretrained("albert-base-v2")
+# transformers 5.x no longer returns token_type_ids by default; request it
+# explicitly so the export below keeps its three-input signature on 4.x and 5.x.
 inputs = tokenizer(
-    ["Hello, I am happy", "and also I am blond"], return_tensors="pt"
+    ["Hello, I am happy", "and also I am blond"],
+    return_tensors="pt",
+    return_token_type_ids=True,
 )
 albert_model = AlbertModel.from_pretrained("albert-base-v2")
 


### PR DESCRIPTION
## Problem

`examples/dynamic_axes/export_albert_fixed.py` fails on transformers 5.x with:

```
KeyError: 'token_type_ids'
  args=[inputs[k] for k in input_names]   # input_names includes "token_type_ids"
```

transformers 5.x no longer returns `token_type_ids` from the ALBERT tokenizer by default, so the export's three-input signature (`input_ids`, `attention_mask`, `token_type_ids`) can't be assembled. This is what turns the dependabot transformers 4.53.2 -> 5.3.0 bump (#225) red on `tier1: dynamic_axes`.

## Fix

Pass `return_token_type_ids=True` to the tokenizer call. This restores the key on 5.x and is a no-op on 4.x (where it was already returned), so the example stays valid across both.

Verified against transformers 5.8.0 + cached `albert-base-v2`:
- default output keys: `['attention_mask', 'input_ids']` (reproduces the failure)
- with `return_token_type_ids=True`: `['attention_mask', 'input_ids', 'token_type_ids']`

Once this lands on `main`, #225 rebased goes green.