### PR TITLE
Let SDPA reification select SDPA attention

### DIFF
--- a/packages/llm/pyproject.toml
+++ b/packages/llm/pyproject.toml
@@ -103,25 +103,25 @@ basepython = ["python3.12", "python3.13"]
 dependency_groups = ["test"]
 constrain_package_deps = false
 deps = ["transformers==4.50.0"]
-commands = [["pytest", "-s", "tests/test_llm_cli.py", "tests/test_load_retry.py", "tests/test_upcast_quant.py"]]
+commands = [["pytest", "-s", "tests/test_llm_cli.py", "tests/test_load_retry.py", "tests/test_upcast_quant.py", "tests/test_sdpa_attention_export.py"]]
 
 [tool.tox.env.cli_transformers_4_52_0]
 basepython = ["python3.12", "python3.13"]
 dependency_groups = ["test"]
 constrain_package_deps = false
 deps = ["transformers==4.52.0"]
-commands = [["pytest", "-s", "tests/test_llm_cli.py", "tests/test_load_retry.py", "tests/test_upcast_quant.py"]]
+commands = [["pytest", "-s", "tests/test_llm_cli.py", "tests/test_load_retry.py", "tests/test_upcast_quant.py", "tests/test_sdpa_attention_export.py"]]
 
 [tool.tox.env.cli_transformers_5_0_0]
 basepython = ["python3.12", "python3.13"]
 dependency_groups = ["test"]
 constrain_package_deps = false
 deps = ["transformers==5.0.0"]
-commands = [["pytest", "-s", "tests/test_llm_cli.py", "tests/test_load_retry.py", "tests/test_upcast_quant.py"]]
+commands = [["pytest", "-s", "tests/test_llm_cli.py", "tests/test_load_retry.py", "tests/test_upcast_quant.py", "tests/test_sdpa_attention_export.py"]]
 
 [tool.tox.env.cli_transformers_5_5_0]
 basepython = ["python3.12", "python3.13"]
 dependency_groups = ["test"]
 constrain_package_deps = false
 deps = ["transformers==5.5.0"]
-commands = [["pytest", "-s", "tests/test_llm_cli.py", "tests/test_load_retry.py", "tests/test_upcast_quant.py"]]
+commands = [["pytest", "-s", "tests/test_llm_cli.py", "tests/test_load_retry.py", "tests/test_upcast_quant.py", "tests/test_sdpa_attention_export.py"]]

--- a/packages/llm/tests/test_load_retry.py
+++ b/packages/llm/tests/test_load_retry.py
@@ -9,6 +9,7 @@ import pytest
 
 from torch_to_nnef.exceptions import T2NErrorRuntime
 from torch_to_nnef_llm import exporter as exp_mod
+from torch_to_nnef_llm import loader
 from torch_to_nnef_llm.exporter import LLMExporter, _hf_http_status
 from torch_to_nnef_llm.loader import _resolve_snapshot_dir
 
@@ -73,6 +74,53 @@ def test_resolve_snapshot_propagates_non_cache_miss_error():
 
     with pytest.raises(PermissionError):
         _resolve_snapshot_dir("some/model", _BoomHub())
+
+
+def test_from_pretrained_device_map_dispatch_reties_weights(
+    monkeypatch, tmp_path
+):
+    """Manual dispatch must keep tied weights from staying as meta tensors."""
+    calls = {"dispatch": 0, "tie": 0}
+
+    class _Model:
+        def tie_weights(self):
+            calls["tie"] += 1
+
+    model = _Model()
+
+    class _AutoModel:
+        @staticmethod
+        def from_pretrained(slug_or_dir, **kwargs):
+            assert slug_or_dir == tmp_path
+            assert "device_map" not in kwargs
+            return model
+
+    class _Transformers:
+        AutoModelForCausalLM = _AutoModel
+
+    def fake_dispatch(dispatched_model, weights_location, **_kwargs):
+        assert dispatched_model is model
+        assert weights_location == tmp_path
+        calls["dispatch"] += 1
+
+    monkeypatch.setattr(
+        loader, "t2n_load_checkpoint_and_dispatch", fake_dispatch
+    )
+
+    from_pretrained = loader._from_pretrained
+    while hasattr(from_pretrained, "__wrapped__"):
+        from_pretrained = from_pretrained.__wrapped__
+
+    assert (
+        from_pretrained(
+            tmp_path,
+            transformers=_Transformers,
+            huggingface_hub=object(),
+            device_map=loader.ON_DISK_DEVICE_MAP_KEY,
+        )
+        is model
+    )
+    assert calls == {"dispatch": 1, "tie": 1}
 
 
 def test_load_retries_transient_then_succeeds(monkeypatch):

