### PR TITLE
Reduce Q40 writer memory

### DIFF
--- a/tests/test_offload.py
+++ b/tests/test_offload.py
@@ -1,6 +1,7 @@
 import tempfile
 from copy import deepcopy
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 import torch
@@ -12,6 +13,7 @@ from tests.utils import (
     skipif_unsupported_qtensor,
 )
 from torch_to_nnef.inference_target.tract import TractCheckTolerance
+from torch_to_nnef.nnef_io.writer import Writer
 from torch_to_nnef.tensor.offload import OffloadedTensor
 from torch_to_nnef.tensor.quant.qtract import (
     QTensorTractScaleOnly,
@@ -165,6 +167,49 @@ def test_offload_qtensor_write_uses_compact_state_without_reload(monkeypatch):
         assert offloaded_value.write_qtensor_in_file(
             out_dir, "weight", INFERENCE_TARGET
         )
+        assert (out_dir / "weight.dat").read_bytes() == (
+            ref_dir / "weight.dat"
+        ).read_bytes()
+
+
+@skipif_unsupported_qtensor
+def test_writer_uses_compact_offloaded_qtensor_path(monkeypatch):
+    with tempfile.TemporaryDirectory() as td:
+        td_path = Path(td)
+        original_weight = torch.randn(4, 32)
+        q_tensor = fp_to_tract_q4_0_with_min_max_calibration(original_weight)
+        offloaded_value = OffloadedTensor.from_original_tensor(
+            q_tensor, "my_offloaded_qweight", offload_dir=td_path
+        )
+
+        ref_dir = td_path / "ref"
+        out_dir = td_path / "out"
+        ref_dir.mkdir()
+        out_dir.mkdir()
+        q_tensor.write_in_file(ref_dir, "weight", INFERENCE_TARGET)
+
+        def fail_if_reloaded(*args, **kwargs):
+            raise AssertionError("writer should use compact offloaded state")
+
+        monkeypatch.setattr(OffloadedTensor, "reload", fail_if_reloaded)
+
+        graph = SimpleNamespace(
+            operations=[
+                SimpleNamespace(
+                    type="variable",
+                    attribs={
+                        "custom_datatype": "quant_tensor",
+                        "label": "weight",
+                    },
+                    output=SimpleNamespace(qtensor=offloaded_value),
+                )
+            ]
+        )
+
+        Writer(inference_target=INFERENCE_TARGET)._write_tensors_from_operators(
+            graph, out_dir
+        )
+
         assert (out_dir / "weight.dat").read_bytes() == (
             ref_dir / "weight.dat"
         ).read_bytes()

--- a/tests/test_offload.py
+++ b/tests/test_offload.py
@@ -14,6 +14,7 @@ from tests.utils import (
 from torch_to_nnef.inference_target.tract import TractCheckTolerance
 from torch_to_nnef.tensor.offload import OffloadedTensor
 from torch_to_nnef.tensor.quant.qtract import (
+    QTensorTractScaleOnly,
     fp_to_tract_q4_0_with_min_max_calibration,
 )
 
@@ -112,6 +113,61 @@ def test_offload_qtensor_export():
                 test_input=test_input,
                 inference_target=INFERENCE_TARGET,
             )
+
+
+@skipif_unsupported_qtensor
+def test_offload_qtensor_uses_compact_serialized_state():
+    with tempfile.TemporaryDirectory() as td:
+        original_weight = torch.randn(8192, 32, dtype=torch.float16)
+        q_tensor = fp_to_tract_q4_0_with_min_max_calibration(original_weight)
+        offloaded_value = OffloadedTensor.from_original_tensor(
+            q_tensor, "my_offloaded_qweight", offload_dir=Path(td)
+        )
+
+        fp_payload_size = (
+            original_weight.numel() * original_weight.element_size()
+        )
+        assert offloaded_value.offload_path.stat().st_size < fp_payload_size
+        reloaded = offloaded_value.reload()
+        assert type(reloaded) is type(q_tensor)
+        assert torch.allclose(reloaded.decompress(), q_tensor.decompress())
+
+
+@skipif_unsupported_qtensor
+def test_offload_qtensor_write_uses_compact_state_without_reload(monkeypatch):
+    with tempfile.TemporaryDirectory() as td:
+        td_path = Path(td)
+        original_weight = torch.randn(4, 32)
+        q_tensor = fp_to_tract_q4_0_with_min_max_calibration(original_weight)
+        offloaded_value = OffloadedTensor.from_original_tensor(
+            q_tensor, "my_offloaded_qweight", offload_dir=td_path
+        )
+
+        ref_dir = td_path / "ref"
+        out_dir = td_path / "out"
+        ref_dir.mkdir()
+        out_dir.mkdir()
+        q_tensor.write_in_file(ref_dir, "weight", INFERENCE_TARGET)
+
+        def fail_if_reloaded(*args, **kwargs):
+            raise AssertionError("offloaded qtensor writer should not reload")
+
+        def fail_if_full_content_is_built(*args, **kwargs):
+            raise AssertionError("offloaded qtensor writer should stream")
+
+        monkeypatch.setattr(OffloadedTensor, "reload", fail_if_reloaded)
+        monkeypatch.setattr(
+            QTensorTractScaleOnly,
+            "_build_binary_dat_content",
+            fail_if_full_content_is_built,
+        )
+
+        assert offloaded_value.write_qtensor_in_file(
+            out_dir, "weight", INFERENCE_TARGET
+        )
+        assert (out_dir / "weight.dat").read_bytes() == (
+            ref_dir / "weight.dat"
+        ).read_bytes()
 
 
 @skipif_limited_offload_support

--- a/tests/test_qtensor.py
+++ b/tests/test_qtensor.py
@@ -8,6 +8,7 @@ from datetime import datetime
 from functools import partial, reduce
 from pathlib import Path
 
+import numpy as np
 import pytest
 import torch
 from torch import nn
@@ -109,6 +110,70 @@ def check_tensor_in_nnef_archive(
                             f"{label_name}: {bin_header.torch_dtype_or_custom}"
                             f" but expected {expected_dtype}"
                         )
+
+
+def _legacy_q40_dat_content(
+    qtensor: QTensorTractScaleOnly, post_tract_21_11: bool
+) -> bytes:
+    tensor_flat = qtensor.decompress_to_u8().clone().flatten()
+    if post_tract_21_11:
+        tensor_per_group = tensor_flat.reshape(-1, 2, 16)
+        tensor_per_group[:, 1, :] <<= 4
+        tensor_per_group = tensor_per_group.sum(dim=1).numpy().astype(np.uint8)
+    else:
+        tensor_per_group = tensor_flat.reshape(-1, 16, 2)
+        tensor_per_group[:, :, 1] <<= 4
+        tensor_per_group = tensor_per_group.sum(dim=2).numpy().astype(np.uint8)
+
+    b_scales = qtensor.qscheme.scale.numpy().view(np.byte)
+    b_vals = tensor_per_group.view(np.byte)
+    return np.hstack([b_scales, b_vals]).tobytes()
+
+
+@skipif_unsupported_qtensor
+@pytest.mark.parametrize("post_tract_21_11", [False, True])
+def test_q40_dat_content_uses_bitpacking_without_sum(
+    monkeypatch, post_tract_21_11
+):
+    qtensor = fp_to_tract_q4_0_with_min_max_calibration(
+        torch.arange(6 * 32).reshape(6, 32).float()
+    )
+    u8_before = qtensor.u8_blob.clone()
+    expected = _legacy_q40_dat_content(qtensor, post_tract_21_11)
+
+    def fail_if_sum_is_used(*args, **kwargs):
+        raise AssertionError("Q40 writer should pack nibbles without sum")
+
+    monkeypatch.setattr(torch.Tensor, "sum", fail_if_sum_is_used)
+
+    assert qtensor._build_binary_dat_content(post_tract_21_11) == expected
+    assert torch.equal(qtensor.u8_blob, u8_before)
+
+
+@skipif_unsupported_qtensor
+def test_q40_write_streams_without_building_full_content(monkeypatch, tmp_path):
+    qtensor = fp_to_tract_q4_0_with_min_max_calibration(
+        torch.arange(6 * 32).reshape(6, 32).float()
+    )
+    ref_dir = tmp_path / "ref"
+    out_dir = tmp_path / "out"
+    ref_dir.mkdir()
+    out_dir.mkdir()
+    qtensor.write_in_file(ref_dir, "weight", TractNNEF.latest())
+
+    def fail_if_full_content_is_built(*args, **kwargs):
+        raise AssertionError("Q40 write should stream content")
+
+    monkeypatch.setattr(
+        QTensorTractScaleOnly,
+        "_build_binary_dat_content",
+        fail_if_full_content_is_built,
+    )
+
+    qtensor.write_in_file(out_dir, "weight", TractNNEF.latest())
+    assert (out_dir / "weight.dat").read_bytes() == (
+        ref_dir / "weight.dat"
+    ).read_bytes()
 
 
 @skipif_unsupported_qtensor
@@ -496,6 +561,36 @@ def test_u8_compressors():
             dummy_compressor1.decompress_times[1]
             > dummy_compressor2.decompress_times[1]
         )
