### PR TITLE
chore(tract): support 0.23.3, drop 0.23.0 as newest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 
 ## [Unreleased]
 
+### Changed
+- Officially supported tract versions bumped to 0.23.3 and 0.22.1 (0.23.0 dropped). The default `TractNNEF.latest()` target is now 0.23.3, so the `tract_core_resize` / `tract_core_grid_sample` lowering path (gated on tract >= 0.23.2) auto-activates by default.
+
 ## [0.24.1] - 2026-07-02
 
 ### Added

--- a/torch_to_nnef/inference_target/tract.py
+++ b/torch_to_nnef/inference_target/tract.py
@@ -86,7 +86,7 @@ class TractNNEF(InferenceTarget):
     OFFICIAL_SUPPORTED_VERSIONS = [
         SemanticVersion.from_str(version)
         for version in [
-            "0.23.0",
+            "0.23.3",
             "0.22.1",
         ]
     ]


### PR DESCRIPTION
Bumps the officially supported tract versions to the latest release **0.23.3** (published 2026-06-19), keeping **0.22.1** as the oldest supported version. Drops 0.23.0 as the newest.

## Changes
- `OFFICIAL_SUPPORTED_VERSIONS` in `torch_to_nnef/inference_target/tract.py` set to `["0.23.3", "0.22.1"]`, so `TractNNEF.latest()` now targets 0.23.3.
- Because 0.23.3 >= `RESIZE_MIN_TRACT_VERSION` (0.23.2), the `tract_core_resize` / `tract_core_grid_sample` lowering path now auto-activates for the default latest target.
- CHANGELOG entry under `[Unreleased]`.

The oldest supported version is unchanged (0.22.1), so `docs/index.md`'s "(>= 0.22.1 to date)" line stays accurate.

## Verification
Exported a small conv + nearest-`interpolate` model with `TractNNEF.latest()` and `check_io=True`: the 0.23.3 binary downloads and validates outputs within tolerance, exercising the newly-activated resize path.