### PR TITLE
Decouple OffloadedTensor from concrete QTensor (generic offload-state dispatch)

### DIFF
--- a/tests/test_offload.py
+++ b/tests/test_offload.py
@@ -15,6 +15,11 @@ from tests.utils import (
 from torch_to_nnef.inference_target.tract import TractCheckTolerance
 from torch_to_nnef.nnef_io.writer import Writer
 from torch_to_nnef.tensor.offload import OffloadedTensor
+from torch_to_nnef.tensor.opaque import (
+    OFFLOAD_STATE_KEY,
+    OpaqueTensor,
+    SupportsOffloadState,
+)
 from torch_to_nnef.tensor.quant.qtract import (
     QTensorTractScaleOnly,
     fp_to_tract_q4_0_with_min_max_calibration,
@@ -213,6 +218,58 @@ def test_writer_uses_compact_offloaded_qtensor_path(monkeypatch):
         assert (out_dir / "weight.dat").read_bytes() == (
             ref_dir / "weight.dat"
         ).read_bytes()
+
+
+@skipif_limited_offload_support
+def test_offload_dispatches_generic_offload_state(tmp_path):
+    # The offload layer must dispatch on the serialized state, not on any
+    # concrete tensor class. A second SupportsOffloadState implementation with
+    # its own tag round-trips through save/reload without OffloadedTensor
+    # knowing anything about it.
+    class _ToyOpaque(OpaqueTensor, SupportsOffloadState):
+        OFFLOAD_STATE_TAG = "tests.toy_opaque.v1"
+
+        @staticmethod
+        def __new__(cls, payload):
+            obj = torch.Tensor._make_subclass(
+                cls, payload.to(torch.float32), False
+            )
+            obj.payload = payload
+            return obj
+
+        def _to_base_tensor(self):
+            return self.payload.clone()
+
+        def to_offload_state(self):
+            return {
+                OFFLOAD_STATE_KEY: self.OFFLOAD_STATE_TAG,
+                "p": self.payload,
+            }
+
+        @classmethod
+        def from_offload_state(cls, state):
+            assert cls.is_offload_state(state), state
+            return cls(state["p"])
+
+        @classmethod
+        def write_offload_state_in_file(
+            cls, state, dirpath, label, inference_target=None
+        ):
+            raise AssertionError("not exercised by this test")
+
+    payload = torch.arange(6).reshape(2, 3)
+    offloaded = OffloadedTensor.from_original_tensor(
+        _ToyOpaque(payload), "toy", offload_dir=tmp_path
+    )
+    # _save dispatched to to_offload_state: the pickle is the compact dict,
+    # not the tensor subclass.
+    raw = torch.load(offloaded.offload_path, weights_only=False)
+    assert isinstance(raw, dict)
+    assert raw[OFFLOAD_STATE_KEY] == _ToyOpaque.OFFLOAD_STATE_TAG
+    # reload dispatched to from_offload_state via the registry.
+    reloaded = offloaded.reload()
+    assert type(reloaded) is _ToyOpaque
+    assert torch.equal(reloaded.payload, payload)
 
 
 @skipif_limited_offload_support

--- a/tests/test_offload.py
+++ b/tests/test_offload.py
@@ -220,43 +220,51 @@ def test_writer_uses_compact_offloaded_qtensor_path(monkeypatch):
         ).read_bytes()
 
 
+class _ToyOpaque(OpaqueTensor, SupportsOffloadState):
+    # A second SupportsOffloadState implementation, unrelated to QTensor, used
+    # to prove the offload layer dispatches on the serialized state alone. It
+    # deliberately has NO ``to_device`` method: the reload path must not
+    # require one (device placement is owned by ``from_offload_state``).
+    OFFLOAD_STATE_TAG = "tests.toy_opaque.v1"
+    last_target_device = None
+
+    @staticmethod
+    def __new__(cls, payload):
+        obj = torch.Tensor._make_subclass(cls, payload.to(torch.float32), False)
+        obj.payload = payload
+        return obj
+
+    def _to_base_tensor(self):
+        return self.payload.clone()
+
+    def to_offload_state(self):
+        return {OFFLOAD_STATE_KEY: self.OFFLOAD_STATE_TAG, "p": self.payload}
+
+    @classmethod
+    def from_offload_state(cls, state, target_device=None):
+        assert cls.is_offload_state(state), state
+        cls.last_target_device = target_device
+        payload = state["p"]
+        if target_device is not None:
+            payload = payload.to(target_device)
+        return cls(payload)
+
+    @classmethod
+    def write_offload_state_in_file(
+        cls, state, dirpath, label, inference_target=None
+    ):
+        (Path(dirpath) / f"{label}.dat").write_bytes(
+            state["p"].numpy().tobytes()
+        )
+
+
 @skipif_limited_offload_support
 def test_offload_dispatches_generic_offload_state(tmp_path):
     # The offload layer must dispatch on the serialized state, not on any
-    # concrete tensor class. A second SupportsOffloadState implementation with
-    # its own tag round-trips through save/reload without OffloadedTensor
-    # knowing anything about it.
-    class _ToyOpaque(OpaqueTensor, SupportsOffloadState):
-        OFFLOAD_STATE_TAG = "tests.toy_opaque.v1"
-
-        @staticmethod
-        def __new__(cls, payload):
-            obj = torch.Tensor._make_subclass(
-                cls, payload.to(torch.float32), False
-            )
-            obj.payload = payload
-            return obj
-
-        def _to_base_tensor(self):
-            return self.payload.clone()
-
-        def to_offload_state(self):
-            return {
-                OFFLOAD_STATE_KEY: self.OFFLOAD_STATE_TAG,
-                "p": self.payload,
-            }
-
-        @classmethod
-        def from_offload_state(cls, state):
-            assert cls.is_offload_state(state), state
-            return cls(state["p"])
-
-        @classmethod
-        def write_offload_state_in_file(
-            cls, state, dirpath, label, inference_target=None
-        ):
-            raise AssertionError("not exercised by this test")
-
+    # concrete tensor class. _ToyOpaque round-trips through save/reload/write
+    # without OffloadedTensor knowing anything about it.
+    assert not hasattr(_ToyOpaque, "to_device")
+    _ToyOpaque.last_target_device = None
     payload = torch.arange(6).reshape(2, 3)
     offloaded = OffloadedTensor.from_original_tensor(
         _ToyOpaque(payload), "toy", offload_dir=tmp_path
@@ -266,10 +274,32 @@ def test_offload_dispatches_generic_offload_state(tmp_path):
     raw = torch.load(offloaded.offload_path, weights_only=False)
     assert isinstance(raw, dict)
     assert raw[OFFLOAD_STATE_KEY] == _ToyOpaque.OFFLOAD_STATE_TAG
-    # reload dispatched to from_offload_state via the registry.
+    # reload dispatched to from_offload_state via the registry and delegated
+    # device placement to it (no to_device call on the reconstructed object).
     reloaded = offloaded.reload()
     assert type(reloaded) is _ToyOpaque
     assert torch.equal(reloaded.payload, payload)
+    assert _ToyOpaque.last_target_device == offloaded.target_device
+    # write dispatched generically too.
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+    assert offloaded.write_qtensor_in_file(out_dir, "toy", None)
+    assert (out_dir / "toy.dat").read_bytes() == payload.numpy().tobytes()
+
+
+def test_offload_state_subclass_without_own_tag_is_not_reregistered():
+    # Subclassing a registered SupportsOffloadState without redeclaring the tag
+    # must not raise (nor shadow the ancestor in the registry).
+    from torch_to_nnef.tensor.opaque import resolve_offload_state
+
+    class _ToySub(_ToyOpaque):
+        pass
+
+    assert _ToySub.OFFLOAD_STATE_TAG == _ToyOpaque.OFFLOAD_STATE_TAG
+    resolved = resolve_offload_state(
+        {OFFLOAD_STATE_KEY: _ToyOpaque.OFFLOAD_STATE_TAG}
+    )
+    assert resolved is _ToyOpaque
 
 
 @skipif_limited_offload_support

--- a/tests/test_offload.py
+++ b/tests/test_offload.py
@@ -258,6 +258,43 @@ class _ToyOpaque(OpaqueTensor, SupportsOffloadState):
         )
 
 
+class _NonOpaqueState(torch.Tensor, SupportsOffloadState):
+    # A SupportsOffloadState that is NOT an OpaqueTensor. reload() only rebuilds
+    # compact state through its OpaqueTensor branch, so _save must NOT compact
+    # this one (it would be unreloadable). Used to lock the save/reload gate.
+    OFFLOAD_STATE_TAG = "tests.non_opaque_state.v1"
+    to_offload_state_called = False
+
+    @staticmethod
+    def __new__(cls, base):
+        return torch.Tensor._make_subclass(cls, base, False)
+
+    def to_offload_state(self):
+        type(self).to_offload_state_called = True
+        return {OFFLOAD_STATE_KEY: self.OFFLOAD_STATE_TAG}
+
+    @classmethod
+    def from_offload_state(cls, state, target_device=None):
+        raise AssertionError("non-opaque state must be pickled plainly")
+
+    @classmethod
+    def write_offload_state_in_file(
+        cls, state, dirpath, label, inference_target=None
+    ):
+        raise AssertionError("non-opaque state has no compact writer")
+
+
+def test_save_does_not_compact_non_opaque_offload_state(tmp_path):
+    _NonOpaqueState.to_offload_state_called = False
+    tensor = _NonOpaqueState(torch.zeros(2, 2))
+    OffloadedTensor._save(tensor, tmp_path, "x")
+
+    assert not _NonOpaqueState.to_offload_state_called
+    path = OffloadedTensor._offload_path(tmp_path, "x", tensor.dtype)
+    raw = torch.load(path, weights_only=False)
+    assert not (isinstance(raw, dict) and OFFLOAD_STATE_KEY in raw)
+
+
 @skipif_limited_offload_support
 def test_offload_dispatches_generic_offload_state(tmp_path):
     # The offload layer must dispatch on the serialized state, not on any

--- a/torch_to_nnef/tensor/offload.py
+++ b/torch_to_nnef/tensor/offload.py
@@ -45,7 +45,11 @@ from torch.jit import TracerWarning
 from torch.overrides import get_default_nowrap_functions
 
 from torch_to_nnef.exceptions import T2NErrorMisuse
-from torch_to_nnef.tensor.opaque import OpaqueTensor
+from torch_to_nnef.tensor.opaque import (
+    OpaqueTensor,
+    SupportsOffloadState,
+    resolve_offload_state,
+)
 from torch_to_nnef.tensor.updater import ModTensorUpdater
 from torch_to_nnef.utils import (
     select_ctx_disable_torch_fn,
@@ -714,12 +718,7 @@ class OffloadedTensor(OpaqueTensor):
     @classmethod
     def _save(cls, tensor, offload_dir, name):
         dtype = tensor.dtype
-        # pylint: disable-next=import-outside-toplevel
-        from torch_to_nnef.tensor.quant.qtract import (
-            QTensorTractScaleOnly,
-        )
-
-        if isinstance(tensor, QTensorTractScaleOnly):
+        if isinstance(tensor, SupportsOffloadState):
             tensor = tensor.to_offload_state()
         return torch.save(tensor, cls._offload_path(offload_dir, name, dtype))
 
@@ -729,13 +728,9 @@ class OffloadedTensor(OpaqueTensor):
             if torch_version() >= "1.13.0":
                 load_kwargs["weights_only"] = False
             loaded = torch.load(self.offload_path, **load_kwargs)
-            # pylint: disable-next=import-outside-toplevel
-            from torch_to_nnef.tensor.quant.qtract import (
-                QTensorTractScaleOnly,
-            )
-
-            if QTensorTractScaleOnly.is_offload_state(loaded):
-                loaded = QTensorTractScaleOnly.from_offload_state(loaded)
+            state_cls = resolve_offload_state(loaded)
+            if state_cls is not None:
+                loaded = state_cls.from_offload_state(loaded)
                 if loaded.device != self.target_device:
                     loaded.to_device(self.target_device)
                 return loaded
@@ -756,14 +751,10 @@ class OffloadedTensor(OpaqueTensor):
         loaded = torch.load(
             self.offload_path, map_location="cpu", **load_kwargs
         )
-        # pylint: disable-next=import-outside-toplevel
-        from torch_to_nnef.tensor.quant.qtract import (
-            QTensorTractScaleOnly,
-        )
-
-        if not QTensorTractScaleOnly.is_offload_state(loaded):
+        state_cls = resolve_offload_state(loaded)
+        if state_cls is None:
             return False
-        QTensorTractScaleOnly.write_offload_state_in_file(
+        state_cls.write_offload_state_in_file(
             loaded, dirpath, label, inference_target=inference_target
         )
         return True

--- a/torch_to_nnef/tensor/offload.py
+++ b/torch_to_nnef/tensor/offload.py
@@ -718,7 +718,13 @@ class OffloadedTensor(OpaqueTensor):
     @classmethod
     def _save(cls, tensor, offload_dir, name):
         dtype = tensor.dtype
-        if isinstance(tensor, SupportsOffloadState):
+        # Compact state is only reloadable through the OpaqueTensor branch of
+        # reload(); gate the save on the same condition so a non-opaque
+        # SupportsOffloadState is pickled plainly instead of being written as a
+        # compact dict that reload() could not rebuild.
+        if isinstance(tensor, OpaqueTensor) and isinstance(
+            tensor, SupportsOffloadState
+        ):
             tensor = tensor.to_offload_state()
         return torch.save(tensor, cls._offload_path(offload_dir, name, dtype))
 

--- a/torch_to_nnef/tensor/offload.py
+++ b/torch_to_nnef/tensor/offload.py
@@ -730,10 +730,9 @@ class OffloadedTensor(OpaqueTensor):
             loaded = torch.load(self.offload_path, **load_kwargs)
             state_cls = resolve_offload_state(loaded)
             if state_cls is not None:
-                loaded = state_cls.from_offload_state(loaded)
-                if loaded.device != self.target_device:
-                    loaded.to_device(self.target_device)
-                return loaded
+                return state_cls.from_offload_state(
+                    loaded, target_device=self.target_device
+                )
             return loaded.to(self.target_device)
         return torch_safe_load(self.offload_path).to(self.target_device)
 

--- a/torch_to_nnef/tensor/opaque.py
+++ b/torch_to_nnef/tensor/opaque.py
@@ -194,11 +194,21 @@ class SupportsOffloadState:
 
     def __init_subclass__(cls, **kwargs):
         super().__init_subclass__(**kwargs)
-        tag = getattr(cls, "OFFLOAD_STATE_TAG", None)
-        if tag is None:
+        # Only a class that declares its OWN tag is a dispatch target. A
+        # subclass that inherits the tag without redeclaring it is not
+        # separately registered: rebuilding it would be ambiguous, so its
+        # state resolves back to the declaring ancestor (or the subclass
+        # declares a distinct tag to keep its identity).
+        if "OFFLOAD_STATE_TAG" not in cls.__dict__:
             return
+        tag = cls.OFFLOAD_STATE_TAG
         existing = _OFFLOAD_STATE_REGISTRY.get(tag)
-        if existing is not None and existing is not cls:
+        # A same-qualname re-registration is a redefinition (test re-runs,
+        # module reloads), not a clash; only distinct classes collide.
+        if existing is not None and (
+            existing.__module__,
+            existing.__qualname__,
+        ) != (cls.__module__, cls.__qualname__):
             raise T2NErrorNotImplemented(
                 f"duplicate offload-state tag '{tag}' for {cls} "
                 f"(already registered by {existing})"
@@ -218,7 +228,13 @@ class SupportsOffloadState:
 
     @classmethod
     @abc.abstractmethod
-    def from_offload_state(cls, state):
+    def from_offload_state(cls, state, target_device=None):
+        """Rebuild the tensor from ``state``, placed on ``target_device``.
+
+        The concrete class owns device placement (``None`` means leave it
+        wherever the state deserializes), so the offload layer needs no
+        device-move API on the reconstructed object.
+        """
         raise T2NErrorNotImplemented()
 
     @classmethod

--- a/torch_to_nnef/tensor/opaque.py
+++ b/torch_to_nnef/tensor/opaque.py
@@ -170,6 +170,79 @@ class OpaqueTensor(torch.Tensor):
         return opaque_t2n_expand(id(self))
 
 
+# Generic key marking a dict as a compact offload-state payload (as opposed to
+# a plainly pickled tensor). The value is a per-class ``OFFLOAD_STATE_TAG``.
+OFFLOAD_STATE_KEY = "__t2n_offload_state__"
+
+# Maps ``OFFLOAD_STATE_TAG`` -> concrete class, filled at class-definition time
+# by ``SupportsOffloadState.__init_subclass__``. Lets ``OffloadedTensor``
+# rebuild a serialized state without importing any concrete tensor class.
+_OFFLOAD_STATE_REGISTRY: T.Dict[str, type] = {}
+
+
+class SupportsOffloadState:
+    """Mixin for opaque tensors carrying a compact, picklable offload state.
+
+    A tensor subclass that would otherwise pickle a large fp-shaped payload can
+    instead serialize a small self-describing dict. It declares a unique
+    ``OFFLOAD_STATE_TAG`` and implements the three hooks below; registration is
+    automatic so ``OffloadedTensor`` dispatches on the serialized state rather
+    than knowing any concrete class.
+    """
+
+    OFFLOAD_STATE_TAG: str
+
+    def __init_subclass__(cls, **kwargs):
+        super().__init_subclass__(**kwargs)
+        tag = getattr(cls, "OFFLOAD_STATE_TAG", None)
+        if tag is None:
+            return
+        existing = _OFFLOAD_STATE_REGISTRY.get(tag)
+        if existing is not None and existing is not cls:
+            raise T2NErrorNotImplemented(
+                f"duplicate offload-state tag '{tag}' for {cls} "
+                f"(already registered by {existing})"
+            )
+        _OFFLOAD_STATE_REGISTRY[tag] = cls
+
+    @classmethod
+    def is_offload_state(cls, state) -> bool:
+        return (
+            isinstance(state, dict)
+            and state.get(OFFLOAD_STATE_KEY) == cls.OFFLOAD_STATE_TAG
+        )
+
+    @abc.abstractmethod
+    def to_offload_state(self) -> T.Dict[str, T.Any]:
+        raise T2NErrorNotImplemented()
+
+    @classmethod
+    @abc.abstractmethod
+    def from_offload_state(cls, state):
+        raise T2NErrorNotImplemented()
+
+    @classmethod
+    @abc.abstractmethod
+    def write_offload_state_in_file(
+        cls, state, dirpath, label, inference_target=None
+    ):
+        raise T2NErrorNotImplemented()
+
+
+def resolve_offload_state(state) -> T.Optional[type]:
+    """Return the class able to rebuild ``state``, or ``None``.
+
+    ``None`` means ``state`` is not a compact offload-state payload (e.g. a
+    plain pickled tensor), so callers fall back to legacy handling.
+    """
+    if not isinstance(state, dict):
+        return None
+    tag = state.get(OFFLOAD_STATE_KEY)
+    if tag is None:
+        return None
+    return _OFFLOAD_STATE_REGISTRY.get(tag)
+
+
 class OpaqueTensorRef(torch.Tensor):
     """Allow to pass through 'tracing'."""
 

--- a/torch_to_nnef/tensor/quant/qtract.py
+++ b/torch_to_nnef/tensor/quant/qtract.py
@@ -91,7 +91,9 @@ class QTensorTractScaleOnly(QTensorTract, SupportsOffloadState):
         }
 
     @classmethod
-    def from_offload_state(cls, state) -> "QTensorTractScaleOnly":
+    def from_offload_state(
+        cls, state, target_device=None
+    ) -> "QTensorTractScaleOnly":
         assert cls.is_offload_state(state), state
         # Fallback reload path only: rebuild the Tensor subclass shell on CPU
         # from the compact state. The fp-shaped buffer is an uninitialized
@@ -113,6 +115,8 @@ class QTensorTractScaleOnly(QTensorTract, SupportsOffloadState):
         qtensor.requires_grad = False
         qtensor.decompressed_shape = state["decompressed_shape"]
         qtensor.specific_machine = state["specific_machine"]
+        if target_device is not None and qtensor.device != target_device:
+            qtensor.to_device(target_device)
         return qtensor
 
     @staticmethod

--- a/torch_to_nnef/tensor/quant/qtract.py
+++ b/torch_to_nnef/tensor/quant/qtract.py
@@ -16,6 +16,10 @@ from torch_to_nnef.exceptions import (
 from torch_to_nnef.inference_target.base import InferenceTarget
 from torch_to_nnef.inference_target.tract import TractNNEF
 from torch_to_nnef.nnef_io.tensor import DatBinHeader
+from torch_to_nnef.tensor.opaque import (
+    OFFLOAD_STATE_KEY,
+    SupportsOffloadState,
+)
 from torch_to_nnef.tensor.quant.base import (
     QScalePerGroupF16,
     QTensor,
@@ -27,7 +31,7 @@ class QTensorTract(QTensor):
     """All QTensorTract implementations."""
 
 
-class QTensorTractScaleOnly(QTensorTract):
+class QTensorTractScaleOnly(QTensorTract, SupportsOffloadState):
     """Tract data format it serializes to: Q4_0."""
 
     OFFLOAD_STATE_TAG = "torch_to_nnef.qtensor_tract_scale_only.v1"
@@ -72,16 +76,9 @@ class QTensorTractScaleOnly(QTensorTract):
             decompress_u8, target_dtype=self.dequant_to_dtype
         )
 
-    @classmethod
-    def is_offload_state(cls, state) -> bool:
-        return (
-            isinstance(state, dict)
-            and state.get("__t2n_qtensor_state__") == cls.OFFLOAD_STATE_TAG
-        )
-
     def to_offload_state(self) -> T.Dict[str, T.Any]:
         return {
-            "__t2n_qtensor_state__": self.OFFLOAD_STATE_TAG,
+            OFFLOAD_STATE_KEY: self.OFFLOAD_STATE_TAG,
             "shape": tuple(self.shape),
             "dtype": self.dtype,
             "u8_blob": self.u8_blob,
@@ -96,10 +93,11 @@ class QTensorTractScaleOnly(QTensorTract):
     @classmethod
     def from_offload_state(cls, state) -> "QTensorTractScaleOnly":
         assert cls.is_offload_state(state), state
-        # Keep the Tensor subclass shell on CPU for fallback reloads. A meta
-        # shell routes nested opaque tracing through PyTorch meta kernels before
-        # the inner QTensor can decompress. Large NNEF exports use the direct
-        # offload-state writer instead of this reload path.
+        # Fallback reload path only: rebuild the Tensor subclass shell on CPU
+        # from the compact state. The fp-shaped buffer is an uninitialized
+        # placeholder (never read: decompression uses u8_blob), so it stays
+        # cheap. Large NNEF exports skip this entirely via the direct
+        # offload-state writer (write_offload_state_in_file).
         fp_placeholder = torch.empty(state["shape"], dtype=state["dtype"])
         qtensor = cls.__new__(
             cls,


### PR DESCRIPTION
## Summary
Follow-up to #243. That PR gave `OffloadedTensor` a compact offload-state path, but wired it through the concrete `QTensorTractScaleOnly` in three places (`_save`, `reload`, `write_qtensor_in_file`) via local imports. `OffloadedTensor` is a generic offload primitive, so hardcoding one concrete `QTensor` is a leaky abstraction: it only works because that class is the sole materialized `QTensor` in this repo. A second implementation (here, or in a downstream repo) would break silently.

Concrete failure modes it removes:
- `_save`: the `isinstance(tensor, QTensorTractScaleOnly)` guard is `False` for any other `SupportsOffloadState` type, so it silently falls back to pickling the fp-shaped subclass (the exact regression #243 fixed), with no error.
- `reload`: `QTensorTractScaleOnly.is_offload_state(loaded)` returns `False` for another type's state, then `loaded.to(...)` runs on a raw `dict` -> `AttributeError`.

## Change
- Add a generic `SupportsOffloadState` mixin + `OFFLOAD_STATE_KEY` marker + tag->class registry (`resolve_offload_state`) in `tensor/opaque.py`. Subclasses self-register at definition time via `__init_subclass__`.
- `OffloadedTensor` now dispatches on the serialized state through the registry and imports no concrete quant class.
- `QTensorTractScaleOnly` declares the mixin and uses the shared marker key; its three hooks are unchanged, so serialization stays byte-identical.
- A registry (not a dotted-path import) keeps it cross-repo friendly and does not widen the pickle code-exec surface.

Also folds in a small comment fix in `from_offload_state` (the prior comment described a `meta` shell the code never used).