### PR TITLE
fix: broadcast index tensors in aten::index gather_nd lowering

### DIFF
--- a/examples/dynamic_axes/export_albert_fixed.py
+++ b/examples/dynamic_axes/export_albert_fixed.py
@@ -1,8 +1,10 @@
 from pathlib import Path
 
+import transformers
 from transformers import AlbertModel, AlbertTokenizer
 
 from torch_to_nnef import TractNNEF, export_model_to_nnef
+from torch_to_nnef.utils import SemanticVersion
 
 tokenizer = AlbertTokenizer.from_pretrained("albert-base-v2")
 # transformers 5.x no longer returns token_type_ids by default; request it
@@ -12,7 +14,13 @@ inputs = tokenizer(
     return_tensors="pt",
     return_token_type_ids=True,
 )
-albert_model = AlbertModel.from_pretrained("albert-base-v2")
+# transformers 5.x defaults to a fused SDPA attention path that feeds a
+# non-float attn_mask into scaled_dot_product_attention, which fails during the
+# export forward. Eager attention decomposes into core ops that export cleanly.
+model_kwargs = {}
+if SemanticVersion.from_str(transformers.__version__) >= "5.0.0":
+    model_kwargs["attn_implementation"] = "eager"
+albert_model = AlbertModel.from_pretrained("albert-base-v2", **model_kwargs)
 
 file_path_export = Path("albert_v2_dyn.nnef.tgz")
 input_names = ["input_ids", "attention_mask", "token_type_ids"]

--- a/tests/proptest/op_specs/shape.py
+++ b/tests/proptest/op_specs/shape.py
@@ -1117,6 +1117,48 @@ def _gather_sample_st() -> st.SearchStrategy[OpSample]:
     return _draw()
 
 
+def _advanced_index_sample_st() -> st.SearchStrategy[OpSample]:
+    """`x[idx0, idx1]`: multi-tensor advanced indexing (`aten::index`).
+
+    The two index tensors have *broadcastable* (not identical) shapes
+    -- `(a, 1)` and `(1, b)` -- so torch broadcasts them to `(a, b)`
+    before gathering. This exercises the `_gather_nd` broadcast path
+    (regression: transformers 5.x mask indexing passes `[B,1,1,1]` and
+    `[1,1,1,S]`, which previously produced an inconsistent NNEF concat).
+    """
+
+    @st.composite
+    def _draw(draw) -> OpSample:
+        d0 = draw(st.integers(min_value=2, max_value=5))
+        d1 = draw(st.integers(min_value=2, max_value=5))
+        a = draw(st.integers(min_value=1, max_value=3))
+        b = draw(st.integers(min_value=1, max_value=3))
+        idx0 = draw(
+            tensor_st(
+                (a, 1), torch.int64, finite=True, domain=Interval(0, d0 - 1)
+            )
+        )
+        idx1 = draw(
+            tensor_st(
+                (1, b), torch.int64, finite=True, domain=Interval(0, d1 - 1)
+            )
+        )
+        x = draw(
+            tensor_st(
+                (d0, d1),
+                torch.float32,
+                finite=True,
+                domain=Interval(-1e2, 1e2),
+            )
+        )
+        return OpSample(
+            inputs=(x, idx0, idx1),
+            module=TernaryPrimitive(lambda t, i0, i1: t[i0, i1]),
+        )
+
+    return _draw()
+
+
 def _masked_fill_sample_st() -> st.SearchStrategy[OpSample]:
     """`Tensor.masked_fill(mask, value)`: bool mask, scalar value."""
 
