### PR TITLE
Handle HF weight converters in offload dispatch

### DIFF
--- a/examples/getting_started_rs/Cargo.lock
+++ b/examples/getting_started_rs/Cargo.lock
@@ -247,9 +247,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/examples/imageclass-wasm/Cargo.lock
+++ b/examples/imageclass-wasm/Cargo.lock
@@ -253,9 +253,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/examples/llm_wasm/Cargo.lock
+++ b/examples/llm_wasm/Cargo.lock
@@ -253,9 +253,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/examples/mamba/external_state/mamba-rs/Cargo.lock
+++ b/examples/mamba/external_state/mamba-rs/Cargo.lock
@@ -152,9 +152,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/examples/mamba/pulse/mamba-rs/Cargo.lock
+++ b/examples/mamba/pulse/mamba-rs/Cargo.lock
@@ -152,9 +152,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/examples/speech_enhancement/dpdfnet/wav-cleaner-pulse/Cargo.lock
+++ b/examples/speech_enhancement/dpdfnet/wav-cleaner-pulse/Cargo.lock
@@ -108,9 +108,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/examples/yolo/Cargo.lock
+++ b/examples/yolo/Cargo.lock
@@ -298,9 +298,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/packages/llm/tests/test_upcast_quant.py
+++ b/packages/llm/tests/test_upcast_quant.py
@@ -360,6 +360,85 @@ def test_t2n_dispatch_rejects_weight_converters_without_device_map(tmp_path):
         )
 
 
