### PR TITLE
chore(examples): pin dynamic_axes transformers <5 (5.x export regression)

### DIFF
--- a/examples/dynamic_axes/pyproject.toml
+++ b/examples/dynamic_axes/pyproject.toml
@@ -7,7 +7,12 @@ dependencies = [
     "torch==2.7.0",
     "torchaudio==2.7.0",
     "torchvision==0.22.0",
-    "transformers==4.53.2",
+    # Pinned <5: t2n's ALBERT export currently regresses on transformers 5.x
+    # (SDPA receives a long attn_mask; graph-build errors), same gap as the
+    # llm_wasm example. Examples are not in the Trivy CVE gate, so this stays
+    # here rather than forcing the incompatible bump. Revisit when 5.x export
+    # is supported.
+    "transformers>=4.35.2,<5",
     "sentencepiece==0.2.1",
 ]
 

--- a/examples/dynamic_axes/uv.lock
+++ b/examples/dynamic_axes/uv.lock
@@ -972,7 +972,7 @@ requires-dist = [
     { name = "torch-to-nnef", editable = "../../" },
     { name = "torchaudio", specifier = "==2.7.0" },
     { name = "torchvision", specifier = "==0.22.0" },
-    { name = "transformers", specifier = "==4.53.2" },
+    { name = "transformers", specifier = ">=4.35.2,<5" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Why

The dependabot bump of `examples/dynamic_axes` to transformers 5.3.0 (#225) turns `tier1: dynamic_axes` red: t2n cannot export the ALBERT model on transformers 5.x.

- transformers 5.3.0: `aten.scaled_dot_product_attention` receives a `long` attn_mask -> `RuntimeError: Expected attn_mask dtype to be bool or float ...`
- transformers 5.5.x: graph build fails earlier with `IndexError: tuple index out of range`

Plain `AlbertModel` forward works on 5.x (eager and sdpa), so this is a t2n export-path gap, the same transformers-5.x attention regression already documented for the `llm_wasm` example (also pinned <5).

## Decision

The HIGH transformers advisory (GHSA-29pf-2h5f-8g72) has **no 4.x fix** (only 5.3.0), so we can't be both CVE-free and export-working here yet. Examples are **not** scanned by the Trivy CVE gate (only the core/llm/nemo root surfaces are), so pinning this demo `<5` has no security-gate impact and keeps CI green. Mirrors the existing `llm_wasm` pin.

Supersedes #225 (to be closed). A follow-up can add transformers-5.x ALBERT export support and lift the pin.