--- a/packages/llm/tests/test_sdpa_attention_export.py
+++ b/packages/llm/tests/test_sdpa_attention_export.py
@@ -1,0 +1,146 @@
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+from torch_to_nnef.exceptions import T2NErrorMisuse
+from torch_to_nnef_llm import cli, exporter, loader
+
+
+class _FakeModel:
+    config = SimpleNamespace(model_type="fake")
+
+    def to(self, _dtype):
+        return self
+
+
+class _FakeAutoModel:
+    calls = []
+
+    @classmethod
+    def from_config(cls, _config, **kwargs):
+        cls.calls.append(kwargs)
+        return _FakeModel()
+
+
+class _FakeTransformers:
+    __version__ = "5.12.1"
+    AutoModelForCausalLM = _FakeAutoModel
+
+
+def _load_fake_model(monkeypatch, *, attn_implementation=None):
+    _FakeAutoModel.calls = []
+    monkeypatch.setitem(loader.CUSTOM_CONFIGS, "fake/model", object())
+    return loader.load_model.__wrapped__(
+        "fake/model",
+        trust_remote_code=False,
+        attn_implementation=attn_implementation,
+        transformers=_FakeTransformers,
+    )
+
+
+def test_load_model_keeps_safe_eager_default_for_transformers_5(monkeypatch):
+    _load_fake_model(monkeypatch)
+    assert _FakeAutoModel.calls[-1]["attn_implementation"] == "eager"
+
+
+def test_load_model_accepts_explicit_sdpa_attention(monkeypatch):
+    _load_fake_model(monkeypatch, attn_implementation="sdpa")
+    assert _FakeAutoModel.calls[-1]["attn_implementation"] == "sdpa"
+
+
+def test_load_model_treats_auto_attention_as_default(monkeypatch):
+    _load_fake_model(monkeypatch, attn_implementation="auto")
+    assert _FakeAutoModel.calls[-1]["attn_implementation"] == "eager"
+
+
+def test_load_model_rejects_unknown_attention_implementation(monkeypatch):
+    with pytest.raises(T2NErrorMisuse, match="attn_implementation"):
+        _load_fake_model(monkeypatch, attn_implementation="definitely-not-real")
+
+
+def test_reify_sdpa_operator_implies_sdpa_attention():
+    assert exporter._resolve_attn_implementation(None, True) == "sdpa"
+    assert exporter._resolve_attn_implementation("auto", True) == "sdpa"
+    assert exporter._resolve_attn_implementation("auto", False) is None
+
+
+def test_reify_sdpa_operator_rejects_eager_attention():
+    with pytest.raises(T2NErrorMisuse, match="requires"):
+        exporter._resolve_attn_implementation("eager", True)
+
+
+def test_dump_llm_routes_reified_sdpa_to_loader(monkeypatch, tmp_path):
+    captured_load = {}
+    captured_dump = {}
+
+    class _Exporter:
+        def dump(self, **kwargs):
+            captured_dump.update(kwargs)
+
+    def fake_load(*args, **kwargs):
+        captured_load.update(kwargs)
+        return _Exporter()
+
+    monkeypatch.setattr(exporter.LLMExporter, "load", staticmethod(fake_load))
+    exporter.dump_llm(
+        "fake/model",
+        export_dirpath=tmp_path / "export",
+        reify_sdpa_operator=True,
+    )
+
+    assert captured_load["attn_implementation"] == "sdpa"
+    assert captured_dump["reify_sdpa_operator"] is True
+
+
+def test_cli_reify_sdpa_operator_implies_sdpa_attention(monkeypatch, tmp_path):
+    captured = {}
+
+    def fake_dump_llm(**kwargs):
+        captured.update(kwargs)
+
+    monkeypatch.setattr(cli, "dump_llm", fake_dump_llm)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "torch-to-nnef-llm",
+            "-s",
+            "fake/model",
+            "-e",
+            str(tmp_path / "export"),
+            "--reify-sdpa-operator",
+        ],
+    )
+
+    cli.main()
+
+    assert captured["attn_implementation"] == "sdpa"
+
+
+def test_cli_accepts_transformers_attention_implementation(
+    monkeypatch, tmp_path
+):
+    captured = {}
+
+    def fake_dump_llm(**kwargs):
+        captured.update(kwargs)
+
+    monkeypatch.setattr(cli, "dump_llm", fake_dump_llm)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "torch-to-nnef-llm",
+            "-s",
+            "fake/model",
+            "-e",
+            str(tmp_path / "export"),
+            "--transformers-attn-implementation",
+            "eager",
+        ],
+    )
+
+    cli.main()
+
+    assert captured["attn_implementation"] == "eager"