@@ -1203,6 +1245,11 @@ def _selector_specs() -> T.List[OpSpec]:
         OpSpec(
             name="gather",
             sample_st=_gather_sample_st(),
+            tolerance=TractCheckTolerance.EXACT,
+        ),
+        OpSpec(
+            name="advanced_index",
+            sample_st=_advanced_index_sample_st(),
             tolerance=TractCheckTolerance.EXACT,
         ),
         OpSpec(

--- a/torch_to_nnef/op/aten/selector.py
+++ b/torch_to_nnef/op/aten/selector.py
@@ -521,55 +521,91 @@ def index_(node, op_helper, inference_target, **kwargs):
 
 def _gather_nd(node, op_helper):
     input_node, indexes_node = node.inputs
-    inputs = []
+    idx_nodes = list(indexes_node.data)
 
-    for idx_node in indexes_node.data:
+    # Cast each index to TDim (tract_core_gather_nd consumes TDim coords).
+    tdim_refs = []
+    for idx_node in idx_nodes:
         i_ref = op_helper.get_or_add_tensor_variable_in_nnef(idx_node)
-        casted_i_ref = op_helper.add_single_output_op_from_nnef_tensors(
-            node,
-            "tract_core_cast",
-            inputs=[i_ref],
-            attrs={"to": "TDim"},
-            force_full_output_tensor_name=f"{i_ref.name}_as_tdim",
-        )
-        casted_unsqueezed_i_ref = (
+        tdim_refs.append(
             op_helper.add_single_output_op_from_nnef_tensors(
                 node,
-                "unsqueeze",
-                inputs=[casted_i_ref],
-                attrs={"axes": [0]},
-                force_full_output_tensor_name=f"{i_ref.name}_as_tdim_d1",
+                "tract_core_cast",
+                inputs=[i_ref],
+                attrs={"to": "TDim"},
+                force_full_output_tensor_name=f"{i_ref.name}_as_tdim",
             )
         )
-        inputs.append(casted_unsqueezed_i_ref)
+
+    # PyTorch advanced indexing broadcasts the index tensors against each
+    # other before gathering, so `input[idx0, idx1, ...]` uses the common
+    # broadcast shape of the idx tensors. tract_core_gather_nd instead needs
+    # a single coordinate tensor whose leading shape is shared by every
+    # index. When the idx tensors differ in shape (e.g. transformers 5.x
+    # mask indexing with `[B,1,1,1]` and `[1,1,1,S]`), broadcast them to
+    # their common shape first via an additive zero frame -- tract broadcasts
+    # elementwise TDim adds natively, including symbolic/dynamic dims, so no
+    # explicit repeats need resolving.
+    if len({tuple(idx.shape) for idx in idx_nodes}) > 1:
+        zero_frame = None
+        for i, ref in enumerate(tdim_refs):
+            zero = op_helper.add_single_output_op_from_nnef_tensors(
+                node,
+                "sub",
+                inputs=[ref, ref],
+                force_consistent_inputs_shapes=False,
+                force_full_output_tensor_name=f"{ref.name}_gnd_zero_{i}",
+            )
+            if zero_frame is None:
+                zero_frame = zero
+            else:
+                zero_frame = op_helper.add_single_output_op_from_nnef_tensors(
+                    node,
+                    "add",
+                    inputs=[zero_frame, zero],
+                    force_consistent_inputs_shapes=False,
+                    force_full_output_tensor_name=f"{ref.name}_gnd_zframe_{i}",
+                )
+        tdim_refs = [
+            op_helper.add_single_output_op_from_nnef_tensors(
+                node,
+                "add",
+                inputs=[ref, zero_frame],
+                force_consistent_inputs_shapes=False,
+                force_full_output_tensor_name=f"{ref.name}_gnd_bcast",
+            )
+            for ref in tdim_refs
+        ]
+
+    # Stack the (now shape-consistent) coordinates on a trailing axis so the
+    # result is `[*broadcast_shape, num_indexed_dims]`, the layout expected by
+    # tract_core_gather_nd (batch_dims=0).
+    coord_axis = max(len(idx.shape) for idx in idx_nodes)
+    coord_refs = [
+        op_helper.add_single_output_op_from_nnef_tensors(
+            node,
+            "unsqueeze",
+            inputs=[ref],
+            attrs={"axes": [coord_axis]},
+            force_full_output_tensor_name=f"{ref.name}_coord",
+        )
+        for ref in tdim_refs
+    ]
     concat_ref = op_helper.add_single_output_op_from_nnef_tensors(
         node,
         "concat",
-        inputs=inputs,
+        inputs=coord_refs,
         ensure_tuple=False,
-        attrs={
-            "axis": 0,
-        },
+        attrs={"axis": coord_axis},
         force_consistent_inputs_shapes=False,
         output_tensor_name_suffix="indices_concat",
-    )
-    t_concat_ref = op_helper.add_single_output_op_from_nnef_tensors(
-        node,
-        "transpose",
-        inputs=concat_ref,
-        ensure_tuple=False,
-        attrs={
-            "axes": [1, 0],
-        },
-        force_consistent_inputs_shapes=False,
-        output_tensor_name_suffix="indices_concat_t",
     )
     op_helper.add_single_output_op_from_nnef_tensors(
         node,
         "tract_core_gather_nd",
         inputs=[
             op_helper.get_or_add_tensor_variable_in_nnef(input_node),
-            t_concat_ref,
+            concat_ref,
         ],
         attrs={
             "batch_dims": 0,


### PR DESCRIPTION
## Problem

Exporting the `dynamic_axes` ALBERT example on transformers 5.x (the dependabot bump #225) failed. Root-causing it uncovered three stacked issues, the last being a latent core bug:

1. **`token_type_ids` missing** — transformers 5.x tokenizer drops it by default (fixed earlier in #229).
2. **SDPA rejects a `long` attn_mask** during the export forward — transformers 5.x defaults to a fused SDPA attention path. Fixed here by selecting eager attention on transformers>=5.0 in the example (mirrors the `llm` loader's existing gate).
3. **`_gather_nd` produced an invalid NNEF concat** — the real core bug below.

## Core fix: `_gather_nd` broadcasting (`torch_to_nnef/op/aten/selector.py`)

`aten::index` with multiple tensor indices (`x[idx0, idx1, ...]`) lowered each index via `cast->TDim`, `unsqueeze(0)`, then concatenated on axis 0 and transposed. That assumes **all index tensors share one shape** — but PyTorch advanced indexing *broadcasts* them first. transformers 5.x's rewritten `masking_utils` indexes the mask with tensors like `[B,1,1,1]` and `[1,1,1,S]`, so the un-broadcast concat had inconsistent operand shapes and tract refused to build the model:

```
Inconsistent concat TypedConcat { axis: 0 } inputs: [1,B,1,1,1,..., 1,1,1,1,S,...]
```

This reproduced even with **fully static shapes**, so it is a pre-existing advanced-index bug, not dynamic-axes or transformers-specific; transformers 5.x merely triggers it.

The fix broadcasts the index tensors to their common shape before stacking, using an additive zero-frame (`sub(x,x)` then broadcast-`add`) that tract broadcasts natively — including symbolic/dynamic dims, with no explicit repeats to resolve. Coordinates are then stacked on a trailing axis (`[*broadcast_shape, N]`), the layout `tract_core_gather_nd` expects, removing the old 1-D-only `unsqueeze(0)/concat(0)/transpose`. The 1-D path is unchanged (same resulting `[L, N]` layout).

## Tests

- New proptest spec `advanced_index` (`x[idx0, idx1]` with broadcastable `(a,1)`/`(1,b)` shapes) in the shape group. Verified it **fails without the fix** (the inconsistent-concat tract error) and passes with it. Existing selector specs (select/index_select/gather/masked_fill) stay green.
- End-to-end: the full `dynamic_axes` ALBERT example now runs on transformers 5.3.0 with `check_io=True` -> **IO bit match between tract and PyTorch** (validated locally in a 5.3.0 env with tract 0.23.0).

Unblocks #225 (goes green on rebase).