+
+
+@skipif_unsupported_qtensor
+def test_q40_offload_state_write_applies_u8_compressors(tmp_path):
+    fp_tensor = torch.rand(2, 32)
+    q_scheme = qscale_per_group_f16_min_max_calibration(
+        fp_tensor, n_bits=4, group_size=32, percentile=1
+    )
+    qtensor = QTensorTractScaleOnly(
+        fp_tensor,
+        qscheme=q_scheme,
+        dequant_to_dtype=fp_tensor.dtype,
+        u8_compressors=[DummyU8Compressor()],
+    )
+    ref_dir = tmp_path / "ref"
+    out_dir = tmp_path / "out"
+    ref_dir.mkdir()
+    out_dir.mkdir()
+
+    qtensor.write_in_file(ref_dir, "weight", TractNNEF.latest())
+    QTensorTractScaleOnly.write_offload_state_in_file(
+        qtensor.to_offload_state(),
+        out_dir,
+        "weight",
+        inference_target=TractNNEF.latest(),
+    )
+
+    assert (out_dir / "weight.dat").read_bytes() == (
+        ref_dir / "weight.dat"
+    ).read_bytes()
 
 
 @skipif_unsupported_qtensor

--- a/tests/test_qtensor.py
+++ b/tests/test_qtensor.py
@@ -564,7 +564,16 @@ def test_u8_compressors():
 
 
 @skipif_unsupported_qtensor