--- a/packages/llm/torch_to_nnef_llm/cli.py
+++ b/packages/llm/torch_to_nnef_llm/cli.py
@@ -144,7 +144,21 @@ def parser_cli(  # pylint: disable=too-many-positional-arguments
             "--reify-sdpa-operator",
             action="store_true",
             help="enable conversion of scaled_dot_product_attention "
-            "to tract_transformers_sdpa. This is an experimental feature.",
+            "to tract_transformers_sdpa. When "
+            "--transformers-attn-implementation is left on auto, this also "
+            "loads the model with sdpa attention so the trace contains "
+            "scaled_dot_product_attention. This is an experimental feature.",
+        )
+
+        parser.add_argument(
+            "--transformers-attn-implementation",
+            dest="attn_implementation",
+            choices=["auto", "eager", "sdpa"],
+            default="auto",
+            help="attention implementation passed to Transformers at model "
+            "load. Mirrors the Transformers attn_implementation option. "
+            "auto keeps torch-to-nnef's safe default, except that "
+            "--reify-sdpa-operator implies sdpa.",
         )
 
         parser.add_argument(
@@ -339,6 +353,10 @@ def main():
         kwargs["upcast_quant"] = [
             m.strip() for m in kwargs["upcast_quant"].split(",") if m.strip()
         ]
+    if kwargs.get("attn_implementation") == "auto" and kwargs.get(
+        "reify_sdpa_operator"
+    ):
+        kwargs["attn_implementation"] = "sdpa"
     dump_llm(
         **kwargs,
         log_level=log_level,

--- a/packages/llm/torch_to_nnef_llm/exporter.py
+++ b/packages/llm/torch_to_nnef_llm/exporter.py
@@ -116,6 +116,25 @@ def _normalize_dump_kwargs(kwargs: T.Dict[str, T.Any]) -> T.Dict[str, T.Any]:
     return dump_kwargs
 
 
+def _resolve_attn_implementation(
+    attn_implementation: T.Optional[str],
+    reify_sdpa_operator: T.Optional[bool],
+) -> T.Optional[str]:
+    if attn_implementation == "auto":
+        attn_implementation = None
+    if attn_implementation is None:
+        return "sdpa" if reify_sdpa_operator else None
+    if attn_implementation not in ("eager", "sdpa"):
+        raise T2NErrorMisuse(
+            "attn_implementation must be one of: auto, eager, sdpa"
+        )
+    if attn_implementation == "eager" and reify_sdpa_operator:
+        raise T2NErrorMisuse(
+            "reify_sdpa_operator requires attn_implementation='sdpa' or 'auto'"
+        )
+    return attn_implementation
+
+
 #: Default number of retries for transient Hugging Face download failures.
 DEFAULT_HF_DOWNLOAD_N_RETRIES = 5
 
@@ -152,6 +171,7 @@ def _load_exporter_from(
     device_map: TYPE_OPTIONAL_DEVICE_MAP = None,
     trust_remote_code: bool = True,
     upcast_quant: T.Optional[T.Sequence[str]] = None,
+    attn_implementation: T.Optional[str] = None,
 ):
     if (
         is_forced_half_precision_model(force_inputs_dtype, force_module_dtype)
@@ -171,6 +191,7 @@ def _load_exporter_from(
         device_map=device_map,
         trust_remote_code=trust_remote_code,
         upcast_quant=upcast_quant,
+        attn_implementation=attn_implementation,
     )
     tokenizer = load_tokenizer(
         hf_model_causal.config,
@@ -1067,9 +1088,14 @@ def dump_llm(
     hf_download_n_retries: int = DEFAULT_HF_DOWNLOAD_N_RETRIES,
     trust_remote_code: bool = True,
     upcast_quant: T.Optional[T.Sequence[str]] = None,
+    attn_implementation: T.Optional[str] = None,
     **kwargs,
 ) -> T.Tuple[T.Union[Path, None], LLMExporter]:
     """Util to export LLM model."""
+    attn_implementation = _resolve_attn_implementation(
+        attn_implementation,
+        kwargs.get("reify_sdpa_operator"),
+    )
     exporter = LLMExporter.load(
         model_slug,
         local_dir,
@@ -1081,6 +1107,7 @@ def dump_llm(
         hf_download_n_retries=hf_download_n_retries,
         trust_remote_code=trust_remote_code,
         upcast_quant=upcast_quant,
+        attn_implementation=attn_implementation,
     )
     dump_kwargs = _normalize_dump_kwargs(kwargs)
     exporter.dump(**dump_kwargs)

--- a/packages/llm/torch_to_nnef_llm/loader.py
+++ b/packages/llm/torch_to_nnef_llm/loader.py
@@ -492,6 +492,11 @@ def _from_pretrained(
                 device_map=device_map,
                 offload_folder=tempfile.mkdtemp(suffix="offload_accelerate"),
             )
+        if hasattr(model, "tie_weights"):
+            # from_pretrained normally re-ties after loading. The manual
+            # init_empty_weights + dispatch path needs the same step, otherwise
+            # tied weights absent from the checkpoint can stay as meta tensors.
+            model.tie_weights()
         return model
     return transformers.AutoModelForCausalLM.from_pretrained(
         slug_or_dir, **kwargs
@@ -507,6 +512,7 @@ def load_model(
     device_map: TYPE_OPTIONAL_DEVICE_MAP = None,
     trust_remote_code: bool = True,
     upcast_quant: T.Optional[T.Sequence[str]] = None,
+    attn_implementation: T.Optional[str] = None,
     *,
     transformers: InjectedTransformersModule = INJECTED,
 ):
@@ -531,13 +537,21 @@ def load_model(
             hf_model_slug or local_dir,
         )
     kwargs: T.Dict[str, T.Any] = {"trust_remote_code": trust_remote_code}
+    if attn_implementation == "auto":
+        attn_implementation = None
+    if attn_implementation not in (None, "eager", "sdpa"):
+        raise T2NErrorMisuse(
+            "attn_implementation must be one of: auto, eager, sdpa"
+        )
     # transformers 5.x defaults to a fused SDPA attention path that (a) passes
     # mixed-dtype q/k/v (bf16 query vs float key/value) which the SDPA kernel
     # rejects during the export forward, and (b) exports to the fused
     # tract_transformers_sdpa op, which diverges from PyTorch on tract. Eager
     # attention decomposes into core ops that export cleanly and track much
     # closer (28%-of-elements divergence -> f32 noise on SmolLM).
-    if SemanticVersion.from_str(transformers.__version__) >= "5.0.0":
+    if attn_implementation is not None:
+        kwargs["attn_implementation"] = attn_implementation
+    elif SemanticVersion.from_str(transformers.__version__) >= "5.0.0":
         kwargs["attn_implementation"] = "eager"
     if force_module_dtype is not None:
         key = "torch_dtype"

--- a/packages/llm/torch_to_nnef_llm/loader.py
+++ b/packages/llm/torch_to_nnef_llm/loader.py
@@ -443,6 +443,29 @@ def _resolve_snapshot_dir(slug: str, huggingface_hub) -> str:
         return huggingface_hub.snapshot_download(slug)
 
 
+def _attention_kwargs(
+    attn_implementation: T.Optional[str],
+    transformers: InjectedTransformersModule,
+) -> T.Dict[str, str]:
+    if attn_implementation == "auto":
+        attn_implementation = None
+    if attn_implementation not in (None, "eager", "sdpa"):
+        raise T2NErrorMisuse(
+            "attn_implementation must be one of: auto, eager, sdpa"
+        )
+    if attn_implementation is not None:
+        return {"attn_implementation": attn_implementation}
+    # transformers 5.x defaults to a fused SDPA attention path that (a) passes
+    # mixed-dtype q/k/v (bf16 query vs float key/value) which the SDPA kernel
+    # rejects during the export forward, and (b) exports to the fused
+    # tract_transformers_sdpa op, which diverges from PyTorch on tract. Eager
+    # attention decomposes into core ops that export cleanly and track much
+    # closer (28%-of-elements divergence -> f32 noise on SmolLM).
+    if SemanticVersion.from_str(transformers.__version__) >= "5.0.0":
+        return {"attn_implementation": "eager"}
+    return {}
+
+
 @require_extra_decorator(extra=T2NExtra.LLM_TRACT, module="huggingface_hub")
 @require_extra_decorator(extra=T2NExtra.LLM_TRACT, module="transformers")
 def _from_pretrained(
@@ -537,22 +560,7 @@ def load_model(
             hf_model_slug or local_dir,
         )
     kwargs: T.Dict[str, T.Any] = {"trust_remote_code": trust_remote_code}
-    if attn_implementation == "auto":
-        attn_implementation = None
-    if attn_implementation not in (None, "eager", "sdpa"):
-        raise T2NErrorMisuse(
-            "attn_implementation must be one of: auto, eager, sdpa"
-        )
-    # transformers 5.x defaults to a fused SDPA attention path that (a) passes
-    # mixed-dtype q/k/v (bf16 query vs float key/value) which the SDPA kernel
-    # rejects during the export forward, and (b) exports to the fused
-    # tract_transformers_sdpa op, which diverges from PyTorch on tract. Eager
-    # attention decomposes into core ops that export cleanly and track much
-    # closer (28%-of-elements divergence -> f32 noise on SmolLM).
-    if attn_implementation is not None:
-        kwargs["attn_implementation"] = attn_implementation
-    elif SemanticVersion.from_str(transformers.__version__) >= "5.0.0":
-        kwargs["attn_implementation"] = "eager"
+    kwargs.update(_attention_kwargs(attn_implementation, transformers))
     if force_module_dtype is not None:
         key = "torch_dtype"
         if SemanticVersion.from_str(transformers.__version__) >= "4.57.0":


### PR DESCRIPTION
Summary:
- add an explicit LLM load-time attn_implementation option with validation
- expose --transformers-attn-implementation {auto,eager,sdpa} in the LLM CLI, naming that this is the Transformers attention implementation choice
- make --reify-sdpa-operator select Transformers sdpa attention when the CLI flag is left on auto
- make programmatic reify_sdpa_operator=True imply attn_implementation=sdpa when omitted or auto
- reject the invalid eager + reify combination early
- re-tie weights after manual device_map checkpoint dispatch so tied weights absent from a checkpoint do not remain meta tensors
- add network-free tests for loader defaults, explicit SDPA, invalid combinations, dump routing, CLI behavior, and manual-dispatch weight tying
- include the new SDPA tests in the LLM tox Transformers 4.x and 5.x matrix

Tests:
- PYTHONPATH=../.. uv run --group test pytest tests/test_load_retry.py tests/test_upcast_quant.py tests/test_sdpa_attention_export.py
- uv run --group test ruff format --check torch_to_nnef tests packages examples
- uv run --group test ruff check torch_to_nnef tests packages examples