+def test_t2n_dispatch_rejects_weight_converters_without_known_keys(tmp_path):
+    class TinyModel(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.foo = nn.Parameter(torch.empty(2, 2))
+
+    with init_empty_weights():
+        model = TinyModel()
+
+    checkpoint = tmp_path / "pytorch_model.bin"
+    torch.save(
+        {
+            "foo_blocks": torch.ones(2, 2),
+            "foo_scales": torch.ones(2, 2),
+        },
+        checkpoint,
+    )
+    offload_dir = tmp_path / "offload"
+    offload_dir.mkdir()
+
+    with pytest.raises(T2NErrorMisuse, match="indexed checkpoint"):
+        t2n_load_checkpoint_and_dispatch(
+            model,
+            checkpoint,
+            device_map=ON_DISK_DEVICE_MAP_KEY,
+            offload_dir=offload_dir,
+            weight_converters=[_ToyWeightConverter()],
+        )
+
+
+def test_from_pretrained_t2n_offload_passes_load_time_converters(
+    monkeypatch, tmp_path
+):
+    sentinel_model = nn.Module()
+    converters = [_ToyWeightConverter()]
+    quantizer = object()
+    calls = {}
+
+    class _FakeAutoModelForCausalLM:
+        @staticmethod
+        def from_pretrained(slug_or_dir, **kwargs):
+            calls["from_pretrained"] = (slug_or_dir, kwargs)
+            return sentinel_model
+
+    class _FakeTransformers:
+        AutoModelForCausalLM = _FakeAutoModelForCausalLM
+
+    monkeypatch.setattr(
+        loader,
+        "_load_time_weight_converters",
+        lambda plan: (converters, quantizer),
+    )
+
+    def fake_dispatch(model, checkpoint, **kwargs):
+        calls["dispatch"] = (model, checkpoint, kwargs)
+
+    monkeypatch.setattr(
+        loader, "t2n_load_checkpoint_and_dispatch", fake_dispatch
+    )
+
+    raw_from_pretrained = loader._from_pretrained.__wrapped__.__wrapped__
+    out = raw_from_pretrained(
+        tmp_path,
+        transformers=_FakeTransformers,
+        huggingface_hub=object(),
+        device_map=ON_DISK_DEVICE_MAP_KEY,
+        t2n_upcast_plan=("load", object()),
+    )
+
+    assert out is sentinel_model
+    assert calls["from_pretrained"][0] == tmp_path
+    dispatch_model, checkpoint, kwargs = calls["dispatch"]
+    assert dispatch_model is sentinel_model
+    assert checkpoint == tmp_path
+    assert kwargs["device_map"] == ON_DISK_DEVICE_MAP_KEY
+    assert kwargs["weight_converters"] is converters
+    assert kwargs["hf_quantizer"] is quantizer
+
+
 def test_t2n_dispatch_applies_weight_converter_across_shards(tmp_path):
     save_file = pytest.importorskip("safetensors.torch").save_file
 

--- a/packages/llm/tests/test_upcast_quant.py
+++ b/packages/llm/tests/test_upcast_quant.py
@@ -341,6 +341,33 @@ class _OrderedWeightConverter:
         return {layer_name: torch.stack(self.collected_tensors["foo_part"])}
 
 
+class _BroadWeightConverter:
+    source_patterns = ["weight$", "weight_scale"]
+    target_patterns = ["weight"]
+
+    def __init__(self):
+        self.collected_tensors = {
+            "weight$": [],
+            "weight_scale": [],
+        }
+
+    def rename_source_key(self, source_key):
+        if source_key.endswith("weight_scale"):
+            target_key = source_key.removesuffix("weight_scale") + "weight"
+            return target_key, "weight_scale"
+        if source_key.endswith("weight"):
+            return source_key, "weight$"
+        return source_key, None
+
+    def add_tensor(self, _target_key, _source_key, source_pattern, tensor):
+        self.collected_tensors[source_pattern].append(tensor)
+
+    def convert(self, layer_name, **_kwargs):
+        weight = self.collected_tensors["weight$"][0]
+        scale = self.collected_tensors["weight_scale"][0]
+        return {layer_name: weight + scale}
+
+
 def test_t2n_dispatch_rejects_weight_converters_without_device_map(tmp_path):
     class TinyModel(nn.Module):
         def __init__(self):
@@ -423,6 +450,7 @@ def test_from_pretrained_t2n_offload_passes_load_time_converters(
     raw_from_pretrained = loader._from_pretrained.__wrapped__.__wrapped__
     out = raw_from_pretrained(
         tmp_path,
+        _FakeAutoModelForCausalLM,
         transformers=_FakeTransformers,
         huggingface_hub=object(),
         device_map=ON_DISK_DEVICE_MAP_KEY,
@@ -529,6 +557,66 @@ def test_t2n_dispatch_preserves_global_converter_key_order(tmp_path):
     )
 
     assert torch.equal(model.foo.reload(), torch.tensor([[2.0], [10.0]]))
+
+
+def test_t2n_dispatch_does_not_capture_dense_weight_with_broad_converter(
+    tmp_path,
+):
+    save_file = pytest.importorskip("safetensors.torch").save_file
+
+    class TinyModel(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.foo = nn.Linear(2, 2, bias=False)
+
+    with init_empty_weights():
+        model = TinyModel()
+
+    save_file(
+        {"foo.weight": torch.full((2, 2), 4.0)}, tmp_path / "model.safetensors"
+    )
+    offload_dir = tmp_path / "offload"
+    offload_dir.mkdir()
+    t2n_load_checkpoint_and_dispatch(
+        model,
+        tmp_path,
+        device_map=ON_DISK_DEVICE_MAP_KEY,
+        offload_dir=offload_dir,
+        weight_converters=[_BroadWeightConverter()],
+    )
+
+    assert torch.equal(model.foo.weight.reload(), torch.full((2, 2), 4.0))
+
+
+def test_t2n_dispatch_uses_broad_converter_with_structural_evidence(tmp_path):
+    save_file = pytest.importorskip("safetensors.torch").save_file
+
+    class TinyModel(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.foo = nn.Linear(2, 2, bias=False)
+
+    with init_empty_weights():
+        model = TinyModel()
+
+    save_file(
+        {
+            "foo.weight": torch.ones(2, 2),
+            "foo.weight_scale": torch.full((2, 2), 2.0),
+        },
+        tmp_path / "model.safetensors",
+    )
+    offload_dir = tmp_path / "offload"
+    offload_dir.mkdir()
+    t2n_load_checkpoint_and_dispatch(
+        model,
+        tmp_path,
+        device_map=ON_DISK_DEVICE_MAP_KEY,
+        offload_dir=offload_dir,
+        weight_converters=[_BroadWeightConverter()],
+    )
+
+    assert torch.equal(model.foo.weight.reload(), torch.full((2, 2), 3.0))
 
 
 def _mxfp4_blocks(shape, packed_nibbles=0x21):

--- a/packages/llm/tests/test_upcast_quant.py
+++ b/packages/llm/tests/test_upcast_quant.py
@@ -6,13 +6,23 @@ GPU kernels, so only the pure planning / selection / dense-verification is
 covered here.
 """
 
+import json
+
 import pytest
+import torch
+from torch import nn
 
 from torch_to_nnef.exceptions import T2NErrorMisuse
+from torch_to_nnef.tensor.offload import (
+    ON_DISK_DEVICE_MAP_KEY,
+    t2n_load_checkpoint_and_dispatch,
+)
+from torch_to_nnef.utils import init_empty_weights
 from torch_to_nnef_llm import loader
 from torch_to_nnef_llm.loader import (
     UPCAST_ANY,
     _finish_upcast,
+    _load_time_weight_converters,
     _native_quant_method,
     _normalize_upcast_request,
     _plan_and_inject_upcast,
@@ -253,3 +263,151 @@ def test_finish_upcast_warns_when_quantized_but_not_requested(caplog):
         out = _finish_upcast(model, ("none", None), None)
     assert out is model  # left as-is (opt-in)
     assert any("upcast_quant was not" in r.message for r in caplog.records)
+
+
+class _ToyWeightConverter:
+    source_patterns = ["foo_blocks", "foo_scales"]
+    target_patterns = ["foo"]
+
+    def __init__(self):
+        self.collected_tensors = {
+            "foo_blocks": [],
+            "foo_scales": [],
+        }
+
+    def rename_source_key(self, source_key):
+        for source_pattern in self.source_patterns:
+            if source_pattern in source_key:
+                return (
+                    source_key.replace(source_pattern, "foo"),
+                    source_pattern,
+                )
+        return source_key, None
+
+    def add_tensor(self, _target_key, _source_key, source_pattern, tensor):
+        self.collected_tensors[source_pattern].append(tensor)
+
+    def convert(self, layer_name, **_kwargs):
+        blocks = self.collected_tensors["foo_blocks"][0]
+        scales = self.collected_tensors["foo_scales"][0]
+        return {layer_name: blocks + scales}
+
+
+def test_t2n_dispatch_applies_weight_converter_across_shards(tmp_path):
+    save_file = pytest.importorskip("safetensors.torch").save_file
+
+    class TinyModel(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.foo = nn.Parameter(torch.empty(2, 2))
+            self.bias = nn.Parameter(torch.empty(2))
+
+    with init_empty_weights():
+        model = TinyModel()
+
+    shard_1 = tmp_path / "model-00001-of-00002.safetensors"
+    shard_2 = tmp_path / "model-00002-of-00002.safetensors"
+    save_file({"foo_blocks": torch.ones(2, 2)}, shard_1)
+    save_file(
+        {
+            "foo_scales": torch.full((2, 2), 2.0),
+            "bias": torch.zeros(2),
+        },
+        shard_2,
+    )
+    (tmp_path / "model.safetensors.index.json").write_text(
+        json.dumps(
+            {
+                "metadata": {"total_size": 0},
+                "weight_map": {
+                    "foo_blocks": shard_1.name,
+                    "foo_scales": shard_2.name,
+                    "bias": shard_2.name,
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    offload_dir = tmp_path / "offload"
+    offload_dir.mkdir()
+    t2n_load_checkpoint_and_dispatch(
+        model,
+        tmp_path,
+        device_map=ON_DISK_DEVICE_MAP_KEY,
+        offload_dir=offload_dir,
+        weight_converters=[_ToyWeightConverter()],
+    )
+
+    assert not model.foo.is_meta
+    assert torch.equal(model.foo.reload(), torch.full((2, 2), 3.0))
+    assert not model.bias.is_meta
+
+
+def _mxfp4_blocks(shape, packed_nibbles=0x21):
+    return torch.full(shape, packed_nibbles, dtype=torch.uint8)
+
+
+def _mxfp4_scales(shape, exponent=0):
+    return torch.full(shape, 127 + exponent, dtype=torch.uint8)
+
+
+def test_t2n_dispatch_applies_mxfp4_weight_converter(tmp_path):
+    save_file = pytest.importorskip("safetensors.torch").save_file
+    pytest.importorskip("transformers.integrations.mxfp4")
+    gpt_oss_config = pytest.importorskip(
+        "transformers.models.gpt_oss.configuration_gpt_oss"
+    )
+    gpt_oss_modeling = pytest.importorskip(
+        "transformers.models.gpt_oss.modeling_gpt_oss"
+    )
+    quant_config_mod = pytest.importorskip(
+        "transformers.utils.quantization_config"
+    )
+
+    class OneExpertLayer(nn.Module):
+        def __init__(self):
+            super().__init__()
+            config = gpt_oss_config.GptOssConfig(
+                hidden_size=32,
+                intermediate_size=32,
+                num_local_experts=2,
+            )
+            self.experts = gpt_oss_modeling.GptOssExperts(config)
+
+    with init_empty_weights():
+        model = OneExpertLayer()
+
+    save_file(
+        {
+            "experts.gate_up_proj_blocks": _mxfp4_blocks((2, 64, 1, 16)),
+            "experts.gate_up_proj_scales": _mxfp4_scales((2, 64, 1)),
+            "experts.down_proj_blocks": _mxfp4_blocks((2, 32, 1, 16)),
+            "experts.down_proj_scales": _mxfp4_scales((2, 32, 1)),
+            "experts.gate_up_proj_bias": torch.zeros(2, 64),
+            "experts.down_proj_bias": torch.zeros(2, 32),
+        },
+        tmp_path / "model.safetensors",
+    )
+    quant_config = quant_config_mod.Mxfp4Config(dequantize=True)
+    weight_converters, hf_quantizer = _load_time_weight_converters(
+        ("load", quant_config)
+    )
+
+    offload_dir = tmp_path / "offload"
+    offload_dir.mkdir()
+    t2n_load_checkpoint_and_dispatch(
+        model,
+        tmp_path,
+        device_map=ON_DISK_DEVICE_MAP_KEY,
+        offload_dir=offload_dir,
+        weight_converters=weight_converters,
+        hf_quantizer=hf_quantizer,
+    )
+
+    gate_up_proj = model.experts.gate_up_proj.reload()
+    down_proj = model.experts.down_proj.reload()
+    assert gate_up_proj.shape == (2, 32, 64)
+    assert down_proj.shape == (2, 32, 32)
+    assert torch.isfinite(gate_up_proj).all()
+    assert torch.isfinite(down_proj).all()

--- a/packages/llm/tests/test_upcast_quant.py
+++ b/packages/llm/tests/test_upcast_quant.py
@@ -7,6 +7,7 @@ covered here.
 """
 
 import json
+from copy import deepcopy
 
 import pytest
 import torch
@@ -368,6 +369,25 @@ class _BroadWeightConverter:
         return {layer_name: weight + scale}
 
 
+class _SameKeyWeightConverter:
+    source_patterns = ["weight"]
+    target_patterns = ["weight"]
+
+    def __init__(self):
+        self.collected_tensors = {"weight": []}
+
+    def rename_source_key(self, source_key):
+        if source_key.endswith("weight"):
+            return source_key, "weight"
+        return source_key, None
+
+    def add_tensor(self, _target_key, _source_key, source_pattern, tensor):
+        self.collected_tensors[source_pattern].append(tensor)
+
+    def convert(self, layer_name, **_kwargs):
+        return {layer_name: self.collected_tensors["weight"][0] * 2}
+
+
 def test_t2n_dispatch_rejects_weight_converters_without_device_map(tmp_path):
     class TinyModel(nn.Module):
         def __init__(self):
@@ -619,12 +639,70 @@ def test_t2n_dispatch_uses_broad_converter_with_structural_evidence(tmp_path):
     assert torch.equal(model.foo.weight.reload(), torch.full((2, 2), 3.0))
 
 
+def test_t2n_dispatch_rejects_ambiguous_same_key_converter(tmp_path):
+    save_file = pytest.importorskip("safetensors.torch").save_file
+
+    class TinyModel(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.foo = nn.Linear(2, 2, bias=False)
+
+    with init_empty_weights():
+        model = TinyModel()
+
+    save_file({"foo.weight": torch.ones(2, 2)}, tmp_path / "model.safetensors")
+    offload_dir = tmp_path / "offload"
+    offload_dir.mkdir()
+    with pytest.raises(T2NErrorMisuse, match="same model key 'foo.weight'"):
+        t2n_load_checkpoint_and_dispatch(
+            model,
+            tmp_path,
+            device_map=ON_DISK_DEVICE_MAP_KEY,
+            offload_dir=offload_dir,
+            weight_converters=[_SameKeyWeightConverter()],
+        )
+
+
 def _mxfp4_blocks(shape, packed_nibbles=0x21):
-    return torch.full(shape, packed_nibbles, dtype=torch.uint8)
+    blocks = torch.empty(shape, dtype=torch.uint8)
+    blocks[..., ::2] = packed_nibbles
+    blocks[..., 1::2] = 0x43
+    return blocks
 
 
 def _mxfp4_scales(shape, exponent=0):
-    return torch.full(shape, 127 + exponent, dtype=torch.uint8)
+    scales = torch.full(shape, 127 + exponent, dtype=torch.uint8)
+    scales[..., 0] += torch.arange(shape[-2], dtype=torch.uint8) % 2
+    return scales
+
+
+def _direct_mxfp4_conversion(
+    state, weight_converters, hf_quantizer, target_key, model
+):
+    for converter_template in weight_converters:
+        converter = deepcopy(converter_template)
+        matched = False
+        for source_key, tensor in state.items():
+            renamed_key, source_pattern = converter.rename_source_key(
+                source_key
+            )
+            if renamed_key != target_key or source_pattern is None:
+                continue
+            matched = True
+            converter.add_tensor(
+                target_key,
+                source_key,
+                source_pattern,
+                tensor,
+            )
+        if matched:
+            return converter.convert(
+                target_key,
+                model=model,
+                config=getattr(model, "config", None),
+                hf_quantizer=hf_quantizer,
+            )[target_key]
+    raise AssertionError(f"no MXFP4 converter matched {target_key}")
 
 
 def test_t2n_dispatch_applies_mxfp4_weight_converter(tmp_path):
@@ -653,17 +731,15 @@ def test_t2n_dispatch_applies_mxfp4_weight_converter(tmp_path):
     with init_empty_weights():
         model = OneExpertLayer()
 
-    save_file(
-        {
-            "experts.gate_up_proj_blocks": _mxfp4_blocks((2, 64, 1, 16)),
-            "experts.gate_up_proj_scales": _mxfp4_scales((2, 64, 1)),
-            "experts.down_proj_blocks": _mxfp4_blocks((2, 32, 1, 16)),
-            "experts.down_proj_scales": _mxfp4_scales((2, 32, 1)),
-            "experts.gate_up_proj_bias": torch.zeros(2, 64),
-            "experts.down_proj_bias": torch.zeros(2, 32),
-        },
-        tmp_path / "model.safetensors",
-    )
+    state = {
+        "experts.gate_up_proj_blocks": _mxfp4_blocks((2, 64, 1, 16)),
+        "experts.gate_up_proj_scales": _mxfp4_scales((2, 64, 1)),
+        "experts.down_proj_blocks": _mxfp4_blocks((2, 32, 1, 16)),
+        "experts.down_proj_scales": _mxfp4_scales((2, 32, 1)),
+        "experts.gate_up_proj_bias": torch.zeros(2, 64),
+        "experts.down_proj_bias": torch.zeros(2, 32),
+    }
+    save_file(state, tmp_path / "model.safetensors")
     quant_config = quant_config_mod.Mxfp4Config(dequantize=True)
     weight_converters, hf_quantizer = _load_time_weight_converters(
         ("load", quant_config)
@@ -682,9 +758,23 @@ def test_t2n_dispatch_applies_mxfp4_weight_converter(tmp_path):
 
     gate_up_proj = model.experts.gate_up_proj.reload()
     down_proj = model.experts.down_proj.reload()
-    assert gate_up_proj.shape == (2, 32, 64)
-    assert down_proj.shape == (2, 32, 32)
-    assert torch.isfinite(gate_up_proj).all()
-    assert torch.isfinite(down_proj).all()
-    assert set(gate_up_proj.to(torch.float32).unique().tolist()) == {0.5, 1.0}
-    assert set(down_proj.to(torch.float32).unique().tolist()) == {0.5, 1.0}
+    assert torch.equal(
+        gate_up_proj,
+        _direct_mxfp4_conversion(
+            state,
+            weight_converters,
+            hf_quantizer,
+            "experts.gate_up_proj",
+            model,
+        ),
+    )
+    assert torch.equal(
+        down_proj,
+        _direct_mxfp4_conversion(
+            state,
+            weight_converters,
+            hf_quantizer,
+            "experts.down_proj",
+            model,
+        ),
+    )

--- a/packages/llm/tests/test_upcast_quant.py
+++ b/packages/llm/tests/test_upcast_quant.py
@@ -265,6 +265,35 @@ def test_finish_upcast_warns_when_quantized_but_not_requested(caplog):
     assert any("upcast_quant was not" in r.message for r in caplog.records)
 
 
+@pytest.mark.parametrize(
+    ("fake_quantizer", "message"),
+    [
+        (object(), "exposes no weight conversions"),
+        (
+            type(
+                "EmptyConverterQuantizer",
+                (),
+                {"get_weight_conversions": lambda self: []},
+            )(),
+            "returned no transformers weight conversions",
+        ),
+    ],
+)
+def test_load_time_weight_converters_fail_loudly(
+    monkeypatch, fake_quantizer, message
+):
+    import transformers.quantizers.auto as auto
+
+    monkeypatch.setattr(
+        auto.AutoHfQuantizer,
+        "from_config",
+        staticmethod(lambda *_args, **_kwargs: fake_quantizer),
+    )
+
+    with pytest.raises(T2NErrorMisuse, match=message):
+        _load_time_weight_converters(("load", _LoadTimeConfig("mxfp4")))
+
+
 class _ToyWeightConverter:
     source_patterns = ["foo_blocks", "foo_scales"]
     target_patterns = ["foo"]
@@ -291,6 +320,44 @@ class _ToyWeightConverter:
         blocks = self.collected_tensors["foo_blocks"][0]
         scales = self.collected_tensors["foo_scales"][0]
         return {layer_name: blocks + scales}
+
+
+class _OrderedWeightConverter:
+    source_patterns = ["foo_part"]
+    target_patterns = ["foo"]
+
+    def __init__(self):
+        self.collected_tensors = {"foo_part": []}
+
+    def rename_source_key(self, source_key):
+        if source_key.startswith("foo_part."):
+            return "foo", "foo_part"
+        return source_key, None
+
+    def add_tensor(self, _target_key, _source_key, source_pattern, tensor):
+        self.collected_tensors[source_pattern].append(tensor)
+
+    def convert(self, layer_name, **_kwargs):
+        return {layer_name: torch.stack(self.collected_tensors["foo_part"])}
+
+
+def test_t2n_dispatch_rejects_weight_converters_without_device_map(tmp_path):
+    class TinyModel(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.foo = nn.Parameter(torch.empty(2, 2))
+
+    with init_empty_weights():
+        model = TinyModel()
+
+    with pytest.raises(T2NErrorMisuse, match="require a device_map"):
+        t2n_load_checkpoint_and_dispatch(
+            model,
+            tmp_path,
+            device_map=None,
+            offload_dir=tmp_path,
+            weight_converters=[_ToyWeightConverter()],
+        )
 
 
 def test_t2n_dispatch_applies_weight_converter_across_shards(tmp_path):
@@ -342,6 +409,47 @@ def test_t2n_dispatch_applies_weight_converter_across_shards(tmp_path):
     assert not model.foo.is_meta
     assert torch.equal(model.foo.reload(), torch.full((2, 2), 3.0))
     assert not model.bias.is_meta
+
+
+def test_t2n_dispatch_preserves_global_converter_key_order(tmp_path):
+    save_file = pytest.importorskip("safetensors.torch").save_file
+
+    class TinyModel(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.foo = nn.Parameter(torch.empty(2, 1))
+
+    with init_empty_weights():
+        model = TinyModel()
+
+    shard_1 = tmp_path / "model-00001-of-00002.safetensors"
+    shard_2 = tmp_path / "model-00002-of-00002.safetensors"
+    save_file({"foo_part.10": torch.tensor([10.0])}, shard_1)
+    save_file({"foo_part.2": torch.tensor([2.0])}, shard_2)
+    (tmp_path / "model.safetensors.index.json").write_text(
+        json.dumps(
+            {
+                "metadata": {"total_size": 0},
+                "weight_map": {
+                    "foo_part.10": shard_1.name,
+                    "foo_part.2": shard_2.name,
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    offload_dir = tmp_path / "offload"
+    offload_dir.mkdir()
+    t2n_load_checkpoint_and_dispatch(
+        model,
+        tmp_path,
+        device_map=ON_DISK_DEVICE_MAP_KEY,
+        offload_dir=offload_dir,
+        weight_converters=[_OrderedWeightConverter()],
+    )
+
+    assert torch.equal(model.foo.reload(), torch.tensor([[2.0], [10.0]]))
 
 
 def _mxfp4_blocks(shape, packed_nibbles=0x21):
@@ -411,3 +519,5 @@ def test_t2n_dispatch_applies_mxfp4_weight_converter(tmp_path):
     assert down_proj.shape == (2, 32, 32)
     assert torch.isfinite(gate_up_proj).all()
     assert torch.isfinite(down_proj).all()
+    assert set(gate_up_proj.to(torch.float32).unique().tolist()) == {0.5, 1.0}
+    assert set(down_proj.to(torch.float32).unique().tolist()) == {0.5, 1.0}

--- a/packages/llm/torch_to_nnef_llm/loader.py
+++ b/packages/llm/torch_to_nnef_llm/loader.py
@@ -280,6 +280,26 @@ def _plan_and_inject_upcast(
     return plan
 
 
+def _load_time_weight_converters(plan):
+    """Return HF load-time converters for a load-time up-cast plan.
+
+    The standard transformers loader applies these converters while reading the
+    checkpoint. T2N's custom offload dispatcher must do the same, otherwise
+    serialized native-quant keys such as packed blocks/scales are treated as
+    unexpected and the dense target parameters stay on meta.
+    """
+    if plan[0] != "load":
+        return None, None
+    # pylint: disable-next=import-outside-toplevel
+    from transformers.quantizers.auto import AutoHfQuantizer
+
+    hf_quantizer = AutoHfQuantizer.from_config(plan[1], pre_quantized=True)
+    get_conversions = getattr(hf_quantizer, "get_weight_conversions", None)
+    if get_conversions is None:
+        return None, hf_quantizer
+    return get_conversions(), hf_quantizer
+
+
 def _finish_upcast(model, plan, requested):
     """Complete the up-cast after load and verify the model is dense.
 
@@ -486,6 +506,7 @@ def _from_pretrained(
     *,
     huggingface_hub: InjectedHuggingFaceHubModule = INJECTED,
     transformers: InjectedTransformersModule = INJECTED,
+    t2n_upcast_plan=("none", None),
     **kwargs,
 ):
     if "device_map" in kwargs and kwargs["device_map"] is not None:
@@ -510,11 +531,16 @@ def _from_pretrained(
             _ in device_map
             for _ in [AUTO_DEVICE_MAP_KEY, ON_DISK_DEVICE_MAP_KEY]
         ):
+            weight_converters, hf_quantizer = _load_time_weight_converters(
+                t2n_upcast_plan
+            )
             t2n_load_checkpoint_and_dispatch(
                 model,
                 weights_location,
                 device_map=device_map,
                 offload_dir=Path(tempfile.mkdtemp(suffix="offload_t2n")),
+                weight_converters=weight_converters,
+                hf_quantizer=hf_quantizer,
             )
         elif device_map:
             # pylint: disable-next=import-outside-toplevel
@@ -608,7 +634,10 @@ def load_model(
             )
             auto_model_class = resolve_auto_model_class(config.model_type)
             hf_model_causal = _from_pretrained(
-                dir_path, auto_model_class, **kwargs
+                dir_path,
+                auto_model_class,
+                t2n_upcast_plan=upcast_plan,
+                **kwargs,
             )
             LOGGER.info(
                 "load '%s' from local directory: %s",
@@ -623,7 +652,10 @@ def load_model(
         )
         auto_model_class = resolve_auto_model_class(config.model_type)
         hf_model_causal = _from_pretrained(
-            hf_model_slug, auto_model_class, **kwargs
+            hf_model_slug,
+            auto_model_class,
+            t2n_upcast_plan=upcast_plan,
+            **kwargs,
         )
         LOGGER.info(
             "load default trained model from huggingface: '%s'", hf_model_slug

--- a/packages/llm/torch_to_nnef_llm/loader.py
+++ b/packages/llm/torch_to_nnef_llm/loader.py
@@ -296,8 +296,20 @@ def _load_time_weight_converters(plan):
     hf_quantizer = AutoHfQuantizer.from_config(plan[1], pre_quantized=True)
     get_conversions = getattr(hf_quantizer, "get_weight_conversions", None)
     if get_conversions is None:
-        return None, hf_quantizer
-    return get_conversions(), hf_quantizer
+        method = _quant_method_of(plan[1])
+        raise T2NErrorMisuse(
+            f"native '{method}' load-time up-cast cannot use T2N custom "
+            "offload dispatch because its transformers quantizer exposes no "
+            "weight conversions"
+        )
+    conversions = get_conversions()
+    if not conversions:
+        method = _quant_method_of(plan[1])
+        raise T2NErrorMisuse(
+            f"native '{method}' load-time up-cast returned no transformers "
+            "weight conversions for T2N custom offload dispatch"
+        )
+    return conversions, hf_quantizer
 
 
 def _finish_upcast(model, plan, requested):

--- a/torch_to_nnef/tensor/offload.py
+++ b/torch_to_nnef/tensor/offload.py
@@ -67,11 +67,244 @@ TDEVICE = T.Union[int, str, torch.device]
 LOGGER = logging.getLogger(__name__)
 
 
+class _WeightConverterLike(T.Protocol):
+    source_patterns: T.Sequence[str]
+    target_patterns: T.Sequence[str]
+
+    def rename_source_key(
+        self, source_key: str
+    ) -> T.Tuple[str, T.Optional[str]]:
+        """Rename a checkpoint source key to a target model key."""
+
+    def add_tensor(
+        self,
+        target_key: str,
+        source_key: str,
+        source_pattern: str,
+        tensor: torch.Tensor,
+    ) -> None:
+        """Collect one source tensor for later conversion."""
+
+    def convert(self, layer_name: str, **kwargs) -> T.Mapping[str, T.Any]:
+        """Convert collected tensors to one or more target tensors."""
+
+
 def _dot_natural_key(key: str):
     return [
         int(part) if part.isdigit() else part
         for part in re.split(r"(\d+)", key)
     ]
+
+
+class _WeightConversionCollector:
+    def __init__(
+        self,
+        *,
+        model: nn.Module,
+        model_keys: T.Set[str],
+        checkpoint_files: T.Sequence[Path],
+        checkpoint_key_to_file: T.Optional[T.Mapping[str, str]],
+        weight_converters: T.Sequence[_WeightConverterLike],
+        hf_quantizer: T.Optional[T.Any],
+        unexpected_keys: T.Set[str],
+        set_param: T.Callable[[str, torch.Tensor], None],
+    ):
+        self.model = model
+        self.model_keys = model_keys
+        self.weight_converters = list(weight_converters)
+        self.hf_quantizer = hf_quantizer
+        self.unexpected_keys = unexpected_keys
+        self.set_param = set_param
+        self.converted_params_to_load: T.Dict[
+            str, T.List[T.Tuple[int, str, str, T.Any]]
+        ] = {}
+        self.converted_templates: T.Dict[str, _WeightConverterLike] = {}
+        self.converter_by_source = {
+            source_pattern: converter
+            for converter in self.weight_converters
+            for source_pattern in converter.source_patterns
+        }
+        self.base_model_prefix = getattr(model, "base_model_prefix", None)
+        all_checkpoint_keys = self._all_checkpoint_keys(
+            checkpoint_files, checkpoint_key_to_file
+        )
+        if self.weight_converters and all_checkpoint_keys is None:
+            raise T2NErrorMisuse(
+                "weight_converters require an indexed checkpoint or "
+                "safetensors files so source tensors can be grouped before "
+                "conversion"
+            )
+        self.checkpoint_key_rank = {}
+        self.converted_expected_counts = None
+        if all_checkpoint_keys is not None:
+            self.checkpoint_key_rank = {
+                key: rank for rank, key in enumerate(all_checkpoint_keys)
+            }
+            self.converted_expected_counts = {}
+            for key in all_checkpoint_keys:
+                renamed_key, source_pattern = self.rename_source_key(key)
+                if source_pattern is None or renamed_key not in self.model_keys:
+                    continue
+                self.converted_expected_counts.setdefault(
+                    renamed_key, Counter()
+                )[source_pattern] += 1
+        self.fallback_rank = count(len(self.checkpoint_key_rank))
+
+    @staticmethod
+    def checkpoint_file_keys(checkpoint_file):
+        if not checkpoint_file.name.endswith(".safetensors"):
+            return None
+        # pylint: disable-next=import-outside-toplevel
+        import safetensors
+
+        with safetensors.safe_open(checkpoint_file, framework="pt") as f:
+            return list(f.keys())
+
+    def _all_checkpoint_keys(self, checkpoint_files, checkpoint_key_to_file):
+        if not self.weight_converters:
+            return None
+        if checkpoint_key_to_file is not None:
+            return sorted(checkpoint_key_to_file.keys(), key=_dot_natural_key)
+        if not all(
+            file.name.endswith(".safetensors") for file in checkpoint_files
+        ):
+            return None
+        keys = []
+        for checkpoint_file in checkpoint_files:
+            file_keys = self.checkpoint_file_keys(checkpoint_file)
+            if file_keys is None:
+                return None
+            keys.extend(file_keys)
+        return sorted(keys, key=_dot_natural_key)
+
+    def rename_source_key(self, source_key):
+        renamed_key = source_key
+        source_pattern = None
+        for converter in self.weight_converters:
+            renamed_key, source_pattern = converter.rename_source_key(
+                renamed_key
+            )
+            if source_pattern is not None:
+                break
+        if self.base_model_prefix:
+            prefix = f"{self.base_model_prefix}."
+            if renamed_key.startswith(prefix):
+                unprefixed = renamed_key[len(prefix) :]
+                if unprefixed in self.model_keys:
+                    renamed_key = unprefixed
+            else:
+                prefixed = f"{self.base_model_prefix}.{renamed_key}"
+                if prefixed in self.model_keys:
+                    renamed_key = prefixed
+        return renamed_key, source_pattern
+
+    def rank_for_key(self, key):
+        if key in self.checkpoint_key_rank:
+            return self.checkpoint_key_rank[key]
+        return next(self.fallback_rank)
+
+    def converter_inputs_complete(self, renamed_key):
+        entries = self.converted_params_to_load[renamed_key]
+        template = self.converted_templates[renamed_key]
+        collected_counts = Counter(entry[2] for entry in entries)
+        expected_counts = (
+            self.converted_expected_counts.get(renamed_key)
+            if self.converted_expected_counts is not None
+            else None
+        )
+        for source_pattern in template.source_patterns:
+            expected = (
+                expected_counts.get(source_pattern, 0)
+                if expected_counts is not None
+                else 1
+            )
+            if expected <= 0 or collected_counts[source_pattern] < expected:
+                return False
+        return True
+
+    def convert_collected_param(self, renamed_key):
+        entries = self.converted_params_to_load.pop(renamed_key)
+        template = self.converted_templates.pop(renamed_key)
+        converter = deepcopy(template)
+        for _rank, param_name, source_pattern, param in sorted(
+            entries,
+            key=lambda entry: (
+                entry[0],
+                _dot_natural_key(entry[1]),
+                entry[2],
+            ),
+        ):
+            converter.add_tensor(
+                renamed_key,
+                param_name,
+                source_pattern,
+                param,
+            )
+        try:
+            converted_tensors = converter.convert(
+                renamed_key,
+                model=self.model,
+                config=getattr(self.model, "config", None),
+                hf_quantizer=self.hf_quantizer,
+            )
+        except Exception as exc:
+            raise T2NErrorMisuse(
+                f"failed to convert checkpoint tensors for '{renamed_key}': "
+                f"{exc}"
+            ) from exc
+        for target_name, param in converted_tensors.items():
+            param = param[0] if isinstance(param, list) else param
+            self.set_param(target_name, param)
+        del converted_tensors
+        gc.collect()
+
+    def collect(self, param_name, param):
+        renamed_key, source_pattern = self.rename_source_key(param_name)
+        if source_pattern is None:
+            return False
+
+        if renamed_key in self.model_keys:
+            self.converted_templates.setdefault(
+                renamed_key, self.converter_by_source[source_pattern]
+            )
+            self.converted_params_to_load.setdefault(renamed_key, []).append(
+                (
+                    self.rank_for_key(param_name),
+                    param_name,
+                    source_pattern,
+                    param,
+                )
+            )
+            if self.converter_inputs_complete(renamed_key):
+                self.convert_collected_param(renamed_key)
+            return True
+
+        converter = self.converter_by_source[source_pattern]
+        for target_pattern in converter.target_patterns:
+            self.unexpected_keys.add(
+                renamed_key.replace(
+                    converter.target_patterns[0], target_pattern
+                )
+            )
+        return True
+
+    def finish(self):
+        if not self.converted_params_to_load:
+            return
+        details = {}
+        for renamed_key, entries in self.converted_params_to_load.items():
+            template = self.converted_templates[renamed_key]
+            collected_counts = Counter(entry[2] for entry in entries)
+            missing = [
+                source_pattern
+                for source_pattern in template.source_patterns
+                if collected_counts[source_pattern] == 0
+            ]
+            details[renamed_key] = missing or list(template.source_patterns)
+        raise T2NErrorMisuse(
+            "incomplete checkpoint tensors for weight conversion: "
+            f"{details}"
+        )
 
 
 class OffloadedTensor(OpaqueTensor):
@@ -655,7 +888,7 @@ def t2n_load_checkpoint_and_dispatch(
     offload_dir: Path,
     strict: bool = False,
     offload_at_load_state_dict: bool = False,
-    weight_converters: T.Optional[T.Sequence[T.Any]] = None,
+    weight_converters: T.Optional[T.Sequence[_WeightConverterLike]] = None,
     hf_quantizer: T.Optional[T.Any] = None,
 ):
     """Allow to offload as soon as possible.
@@ -739,16 +972,6 @@ def t2n_load_checkpoint_and_dispatch(
         checkpoint_files = [checkpoint_folder / f for f in checkpoint_files]
     unexpected_keys = set()
     model_keys = set(model.state_dict().keys())
-    converted_params_to_load: T.Dict[
-        str, T.List[T.Tuple[int, str, str, T.Any]]
-    ] = {}
-    converted_templates: T.Dict[str, T.Any] = {}
-    converter_by_source = {
-        source_pattern: converter
-        for converter in weight_converters
-        for source_pattern in converter.source_patterns
-    }
-    base_model_prefix = getattr(model, "base_model_prefix", None)
     assert checkpoint_files is not None
     mod_updater = ModTensorUpdater(
         model,
@@ -756,76 +979,6 @@ def t2n_load_checkpoint_and_dispatch(
         add_buffers=True,
         add_unregistred_tensor=True,
     )
-
-    def rename_with_converters(source_key):
-        renamed_key = source_key
-        source_pattern = None
-        for converter in weight_converters:
-            renamed_key, source_pattern = converter.rename_source_key(
-                renamed_key
-            )
-            if source_pattern is not None:
-                break
-        if base_model_prefix:
-            prefix = f"{base_model_prefix}."
-            if renamed_key.startswith(prefix):
-                unprefixed = renamed_key[len(prefix) :]
-                if unprefixed in model_keys:
-                    renamed_key = unprefixed
-            else:
-                prefixed = f"{base_model_prefix}.{renamed_key}"
-                if prefixed in model_keys:
-                    renamed_key = prefixed
-        return renamed_key, source_pattern
-
-    def checkpoint_file_keys(checkpoint_file):
-        if not checkpoint_file.name.endswith(".safetensors"):
-            return None
-        # pylint: disable-next=import-outside-toplevel
-        import safetensors
-
-        with safetensors.safe_open(checkpoint_file, framework="pt") as f:
-            return list(f.keys())
-
-    all_checkpoint_keys = None
-    if weight_converters and checkpoint_key_to_file is not None:
-        all_checkpoint_keys = sorted(
-            checkpoint_key_to_file.keys(), key=_dot_natural_key
-        )
-    elif weight_converters and all(
-        file.name.endswith(".safetensors") for file in checkpoint_files
-    ):
-        keys = []
-        for checkpoint_file in checkpoint_files:
-            file_keys = checkpoint_file_keys(checkpoint_file)
-            if file_keys is None:
-                keys = None
-                break
-            keys.extend(file_keys)
-        if keys is not None:
-            all_checkpoint_keys = sorted(keys, key=_dot_natural_key)
-
-    checkpoint_key_rank = {}
-    converted_expected_counts = None
-    if all_checkpoint_keys is not None:
-        checkpoint_key_rank = {
-            key: rank for rank, key in enumerate(all_checkpoint_keys)
-        }
-        converted_expected_counts = {}
-        for key in all_checkpoint_keys:
-            renamed_key, source_pattern = rename_with_converters(key)
-            if source_pattern is None or renamed_key not in model_keys:
-                continue
-            converted_expected_counts.setdefault(renamed_key, Counter())[
-                source_pattern
-            ] += 1
-
-    fallback_rank = count(len(checkpoint_key_rank))
-
-    def rank_for_key(key):
-        if key in checkpoint_key_rank:
-            return checkpoint_key_rank[key]
-        return next(fallback_rank)
 
     def param_device_for(param_name):
         module_name = param_name
@@ -845,90 +998,16 @@ def t2n_load_checkpoint_and_dispatch(
             offload_dir=offload_dir,
         )
 
-    def converter_inputs_complete(renamed_key):
-        entries = converted_params_to_load[renamed_key]
-        template = converted_templates[renamed_key]
-        collected_counts = Counter(entry[2] for entry in entries)
-        expected_counts = (
-            converted_expected_counts.get(renamed_key)
-            if converted_expected_counts is not None
-            else None
-        )
-        for source_pattern in template.source_patterns:
-            expected = (
-                expected_counts.get(source_pattern, 0)
-                if expected_counts is not None
-                else 1
-            )
-            if expected <= 0 or collected_counts[source_pattern] < expected:
-                return False
-        return True
-
-    def convert_collected_param(renamed_key):
-        entries = converted_params_to_load.pop(renamed_key)
-        template = converted_templates.pop(renamed_key)
-        converter = deepcopy(template)
-        for _rank, param_name, source_pattern, param in sorted(
-            entries,
-            key=lambda entry: (
-                entry[0],
-                _dot_natural_key(entry[1]),
-                entry[2],
-            ),
-        ):
-            converter.add_tensor(
-                renamed_key,
-                param_name,
-                source_pattern,
-                param,
-            )
-        try:
-            converted_tensors = converter.convert(
-                renamed_key,
-                model=model,
-                config=getattr(model, "config", None),
-                hf_quantizer=hf_quantizer,
-            )
-        except Exception as exc:
-            raise T2NErrorMisuse(
-                f"failed to convert checkpoint tensors for '{renamed_key}': "
-                f"{exc}"
-            ) from exc
-        for target_name, param in converted_tensors.items():
-            param = param[0] if isinstance(param, list) else param
-            set_param(target_name, param)
-        del converted_tensors
-        gc.collect()
-
-    def collect_converted_param(param_name, param):
-        renamed_key, source_pattern = rename_with_converters(param_name)
-        if source_pattern is None:
-            return False
-
-        if renamed_key in model_keys:
-            converted_templates.setdefault(
-                renamed_key, converter_by_source[source_pattern]
-            )
-            converted_params_to_load.setdefault(renamed_key, []).append(
-                (
-                    rank_for_key(param_name),
-                    param_name,
-                    source_pattern,
-                    param,
-                )
-            )
-            if converter_inputs_complete(renamed_key):
-                convert_collected_param(renamed_key)
-            return True
-
-        converter = converter_by_source[source_pattern]
-        for target_pattern in converter.target_patterns:
-            unexpected_keys.add(
-                renamed_key.replace(
-                    converter.target_patterns[0], target_pattern
-                )
-            )
-        return True
+    converter_collector = _WeightConversionCollector(
+        model=model,
+        model_keys=model_keys,
+        checkpoint_files=checkpoint_files,
+        checkpoint_key_to_file=checkpoint_key_to_file,
+        weight_converters=weight_converters,
+        hf_quantizer=hf_quantizer,
+        unexpected_keys=unexpected_keys,
+        set_param=set_param,
+    )
 
     for checkpoint_file in checkpoint_files:
         loaded_checkpoint = load_state_dict(
@@ -941,16 +1020,16 @@ def t2n_load_checkpoint_and_dispatch(
             model.load_state_dict(loaded_checkpoint, strict=strict)
             unexpected_keys.update(set(loaded_checkpoint.keys()) - model_keys)
         else:
-            for param_name, param in sorted(
-                loaded_checkpoint.items(),
-                key=lambda kv: _dot_natural_key(kv[0]),
+            for param_name in sorted(
+                list(loaded_checkpoint.keys()), key=_dot_natural_key
             ):
+                param = loaded_checkpoint.pop(param_name)
                 # skip SCB parameter (for 8-bit serialization)
                 if "SCB" in param_name:
                     LOGGER.error("unsupported SCB param")
                     continue
 
-                if collect_converted_param(param_name, param):
+                if converter_collector.collect(param_name, param):
                     continue
 
                 if param_name not in model_keys:
@@ -962,21 +1041,7 @@ def t2n_load_checkpoint_and_dispatch(
         # Force Python to clean up.
         del loaded_checkpoint
         gc.collect()
-    if converted_params_to_load:
-        details = {}
-        for renamed_key, entries in converted_params_to_load.items():
-            template = converted_templates[renamed_key]
-            collected_counts = Counter(entry[2] for entry in entries)
-            missing = [
-                source_pattern
-                for source_pattern in template.source_patterns
-                if collected_counts[source_pattern] == 0
-            ]
-            details[renamed_key] = missing or list(template.source_patterns)
-        raise T2NErrorMisuse(
-            "incomplete checkpoint tensors for weight conversion: "
-            f"{details}"
-        )
+    converter_collector.finish()
     if not strict and len(unexpected_keys) > 0:
         LOGGER.warning(
             "Some weights of the model checkpoint at %s were not used when"

--- a/torch_to_nnef/tensor/offload.py
+++ b/torch_to_nnef/tensor/offload.py
@@ -89,6 +89,12 @@ class _WeightConverterLike(T.Protocol):
         """Convert collected tensors to one or more target tensors."""
 
 
+class _MatchedWeightConverter(T.NamedTuple):
+    renamed_key: str
+    converter: T.Optional[_WeightConverterLike]
+    source_pattern: T.Optional[str]
+
+
 def _dot_natural_key(key: str):
     return [
         int(part) if part.isdigit() else part
@@ -119,11 +125,9 @@ class _WeightConversionCollector:
             str, T.List[T.Tuple[int, str, str, T.Any]]
         ] = {}
         self.converted_templates: T.Dict[str, _WeightConverterLike] = {}
-        self.converter_by_source = {
-            source_pattern: converter
-            for converter in self.weight_converters
-            for source_pattern in converter.source_patterns
-        }
+        self.unsupported_same_key_conversions: T.Dict[
+            str, T.Tuple[str, str]
+        ] = {}
         self.base_model_prefix = getattr(model, "base_model_prefix", None)
         all_checkpoint_keys = self._all_checkpoint_keys(
             checkpoint_files, checkpoint_key_to_file
@@ -143,17 +147,34 @@ class _WeightConversionCollector:
             self.converted_expected_counts = {}
             converted_source_keys = {}
             for key in all_checkpoint_keys:
-                renamed_key, source_pattern = self.rename_source_key(key)
-                if source_pattern is None or renamed_key not in self.model_keys:
+                match = self.rename_source_key(key)
+                if (
+                    match.source_pattern is None
+                    or match.converter is None
+                    or match.renamed_key not in self.model_keys
+                ):
                     continue
                 self.converted_expected_counts.setdefault(
-                    renamed_key, Counter()
-                )[source_pattern] += 1
-                converted_source_keys.setdefault(renamed_key, []).append(key)
+                    match.renamed_key, Counter()
+                )[match.source_pattern] += 1
+                converted_source_keys.setdefault(match.renamed_key, []).append(
+                    (key, match.converter)
+                )
             self.convertible_keys = {
                 renamed_key
-                for renamed_key, source_keys in converted_source_keys.items()
-                if self._has_conversion_evidence(renamed_key, source_keys)
+                for renamed_key, matches in converted_source_keys.items()
+                if self._has_conversion_evidence(
+                    renamed_key, [source_key for source_key, _ in matches]
+                )
+            }
+            self.unsupported_same_key_conversions = {
+                renamed_key: (source_key, converter.__class__.__name__)
+                for renamed_key, matches in converted_source_keys.items()
+                if renamed_key not in self.convertible_keys
+                for source_key, converter in matches
+                if self._is_ambiguous_same_key_conversion(
+                    renamed_key, source_key, converter
+                )
             }
         else:
             self.convertible_keys = set()
@@ -188,12 +209,14 @@ class _WeightConversionCollector:
 
     def rename_source_key(self, source_key):
         renamed_key = source_key
+        converter = None
         source_pattern = None
-        for converter in self.weight_converters:
-            renamed_key, source_pattern = converter.rename_source_key(
+        for candidate in self.weight_converters:
+            renamed_key, source_pattern = candidate.rename_source_key(
                 renamed_key
             )
             if source_pattern is not None:
+                converter = candidate
                 break
         if self.base_model_prefix:
             prefix = f"{self.base_model_prefix}."
@@ -205,7 +228,7 @@ class _WeightConversionCollector:
                 prefixed = f"{self.base_model_prefix}.{renamed_key}"
                 if prefixed in self.model_keys:
                     renamed_key = prefixed
-        return renamed_key, source_pattern
+        return _MatchedWeightConverter(renamed_key, converter, source_pattern)
 
     def normalize_model_key(self, source_key):
         if not self.base_model_prefix:
@@ -235,6 +258,16 @@ class _WeightConversionCollector:
                 self.normalize_model_key(key) != renamed_key
                 for key in source_keys
             )
+        )
+
+    def _is_ambiguous_same_key_conversion(
+        self, renamed_key, source_key, converter
+    ):
+        """Whether direct-loading would silently bypass a matched converter."""
+        return (
+            len(converter.source_patterns) == 1
+            and len(converter.target_patterns) == 1
+            and self.normalize_model_key(source_key) == renamed_key
         )
 
     def rank_for_key(self, key):
@@ -301,33 +334,47 @@ class _WeightConversionCollector:
         gc.collect()
 
     def collect(self, param_name, param):
-        renamed_key, source_pattern = self.rename_source_key(param_name)
-        if source_pattern is None:
+        match = self.rename_source_key(param_name)
+        if match.source_pattern is None or match.converter is None:
             return False
 
-        if renamed_key in self.model_keys:
-            if renamed_key not in self.convertible_keys:
+        if match.renamed_key in self.model_keys:
+            if match.renamed_key not in self.convertible_keys:
+                if match.renamed_key in self.unsupported_same_key_conversions:
+                    source_key, converter_name = (
+                        self.unsupported_same_key_conversions[match.renamed_key]
+                    )
+                    raise T2NErrorMisuse(
+                        "unsupported weight converter for custom offload "
+                        f"dispatch: '{converter_name}' maps '{source_key}' to "
+                        f"the same model key '{match.renamed_key}' without "
+                        "checkpoint-level structural evidence. Use the "
+                        "standard transformers loader for this quantizer, or "
+                        "provide a checkpoint whose converted tensors are "
+                        "structurally distinguishable."
+                    )
                 return False
             self.converted_templates.setdefault(
-                renamed_key, self.converter_by_source[source_pattern]
+                match.renamed_key, match.converter
             )
-            self.converted_params_to_load.setdefault(renamed_key, []).append(
+            self.converted_params_to_load.setdefault(
+                match.renamed_key, []
+            ).append(
                 (
                     self.rank_for_key(param_name),
                     param_name,
-                    source_pattern,
+                    match.source_pattern,
                     param,
                 )
             )
-            if self.converter_inputs_complete(renamed_key):
-                self.convert_collected_param(renamed_key)
+            if self.converter_inputs_complete(match.renamed_key):
+                self.convert_collected_param(match.renamed_key)
             return True
 
-        converter = self.converter_by_source[source_pattern]
-        for target_pattern in converter.target_patterns:
+        for target_pattern in match.converter.target_patterns:
             self.unexpected_keys.add(
-                renamed_key.replace(
-                    converter.target_patterns[0], target_pattern
+                match.renamed_key.replace(
+                    match.converter.target_patterns[0], target_pattern
                 )
             )
         return True
@@ -946,10 +993,29 @@ def t2n_load_checkpoint_and_dispatch(
 ):
     """Allow to offload as soon as possible.
 
-    This may be benefical in some rare case where
+    This may be beneficial in some rare case where
     partitioned safetensors file are too big for RAM
     else it's better to offload after
     dtype cast in set_module_tensor_to_device.
+
+    Args:
+        model: Model skeleton to populate.
+        checkpoint: Checkpoint file, checkpoint index, or checkpoint directory.
+        device_map: Device placement map, ``t2n_auto``, ``t2n_offload_disk``,
+            or ``None`` to use ``load_state_dict`` directly.
+        offload_dir: Directory used to store disk-offloaded tensors.
+        strict: Whether to enforce strict checkpoint/model key matching.
+        offload_at_load_state_dict: Whether each tensor should be offloaded as
+            soon as it is read from the checkpoint.
+        weight_converters: Optional Hugging Face load-time weight converters to
+            apply while dispatching. The custom offload path supports
+            converters whose checkpoint tensors are structurally
+            distinguishable from their dense target, such as multiple source
+            tensors or renamed packed tensors for one model key. Single-source
+            converters that map a source key to the same model key are rejected
+            instead of silently direct-loading serialized quantized data.
+        hf_quantizer: Optional Hugging Face quantizer passed through to
+            converter operations.
 
     """
     if isinstance(device_map, str):

--- a/torch_to_nnef/tensor/offload.py
+++ b/torch_to_nnef/tensor/offload.py
@@ -32,8 +32,10 @@ import re
 import tempfile
 import typing as T
 import warnings
+from collections import Counter
 from contextlib import contextmanager
 from copy import deepcopy
+from itertools import count
 from pathlib import Path
 
 import torch
@@ -673,8 +675,16 @@ def t2n_load_checkpoint_and_dispatch(
         elif device_map == ON_DISK_DEVICE_MAP_KEY:
             device_map = {"": "disk_cpu"}
 
+    weight_converters = list(weight_converters or [])
+    if device_map is None and weight_converters:
+        raise T2NErrorMisuse(
+            "weight_converters require a device_map in "
+            "t2n_load_checkpoint_and_dispatch"
+        )
+
     checkpoint_files = None
     index_filename = None
+    checkpoint_key_to_file = None
     if checkpoint.is_file():
         if str(checkpoint).endswith(".json"):
             index_filename = checkpoint
@@ -724,12 +734,15 @@ def t2n_load_checkpoint_and_dispatch(
 
         if "weight_map" in index:
             index = index["weight_map"]
+        checkpoint_key_to_file = index
         checkpoint_files = sorted(list(set(index.values())))
         checkpoint_files = [checkpoint_folder / f for f in checkpoint_files]
     unexpected_keys = set()
     model_keys = set(model.state_dict().keys())
-    converted_params_to_load: T.Dict[str, T.Any] = {}
-    weight_converters = list(weight_converters or [])
+    converted_params_to_load: T.Dict[
+        str, T.List[T.Tuple[int, str, str, T.Any]]
+    ] = {}
+    converted_templates: T.Dict[str, T.Any] = {}
     converter_by_source = {
         source_pattern: converter
         for converter in weight_converters
@@ -765,6 +778,55 @@ def t2n_load_checkpoint_and_dispatch(
                     renamed_key = prefixed
         return renamed_key, source_pattern
 
+    def checkpoint_file_keys(checkpoint_file):
+        if not checkpoint_file.name.endswith(".safetensors"):
+            return None
+        # pylint: disable-next=import-outside-toplevel
+        import safetensors
+
+        with safetensors.safe_open(checkpoint_file, framework="pt") as f:
+            return list(f.keys())
+
+    all_checkpoint_keys = None
+    if weight_converters and checkpoint_key_to_file is not None:
+        all_checkpoint_keys = sorted(
+            checkpoint_key_to_file.keys(), key=_dot_natural_key
+        )
+    elif weight_converters and all(
+        file.name.endswith(".safetensors") for file in checkpoint_files
+    ):
+        keys = []
+        for checkpoint_file in checkpoint_files:
+            file_keys = checkpoint_file_keys(checkpoint_file)
+            if file_keys is None:
+                keys = None
+                break
+            keys.extend(file_keys)
+        if keys is not None:
+            all_checkpoint_keys = sorted(keys, key=_dot_natural_key)
+
+    checkpoint_key_rank = {}
+    converted_expected_counts = None
+    if all_checkpoint_keys is not None:
+        checkpoint_key_rank = {
+            key: rank for rank, key in enumerate(all_checkpoint_keys)
+        }
+        converted_expected_counts = {}
+        for key in all_checkpoint_keys:
+            renamed_key, source_pattern = rename_with_converters(key)
+            if source_pattern is None or renamed_key not in model_keys:
+                continue
+            converted_expected_counts.setdefault(renamed_key, Counter())[
+                source_pattern
+            ] += 1
+
+    fallback_rank = count(len(checkpoint_key_rank))
+
+    def rank_for_key(key):
+        if key in checkpoint_key_rank:
+            return checkpoint_key_rank[key]
+        return next(fallback_rank)
+
     def param_device_for(param_name):
         module_name = param_name
         while len(module_name) > 0 and module_name not in device_map:
@@ -783,21 +845,80 @@ def t2n_load_checkpoint_and_dispatch(
             offload_dir=offload_dir,
         )
 
-    def collect_converted_param(param_name, param):
-        renamed_key, source_pattern = rename_with_converters(param_name)
-        if source_pattern is None:
-            return False
-
-        if renamed_key in model_keys:
-            converter = converted_params_to_load.setdefault(
-                renamed_key, deepcopy(converter_by_source[source_pattern])
+    def converter_inputs_complete(renamed_key):
+        entries = converted_params_to_load[renamed_key]
+        template = converted_templates[renamed_key]
+        collected_counts = Counter(entry[2] for entry in entries)
+        expected_counts = (
+            converted_expected_counts.get(renamed_key)
+            if converted_expected_counts is not None
+            else None
+        )
+        for source_pattern in template.source_patterns:
+            expected = (
+                expected_counts.get(source_pattern, 0)
+                if expected_counts is not None
+                else 1
             )
+            if expected <= 0 or collected_counts[source_pattern] < expected:
+                return False
+        return True
+
+    def convert_collected_param(renamed_key):
+        entries = converted_params_to_load.pop(renamed_key)
+        template = converted_templates.pop(renamed_key)
+        converter = deepcopy(template)
+        for _rank, param_name, source_pattern, param in sorted(
+            entries,
+            key=lambda entry: (
+                entry[0],
+                _dot_natural_key(entry[1]),
+                entry[2],
+            ),
+        ):
             converter.add_tensor(
                 renamed_key,
                 param_name,
                 source_pattern,
                 param,
             )
+        try:
+            converted_tensors = converter.convert(
+                renamed_key,
+                model=model,
+                config=getattr(model, "config", None),
+                hf_quantizer=hf_quantizer,
+            )
+        except Exception as exc:
+            raise T2NErrorMisuse(
+                f"failed to convert checkpoint tensors for '{renamed_key}': "
+                f"{exc}"
+            ) from exc
+        for target_name, param in converted_tensors.items():
+            param = param[0] if isinstance(param, list) else param
+            set_param(target_name, param)
+        del converted_tensors
+        gc.collect()
+
+    def collect_converted_param(param_name, param):
+        renamed_key, source_pattern = rename_with_converters(param_name)
+        if source_pattern is None:
+            return False
+
+        if renamed_key in model_keys:
+            converted_templates.setdefault(
+                renamed_key, converter_by_source[source_pattern]
+            )
+            converted_params_to_load.setdefault(renamed_key, []).append(
+                (
+                    rank_for_key(param_name),
+                    param_name,
+                    source_pattern,
+                    param,
+                )
+            )
+            if converter_inputs_complete(renamed_key):
+                convert_collected_param(renamed_key)
             return True
 
         converter = converter_by_source[source_pattern]
@@ -841,26 +962,21 @@ def t2n_load_checkpoint_and_dispatch(
         # Force Python to clean up.
         del loaded_checkpoint
         gc.collect()
-    for param_name, converter in sorted(
-        converted_params_to_load.items(), key=lambda kv: _dot_natural_key(kv[0])
-    ):
-        try:
-            converted_tensors = converter.convert(
-                param_name,
-                model=model,
-                config=getattr(model, "config", None),
-                hf_quantizer=hf_quantizer,
-            )
-        except Exception as exc:
-            raise T2NErrorMisuse(
-                f"failed to convert checkpoint tensors for '{param_name}': "
-                f"{exc}"
-            ) from exc
-        for target_name, param in converted_tensors.items():
-            param = param[0] if isinstance(param, list) else param
-            set_param(target_name, param)
-        del converted_tensors
-        gc.collect()
+    if converted_params_to_load:
+        details = {}
+        for renamed_key, entries in converted_params_to_load.items():
+            template = converted_templates[renamed_key]
+            collected_counts = Counter(entry[2] for entry in entries)
+            missing = [
+                source_pattern
+                for source_pattern in template.source_patterns
+                if collected_counts[source_pattern] == 0
+            ]
+            details[renamed_key] = missing or list(template.source_patterns)
+        raise T2NErrorMisuse(
+            "incomplete checkpoint tensors for weight conversion: "
+            f"{details}"
+        )
     if not strict and len(unexpected_keys) > 0:
         LOGGER.warning(
             "Some weights of the model checkpoint at %s were not used when"

--- a/torch_to_nnef/tensor/offload.py
+++ b/torch_to_nnef/tensor/offload.py
@@ -302,8 +302,7 @@ class _WeightConversionCollector:
             ]
             details[renamed_key] = missing or list(template.source_patterns)
         raise T2NErrorMisuse(
-            "incomplete checkpoint tensors for weight conversion: "
-            f"{details}"
+            f"incomplete checkpoint tensors for weight conversion: {details}"
         )
 
 

--- a/torch_to_nnef/tensor/offload.py
+++ b/torch_to_nnef/tensor/offload.py
@@ -28,10 +28,12 @@ import gc
 import json
 import logging
 import os
+import re
 import tempfile
 import typing as T
 import warnings
 from contextlib import contextmanager
+from copy import deepcopy
 from pathlib import Path
 
 import torch
@@ -61,6 +63,13 @@ SAFE_WEIGHTS_NAME = f"{SAFE_MODEL_NAME}.safetensors"
 TDEVICE = T.Union[int, str, torch.device]
 
 LOGGER = logging.getLogger(__name__)
+
+
+def _dot_natural_key(key: str):
+    return [
+        int(part) if part.isdigit() else part
+        for part in re.split(r"(\d+)", key)
+    ]
 
 
 class OffloadedTensor(OpaqueTensor):
@@ -644,6 +653,8 @@ def t2n_load_checkpoint_and_dispatch(
     offload_dir: Path,
     strict: bool = False,
     offload_at_load_state_dict: bool = False,
+    weight_converters: T.Optional[T.Sequence[T.Any]] = None,
+    hf_quantizer: T.Optional[T.Any] = None,
 ):
     """Allow to offload as soon as possible.
 
@@ -717,6 +728,14 @@ def t2n_load_checkpoint_and_dispatch(
         checkpoint_files = [checkpoint_folder / f for f in checkpoint_files]
     unexpected_keys = set()
     model_keys = set(model.state_dict().keys())
+    converted_params_to_load: T.Dict[str, T.Any] = {}
+    weight_converters = list(weight_converters or [])
+    converter_by_source = {
+        source_pattern: converter
+        for converter in weight_converters
+        for source_pattern in converter.source_patterns
+    }
+    base_model_prefix = getattr(model, "base_model_prefix", None)
     assert checkpoint_files is not None
     mod_updater = ModTensorUpdater(
         model,
@@ -724,6 +743,72 @@ def t2n_load_checkpoint_and_dispatch(
         add_buffers=True,
         add_unregistred_tensor=True,
     )
+
+    def rename_with_converters(source_key):
+        renamed_key = source_key
+        source_pattern = None
+        for converter in weight_converters:
+            renamed_key, source_pattern = converter.rename_source_key(
+                renamed_key
+            )
+            if source_pattern is not None:
+                break
+        if base_model_prefix:
+            prefix = f"{base_model_prefix}."
+            if renamed_key.startswith(prefix):
+                unprefixed = renamed_key[len(prefix) :]
+                if unprefixed in model_keys:
+                    renamed_key = unprefixed
+            else:
+                prefixed = f"{base_model_prefix}.{renamed_key}"
+                if prefixed in model_keys:
+                    renamed_key = prefixed
+        return renamed_key, source_pattern
+
+    def param_device_for(param_name):
+        module_name = param_name
+        while len(module_name) > 0 and module_name not in device_map:
+            module_name = ".".join(module_name.split(".")[:-1])
+        if module_name == "" and "" not in device_map:
+            raise T2NErrorMisuse(f"{param_name} doesn't have any device set.")
+        return device_map[module_name]
+
+    def set_param(param_name, param):
+        set_module_tensor_to_device(
+            mod_updater,
+            param_name,
+            param_device_for(param_name),
+            value=param,
+            dtype=None,
+            offload_dir=offload_dir,
+        )
+
+    def collect_converted_param(param_name, param):
+        renamed_key, source_pattern = rename_with_converters(param_name)
+        if source_pattern is None:
+            return False
+
+        if renamed_key in model_keys:
+            converter = converted_params_to_load.setdefault(
+                renamed_key, deepcopy(converter_by_source[source_pattern])
+            )
+            converter.add_tensor(
+                renamed_key,
+                param_name,
+                source_pattern,
+                param,
+            )
+            return True
+
+        converter = converter_by_source[source_pattern]
+        for target_pattern in converter.target_patterns:
+            unexpected_keys.add(
+                renamed_key.replace(
+                    converter.target_patterns[0], target_pattern
+                )
+            )
+        return True
+
     for checkpoint_file in checkpoint_files:
         loaded_checkpoint = load_state_dict(
             checkpoint_file,
@@ -735,10 +820,16 @@ def t2n_load_checkpoint_and_dispatch(
             model.load_state_dict(loaded_checkpoint, strict=strict)
             unexpected_keys.update(set(loaded_checkpoint.keys()) - model_keys)
         else:
-            for param_name, param in loaded_checkpoint.items():
+            for param_name, param in sorted(
+                loaded_checkpoint.items(),
+                key=lambda kv: _dot_natural_key(kv[0]),
+            ):
                 # skip SCB parameter (for 8-bit serialization)
                 if "SCB" in param_name:
                     LOGGER.error("unsupported SCB param")
+                    continue
+
+                if collect_converted_param(param_name, param):
                     continue
 
                 if param_name not in model_keys:
@@ -746,25 +837,29 @@ def t2n_load_checkpoint_and_dispatch(
                     if not strict:
                         continue  # Skip loading this parameter.
 
-                module_name = param_name
-
-                while len(module_name) > 0 and module_name not in device_map:
-                    module_name = ".".join(module_name.split(".")[:-1])
-                if module_name == "" and "" not in device_map:
-                    raise T2NErrorMisuse(
-                        f"{param_name} doesn't have any device set."
-                    )
-                param_device = device_map[module_name]
-                set_module_tensor_to_device(
-                    mod_updater,
-                    param_name,
-                    param_device,
-                    value=param,
-                    dtype=None,
-                    offload_dir=offload_dir,
-                )
+                set_param(param_name, param)
         # Force Python to clean up.
         del loaded_checkpoint
+        gc.collect()
+    for param_name, converter in sorted(
+        converted_params_to_load.items(), key=lambda kv: _dot_natural_key(kv[0])
+    ):
+        try:
+            converted_tensors = converter.convert(
+                param_name,
+                model=model,
+                config=getattr(model, "config", None),
+                hf_quantizer=hf_quantizer,
+            )
+        except Exception as exc:
+            raise T2NErrorMisuse(
+                f"failed to convert checkpoint tensors for '{param_name}': "
+                f"{exc}"
+            ) from exc
+        for target_name, param in converted_tensors.items():
+            param = param[0] if isinstance(param, list) else param
+            set_param(target_name, param)
+        del converted_tensors
         gc.collect()
     if not strict and len(unexpected_keys) > 0:
         LOGGER.warning(

--- a/torch_to_nnef/tensor/offload.py
+++ b/torch_to_nnef/tensor/offload.py
@@ -141,6 +141,7 @@ class _WeightConversionCollector:
                 key: rank for rank, key in enumerate(all_checkpoint_keys)
             }
             self.converted_expected_counts = {}
+            converted_source_keys = {}
             for key in all_checkpoint_keys:
                 renamed_key, source_pattern = self.rename_source_key(key)
                 if source_pattern is None or renamed_key not in self.model_keys:
@@ -148,6 +149,14 @@ class _WeightConversionCollector:
                 self.converted_expected_counts.setdefault(
                     renamed_key, Counter()
                 )[source_pattern] += 1
+                converted_source_keys.setdefault(renamed_key, []).append(key)
+            self.convertible_keys = {
+                renamed_key
+                for renamed_key, source_keys in converted_source_keys.items()
+                if self._has_conversion_evidence(renamed_key, source_keys)
+            }
+        else:
+            self.convertible_keys = set()
         self.fallback_rank = count(len(self.checkpoint_key_rank))
 
     @staticmethod
@@ -198,6 +207,36 @@ class _WeightConversionCollector:
                     renamed_key = prefixed
         return renamed_key, source_pattern
 
+    def normalize_model_key(self, source_key):
+        if not self.base_model_prefix:
+            return source_key
+        prefix = f"{self.base_model_prefix}."
+        if source_key.startswith(prefix):
+            unprefixed = source_key[len(prefix) :]
+            if unprefixed in self.model_keys:
+                return unprefixed
+        else:
+            prefixed = f"{self.base_model_prefix}.{source_key}"
+            if prefixed in self.model_keys:
+                return prefixed
+        return source_key
+
+    def _has_conversion_evidence(self, renamed_key, source_keys):
+        """Whether this target is structurally a conversion.
+
+        This keeps broad patterns such as ``weight`` from capturing ordinary
+        dense weights, without keeping per-quantizer allow/deny lists.
+        """
+        expected_counts = self.converted_expected_counts[renamed_key]
+        return (
+            len(expected_counts) > 1
+            or len(source_keys) > 1
+            or any(
+                self.normalize_model_key(key) != renamed_key
+                for key in source_keys
+            )
+        )
+
     def rank_for_key(self, key):
         if key in self.checkpoint_key_rank:
             return self.checkpoint_key_rank[key]
@@ -212,11 +251,14 @@ class _WeightConversionCollector:
             if self.converted_expected_counts is not None
             else None
         )
-        for source_pattern in template.source_patterns:
+        expected_patterns = (
+            expected_counts.keys()
+            if expected_counts is not None
+            else template.source_patterns
+        )
+        for source_pattern in expected_patterns:
             expected = (
-                expected_counts.get(source_pattern, 0)
-                if expected_counts is not None
-                else 1
+                expected_counts.get(source_pattern, 0) if expected_counts else 1
             )
             if expected <= 0 or collected_counts[source_pattern] < expected:
                 return False
@@ -264,6 +306,8 @@ class _WeightConversionCollector:
             return False
 
         if renamed_key in self.model_keys:
+            if renamed_key not in self.convertible_keys:
+                return False
             self.converted_templates.setdefault(
                 renamed_key, self.converter_by_source[source_pattern]
             )
@@ -295,12 +339,22 @@ class _WeightConversionCollector:
         for renamed_key, entries in self.converted_params_to_load.items():
             template = self.converted_templates[renamed_key]
             collected_counts = Counter(entry[2] for entry in entries)
+            expected_counts = (
+                self.converted_expected_counts.get(renamed_key)
+                if self.converted_expected_counts is not None
+                else None
+            )
+            expected_patterns = (
+                expected_counts.keys()
+                if expected_counts is not None
+                else template.source_patterns
+            )
             missing = [
                 source_pattern
-                for source_pattern in template.source_patterns
+                for source_pattern in expected_patterns
                 if collected_counts[source_pattern] == 0
             ]
-            details[renamed_key] = missing or list(template.source_patterns)
+            details[renamed_key] = missing or list(expected_patterns)
         raise T2NErrorMisuse(
             f"incomplete checkpoint tensors for weight conversion: {details}"
         )


### PR DESCRIPTION
## Summary
- apply Hugging Face load-time weight converters in T2N custom offload dispatch
- convert grouped source tensors as soon as each target is complete, then release shard tensor references
- gate converter application on checkpoint structure rather than a per-quantizer allow/deny list, so broad patterns like `weight` do not swallow ordinary dense weights
- fail clearly for unsupported same-key single-source converters instead of silently direct-loading serialized quantized data
- carry the matched converter object through dispatch rather than looking it up again by source pattern
- add regression coverage for MXFP4 expert dequantization against Transformers' converter output, sharded ordering, broad-pattern converter gating, unsupported converter shapes, unsupported checkpoint layouts, and loader handoff

## Tests
- `uv run ruff format --check torch_to_nnef tests packages examples`
- `uv run ruff check torch_to_nnef tests packages examples`
- `uv run --package torch_to_nnef_llm --group test --extra safetensors pytest -s packages/llm/tests/test_upcast_quant.py`
- `uv run --package torch_to_nnef_llm --group test --extra safetensors pytest -s packages/llm/tests/test_llm_cli.py packages/llm/tests/test_load_retry.py packages/llm/tests/test_upcast_quant.py`