-def test_q40_offload_state_write_applies_u8_compressors(tmp_path):
+@pytest.mark.parametrize(
+    "inference_target",
+    [
+        TractNNEF("0.21.10", check_io=False),
+        TractNNEF("0.21.11", check_io=False),
+    ],
+)
+def test_q40_offload_state_write_applies_u8_compressors(
+    tmp_path, inference_target
+):
     fp_tensor = torch.rand(2, 32)
     q_scheme = qscale_per_group_f16_min_max_calibration(
         fp_tensor, n_bits=4, group_size=32, percentile=1
@@ -580,12 +589,12 @@ def test_q40_offload_state_write_applies_u8_compressors(tmp_path):
     ref_dir.mkdir()
     out_dir.mkdir()
 
-    qtensor.write_in_file(ref_dir, "weight", TractNNEF.latest())
+    qtensor.write_in_file(ref_dir, "weight", inference_target)
     QTensorTractScaleOnly.write_offload_state_in_file(
         qtensor.to_offload_state(),
         out_dir,
         "weight",
-        inference_target=TractNNEF.latest(),
+        inference_target=inference_target,
     )
 
     assert (out_dir / "weight.dat").read_bytes() == (

--- a/torch_to_nnef/nnef_io/writer.py
+++ b/torch_to_nnef/nnef_io/writer.py
@@ -362,6 +362,13 @@ class Writer:
             if op.type == "variable":
                 if op.attribs.pop("custom_datatype", "") == "quant_tensor":
                     qtensor = op.output.qtensor
+                    if isinstance(qtensor, OffloadedTensor):
+                        label = op.attribs["label"]
+                        if qtensor.write_qtensor_in_file(
+                            folder, label, self._inference_target
+                        ):
+                            LOGGER.info("written qtensor: '%s'", label)
+                            continue
                     while isinstance(qtensor, OffloadedTensor):
                         qtensor = qtensor.to_base_tensor()
                     label = op.attribs["label"]

--- a/torch_to_nnef/tensor/offload.py
+++ b/torch_to_nnef/tensor/offload.py
@@ -713,19 +713,58 @@ class OffloadedTensor(OpaqueTensor):
 
     @classmethod
     def _save(cls, tensor, offload_dir, name):
-        return torch.save(
-            tensor, cls._offload_path(offload_dir, name, tensor.dtype)
+        dtype = tensor.dtype
+        # pylint: disable-next=import-outside-toplevel
+        from torch_to_nnef.tensor.quant.qtract import (
+            QTensorTractScaleOnly,
         )
+
+        if isinstance(tensor, QTensorTractScaleOnly):
+            tensor = tensor.to_offload_state()
+        return torch.save(tensor, cls._offload_path(offload_dir, name, dtype))
 
     def reload(self):
         if issubclass(self.offloaded_tensor_type, OpaqueTensor):
             load_kwargs = {}
             if torch_version() >= "1.13.0":
                 load_kwargs["weights_only"] = False
-            return torch.load(self.offload_path, **load_kwargs).to(
-                self.target_device
+            loaded = torch.load(self.offload_path, **load_kwargs)
+            # pylint: disable-next=import-outside-toplevel
+            from torch_to_nnef.tensor.quant.qtract import (
+                QTensorTractScaleOnly,
             )
+
+            if QTensorTractScaleOnly.is_offload_state(loaded):
+                loaded = QTensorTractScaleOnly.from_offload_state(loaded)
+                if loaded.device != self.target_device:
+                    loaded.to_device(self.target_device)
+                return loaded
+            return loaded.to(self.target_device)
         return torch_safe_load(self.offload_path).to(self.target_device)
+
+    def write_qtensor_in_file(
+        self,
+        dirpath: T.Union[str, Path],
+        label: str,
+        inference_target=None,
+    ) -> bool:
+        if not issubclass(self.offloaded_tensor_type, OpaqueTensor):
+            return False
+        load_kwargs = {}
+        if torch_version() >= "1.13.0":
+            load_kwargs["weights_only"] = False
+        loaded = torch.load(self.offload_path, **load_kwargs)
+        # pylint: disable-next=import-outside-toplevel
+        from torch_to_nnef.tensor.quant.qtract import (
+            QTensorTractScaleOnly,
+        )
+
+        if not QTensorTractScaleOnly.is_offload_state(loaded):
+            return False
+        QTensorTractScaleOnly.write_offload_state_in_file(
+            loaded, dirpath, label, inference_target=inference_target
+        )
+        return True
 
     def _to_base_tensor(self) -> torch.Tensor:
         return self.reload()

--- a/torch_to_nnef/tensor/offload.py
+++ b/torch_to_nnef/tensor/offload.py
@@ -753,7 +753,9 @@ class OffloadedTensor(OpaqueTensor):
         load_kwargs = {}
         if torch_version() >= "1.13.0":
             load_kwargs["weights_only"] = False
-        loaded = torch.load(self.offload_path, **load_kwargs)
+        loaded = torch.load(
+            self.offload_path, map_location="cpu", **load_kwargs
+        )
         # pylint: disable-next=import-outside-toplevel
         from torch_to_nnef.tensor.quant.qtract import (
             QTensorTractScaleOnly,

--- a/torch_to_nnef/tensor/quant/qtract.py
+++ b/torch_to_nnef/tensor/quant/qtract.py
@@ -30,6 +30,7 @@ class QTensorTract(QTensor):
 class QTensorTractScaleOnly(QTensorTract):
     """Tract data format it serializes to: Q4_0."""
 
+    OFFLOAD_STATE_TAG = "torch_to_nnef.qtensor_tract_scale_only.v1"
     qscheme: QScalePerGroupF16  # type notation for mypy
 
     def __init__(
@@ -71,42 +72,210 @@ class QTensorTractScaleOnly(QTensorTract):
             decompress_u8, target_dtype=self.dequant_to_dtype
         )
 
-    def _build_binary_dat_header(self, post_tract_21_11: bool = False) -> bytes:
+    @classmethod
+    def is_offload_state(cls, state) -> bool:
+        return (
+            isinstance(state, dict)
+            and state.get("__t2n_qtensor_state__") == cls.OFFLOAD_STATE_TAG
+        )
+
+    def to_offload_state(self) -> T.Dict[str, T.Any]:
+        return {
+            "__t2n_qtensor_state__": self.OFFLOAD_STATE_TAG,
+            "shape": tuple(self.shape),
+            "dtype": self.dtype,
+            "u8_blob": self.u8_blob,
+            "u8_compressors": self.u8_compressors,
+            "qscheme": self.qscheme,
+            "dequant_to_dtype": self.dequant_to_dtype,
+            "nnef_name": self.nnef_name,
+            "decompressed_shape": tuple(self.decompressed_shape),
+            "specific_machine": self.specific_machine,
+        }
+
+    @classmethod
+    def from_offload_state(cls, state) -> "QTensorTractScaleOnly":
+        assert cls.is_offload_state(state), state
+        fp_placeholder = torch.empty(state["shape"], dtype=state["dtype"])
+        qtensor = cls.__new__(
+            cls,
+            fp_placeholder,
+            state["qscheme"],
+            dequant_to_dtype=state["dequant_to_dtype"],
+        )
+        qtensor.u8_compressors = state["u8_compressors"]
+        qtensor.u8_blob = state["u8_blob"]
+        qtensor.qscheme = state["qscheme"]
+        qtensor.dequant_to_dtype = state["dequant_to_dtype"]
+        qtensor.nnef_name = state["nnef_name"]
+        qtensor.requires_grad = False
+        qtensor.decompressed_shape = state["decompressed_shape"]
+        qtensor.specific_machine = state["specific_machine"]
+        return qtensor
+
+    @staticmethod
+    def _build_binary_dat_header_for_shape(
+        decompressed_shape, post_tract_21_11: bool = False
+    ) -> bytes:
         if post_tract_21_11:
             item_type = DatBinHeader.TractCustomTypes.Q40
         else:
             item_type = DatBinHeader.TractCustomTypes.Q40_LEGACY
         return DatBinHeader.build_tract_qtensor(
-            item_type, self.decompressed_shape
+            item_type, decompressed_shape
         ).to_bytes()
+
+    def _build_binary_dat_header(self, post_tract_21_11: bool = False) -> bytes:
+        return self._build_binary_dat_header_for_shape(
+            self.decompressed_shape, post_tract_21_11
+        )
+
+    @staticmethod
+    def _decompress_u8_blob(u8_blob, u8_compressors):
+        decompress_u8 = u8_blob
+        for u8_compressor in reversed(u8_compressors or []):
+            decompress_u8 = u8_compressor.decompress(decompress_u8)
+        return decompress_u8
+
+    @staticmethod
+    def _pack_binary_dat_values(
+        tensor_flat: torch.Tensor, post_tract_21_11: bool
+    ) -> np.ndarray:
+        if post_tract_21_11:
+            tensor_per_group = tensor_flat.reshape(-1, 2, 16)
+            return (
+                tensor_per_group[:, 0, :] | (tensor_per_group[:, 1, :] << 4)
+            ).numpy()
+        tensor_per_group = tensor_flat.reshape(-1, 16, 2)
+        return (
+            tensor_per_group[:, :, 0] | (tensor_per_group[:, :, 1] << 4)
+        ).numpy()
+
+    @classmethod
+    def _iter_binary_dat_content_chunks(
+        cls,
+        u8_blob: torch.Tensor,
+        scale: torch.Tensor,
+        post_tract_21_11: bool = False,
+        chunk_groups: int = 1 << 20,
+    ):
+        n_bytes_per_group = 18
+        tensor_flat = u8_blob.flatten()
+        assert tensor_flat.numel() % 32 == 0, tensor_flat.shape
+        group_count = tensor_flat.numel() // 32
+        scale_bytes = (
+            scale.reshape(group_count, 1)
+            .contiguous()
+            .numpy()
+            .view(np.uint8)
+            .reshape(group_count, 2)
+        )
+
+        for start in range(0, group_count, chunk_groups):
+            end = min(start + chunk_groups, group_count)
+            chunk_flat = tensor_flat[start * 32 : end * 32]
+            b_vals = cls._pack_binary_dat_values(
+                chunk_flat, post_tract_21_11
+            ).view(np.uint8)
+            b_all = np.empty((end - start, n_bytes_per_group), dtype=np.uint8)
+            b_all[:, :2] = scale_bytes[start:end]
+            b_all[:, 2:] = b_vals.reshape(end - start, 16)
+            b_arr = b_all.tobytes()
+            assert len(b_arr) % n_bytes_per_group == 0
+            yield b_arr
+
+    @classmethod
+    def _build_binary_dat_content_from_parts(
+        cls,
+        u8_blob: torch.Tensor,
+        scale: torch.Tensor,
+        post_tract_21_11: bool = False,
+    ) -> bytes:
+        return b"".join(
+            cls._iter_binary_dat_content_chunks(
+                u8_blob,
+                scale,
+                post_tract_21_11=post_tract_21_11,
+            )
+        )
 
     def _build_binary_dat_content(
         self, post_tract_21_11: bool = False
     ) -> bytes:
-        # NOTE: implementation with multiple call to .tobytes,
-        # not tested if bottleneck
+        return self._build_binary_dat_content_from_parts(
+            self.decompress_to_u8(),
+            self.qscheme.scale,
+            post_tract_21_11=post_tract_21_11,
+        )
 
-        n_bytes_per_group = 18
-        tensor_flat = self.decompress_to_u8().clone().flatten()
-        if post_tract_21_11:
-            tensor_per_group = tensor_flat.reshape(-1, 2, 16)
-            tensor_per_group[:, 1, :] <<= 4
-            tensor_per_group = (
-                tensor_per_group.sum(dim=1).numpy().astype(np.uint8)
-            )
-        else:
-            tensor_per_group = tensor_flat.reshape(-1, 16, 2)
-            tensor_per_group[:, :, 1] <<= 4
-            tensor_per_group = (
-                tensor_per_group.sum(dim=2).numpy().astype(np.uint8)
-            )
+    @classmethod
+    def _write_binary_dat_content(cls, fh, u8_blob, scale, post_tract_21_11):
+        for chunk in cls._iter_binary_dat_content_chunks(
+            u8_blob, scale, post_tract_21_11=post_tract_21_11
+        ):
+            fh.write(chunk)
 
-        b_scales = self.qscheme.scale.numpy().view(np.byte)
-        b_vals = tensor_per_group.view(np.byte)
-        b_all = np.hstack([b_scales, b_vals])
-        b_arr = b_all.tobytes()
-        assert len(b_arr) % n_bytes_per_group == 0
-        return b_arr
+    @classmethod
+    def _write_binary_dat(
+        cls, path: Path, bin_header: bytes, bin_content: bytes
+    ):
+        with path.open("wb") as fh:
+            fh.write(bin_header)
+            fh.write(bin_content)
+
+    @classmethod
+    def _write_binary_dat_from_parts(
+        cls,
+        path: Path,
+        bin_header: bytes,
+        u8_blob: torch.Tensor,
+        scale: torch.Tensor,
+        post_tract_21_11: bool,
+    ):
+        with path.open("wb") as fh:
+            fh.write(bin_header)
+            cls._write_binary_dat_content(fh, u8_blob, scale, post_tract_21_11)
+
+    @classmethod
+    def write_offload_state_in_file(
+        cls,
+        state,
+        dirpath: T.Union[str, Path],
+        label: str,
+        inference_target: T.Optional[InferenceTarget] = None,
+    ):
+        assert cls.is_offload_state(state), state
+        if inference_target is None:
+            inference_target = TractNNEF.latest()
+        path = Path(dirpath) / f"{label}.dat"
+        if path.exists():
+            with tempfile.TemporaryDirectory() as _td:
+                td = Path(_td)
+                cls.write_offload_state_in_file(
+                    state, td, label, inference_target=inference_target
+                )
+                new_path = td / f"{label}.dat"
+                assert new_path.exists(), new_path
+                if filecmp.cmp(path, new_path):
+                    return
+            raise T2NErrorNotImplemented(
+                "At least 2 variables in the NNEF graph, "
+                f"share same Parameters: '{label}' but they try "
+                "to use different data-type (likely quantization format). "
+                "This variable collision as no resolution strategy yet."
+            )
+        assert isinstance(inference_target, TractNNEF), inference_target
+        post_tract_21_11 = inference_target.version >= "0.21.11"
+        bin_header = cls._build_binary_dat_header_for_shape(
+            state["decompressed_shape"], post_tract_21_11
+        )
+        cls._write_binary_dat_from_parts(
+            path,
+            bin_header,
+            cls._decompress_u8_blob(state["u8_blob"], state["u8_compressors"]),
+            state["qscheme"].scale,
+            post_tract_21_11,
+        )
 
     def write_in_file(
         self,
@@ -137,10 +306,13 @@ class QTensorTractScaleOnly(QTensorTract):
         assert isinstance(inference_target, TractNNEF), inference_target
         post_tract_21_11 = inference_target.version >= "0.21.11"
         bin_header = self._build_binary_dat_header(post_tract_21_11)
-        bin_content = self._build_binary_dat_content(post_tract_21_11)
-        with path.open("wb") as fh:
-            fh.write(bin_header)
-            fh.write(bin_content)
+        self._write_binary_dat_from_parts(
+            path,
+            bin_header,
+            self.decompress_to_u8(),
+            self.qscheme.scale,
+            post_tract_21_11,
+        )
 
 
 def fp_to_tract_q4_0_with_min_max_calibration(

--- a/torch_to_nnef/tensor/quant/qtract.py
+++ b/torch_to_nnef/tensor/quant/qtract.py
@@ -96,6 +96,10 @@ class QTensorTractScaleOnly(QTensorTract):
     @classmethod
     def from_offload_state(cls, state) -> "QTensorTractScaleOnly":
         assert cls.is_offload_state(state), state
+        # Keep the Tensor subclass shell on CPU for fallback reloads. A meta
+        # shell routes nested opaque tracing through PyTorch meta kernels before
+        # the inner QTensor can decompress. Large NNEF exports use the direct
+        # offload-state writer instead of this reload path.
         fp_placeholder = torch.empty(state["shape"], dtype=state["dtype"])
         qtensor = cls.__new__(
             cls,
@@ -163,13 +167,7 @@ class QTensorTractScaleOnly(QTensorTract):
         tensor_flat = u8_blob.flatten()
         assert tensor_flat.numel() % 32 == 0, tensor_flat.shape
         group_count = tensor_flat.numel() // 32
-        scale_bytes = (
-            scale.reshape(group_count, 1)
-            .contiguous()
-            .numpy()
-            .view(np.uint8)
-            .reshape(group_count, 2)
-        )
+        scale_flat = scale.reshape(group_count)
 
         for start in range(0, group_count, chunk_groups):
             end = min(start + chunk_groups, group_count)
@@ -177,8 +175,15 @@ class QTensorTractScaleOnly(QTensorTract):
             b_vals = cls._pack_binary_dat_values(
                 chunk_flat, post_tract_21_11
             ).view(np.uint8)
+            scale_bytes = (
+                scale_flat[start:end]
+                .contiguous()
+                .numpy()
+                .view(np.uint8)
+                .reshape(end - start, 2)
+            )
             b_all = np.empty((end - start, n_bytes_per_group), dtype=np.uint8)
-            b_all[:, :2] = scale_bytes[start:end]
+            b_all[:, :2] = scale_bytes
             b_all[:, 2:] = b_vals.reshape(end - start, 16)
             b_arr = b_all.tobytes()
             assert len(b_arr) % n_bytes_per_group == 0
@@ -214,14 +219,6 @@ class QTensorTractScaleOnly(QTensorTract):
             u8_blob, scale, post_tract_21_11=post_tract_21_11
         ):
             fh.write(chunk)
-
-    @classmethod
-    def _write_binary_dat(
-        cls, path: Path, bin_header: bytes, bin_content: bytes
-    ):
-        with path.open("wb") as fh:
-            fh.write(bin_header)
-            fh.write(bin_content)
 
     @classmethod
     def _write_binary_dat_from_parts(


### PR DESCRIPTION
## Summary
- replace Q40 nibble packing via uint8 sum with direct bitwise packing
- stream Q40 `.dat` writes in chunks instead of building one full payload in memory
- stream scale bytes per chunk as well, avoiding a tensor-wide scale-byte materialization
- store offloaded Tract Q40 tensors as compact compressed state instead of pickling the fp-shaped tensor subclass payload
- let the NNEF writer emit compact offloaded Q40 state directly without reloading the q-tensor object
- load compact offloaded Q40 state on CPU for the direct writer path so serialization is independent of the original tensor device

## Benchmark
Isolated microbench for one GPT-OSS-style expert matrix payload (`32 x 2880 x 2880`, final Q40 payload ~142 MiB), using the actual file-write path:
- legacy full-content writer: `0.297s`, max RSS `~3.9 GiB`
- streaming bitwise writer: `0.086s`, max RSS `~702 MiB`