### PR TITLE
chore: add intuitive install extras (llm, nemo-asr)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 
 ## [Unreleased]
 
+### Added
+- Intuitive install extras `torch_to_nnef[llm]` and `torch_to_nnef[nemo-asr]`, aliasing the existing `llm-tract` / `nemo-tract` redirect extras so the extra name matches the split package (`torch_to_nnef_llm`, `torch_to_nnef_nemo_asr`) and directory. The old names still work.
+
 ## [0.24.2] - 2026-07-08
 
 ### Added

--- a/examples/dynamic_axes/uv.lock
+++ b/examples/dynamic_axes/uv.lock
@@ -1071,7 +1071,7 @@ wheels = [
 
 [[package]]
 name = "torch-to-nnef"
-version = "0.24.1"
+version = "0.24.2"
 source = { editable = "../../" }
 dependencies = [
     { name = "mako" },
@@ -1092,13 +1092,15 @@ requires-dist = [
     { name = "pyyaml", specifier = ">=5.0" },
     { name = "safetensors", marker = "extra == 'safetensors'" },
     { name = "torch", specifier = ">=1.8.0,<3" },
+    { name = "torch-to-nnef-llm", marker = "extra == 'llm'", editable = "../../packages/llm" },
     { name = "torch-to-nnef-llm", marker = "extra == 'llm-tract'", editable = "../../packages/llm" },
     { name = "torch-to-nnef-llm", extras = ["accelerate"], marker = "extra == 'llm-tract-accelerate'", editable = "../../packages/llm" },
     { name = "torch-to-nnef-llm", extras = ["peft"], marker = "extra == 'peft'", editable = "../../packages/llm" },
+    { name = "torch-to-nnef-nemo-asr", marker = "extra == 'nemo-asr'", editable = "../../packages/nemo-asr" },
     { name = "torch-to-nnef-nemo-asr", marker = "extra == 'nemo-tract'", editable = "../../packages/nemo-asr" },
     { name = "typing-extensions", specifier = ">=4.0.0" },
 ]
-provides-extras = ["llm-tract", "llm-tract-accelerate", "peft", "nemo-tract", "safetensors"]
+provides-extras = ["llm-tract", "llm-tract-accelerate", "peft", "nemo-tract", "safetensors", "llm", "nemo-asr"]
 
 [package.metadata.requires-dev]
 dev = [

--- a/examples/getting_started_py/uv.lock
+++ b/examples/getting_started_py/uv.lock
@@ -645,7 +645,7 @@ wheels = [
 
 [[package]]
 name = "torch-to-nnef"
-version = "0.24.1"
+version = "0.24.2"
 source = { editable = "../../" }
 dependencies = [
     { name = "mako" },
@@ -666,13 +666,15 @@ requires-dist = [
     { name = "pyyaml", specifier = ">=5.0" },
     { name = "safetensors", marker = "extra == 'safetensors'" },
     { name = "torch", specifier = ">=1.8.0,<3" },
+    { name = "torch-to-nnef-llm", marker = "extra == 'llm'", editable = "../../packages/llm" },
     { name = "torch-to-nnef-llm", marker = "extra == 'llm-tract'", editable = "../../packages/llm" },
     { name = "torch-to-nnef-llm", extras = ["accelerate"], marker = "extra == 'llm-tract-accelerate'", editable = "../../packages/llm" },
     { name = "torch-to-nnef-llm", extras = ["peft"], marker = "extra == 'peft'", editable = "../../packages/llm" },
+    { name = "torch-to-nnef-nemo-asr", marker = "extra == 'nemo-asr'", editable = "../../packages/nemo-asr" },
     { name = "torch-to-nnef-nemo-asr", marker = "extra == 'nemo-tract'", editable = "../../packages/nemo-asr" },
     { name = "typing-extensions", specifier = ">=4.0.0" },
 ]
-provides-extras = ["llm-tract", "llm-tract-accelerate", "peft", "nemo-tract", "safetensors"]
+provides-extras = ["llm-tract", "llm-tract-accelerate", "peft", "nemo-tract", "safetensors", "llm", "nemo-asr"]
 
 [package.metadata.requires-dev]
 dev = [

--- a/examples/image_gen/uv.lock
+++ b/examples/image_gen/uv.lock
@@ -1345,7 +1345,7 @@ wheels = [
 
 [[package]]
 name = "torch-to-nnef"
-version = "0.24.1"
+version = "0.24.2"
 source = { editable = "../../" }
 dependencies = [
     { name = "mako" },
@@ -1366,13 +1366,15 @@ requires-dist = [
     { name = "pyyaml", specifier = ">=5.0" },
     { name = "safetensors", marker = "extra == 'safetensors'" },
     { name = "torch", specifier = ">=1.8.0,<3" },
+    { name = "torch-to-nnef-llm", marker = "extra == 'llm'", editable = "../../packages/llm" },
     { name = "torch-to-nnef-llm", marker = "extra == 'llm-tract'", editable = "../../packages/llm" },
     { name = "torch-to-nnef-llm", extras = ["accelerate"], marker = "extra == 'llm-tract-accelerate'", editable = "../../packages/llm" },
     { name = "torch-to-nnef-llm", extras = ["peft"], marker = "extra == 'peft'", editable = "../../packages/llm" },
+    { name = "torch-to-nnef-nemo-asr", marker = "extra == 'nemo-asr'", editable = "../../packages/nemo-asr" },
     { name = "torch-to-nnef-nemo-asr", marker = "extra == 'nemo-tract'", editable = "../../packages/nemo-asr" },
     { name = "typing-extensions", specifier = ">=4.0.0" },
 ]
-provides-extras = ["llm-tract", "llm-tract-accelerate", "peft", "nemo-tract", "safetensors"]
+provides-extras = ["llm-tract", "llm-tract-accelerate", "peft", "nemo-tract", "safetensors", "llm", "nemo-asr"]
 
 [package.metadata.requires-dev]
 dev = [

--- a/examples/imageclass-wasm/uv.lock
+++ b/examples/imageclass-wasm/uv.lock
@@ -643,7 +643,7 @@ wheels = [
 
 [[package]]
 name = "torch-to-nnef"
-version = "0.24.1"
+version = "0.24.2"
 source = { editable = "../../" }
 dependencies = [
     { name = "mako" },
@@ -664,13 +664,15 @@ requires-dist = [
     { name = "pyyaml", specifier = ">=5.0" },
     { name = "safetensors", marker = "extra == 'safetensors'" },
     { name = "torch", specifier = ">=1.8.0,<3" },
+    { name = "torch-to-nnef-llm", marker = "extra == 'llm'", editable = "../../packages/llm" },
     { name = "torch-to-nnef-llm", marker = "extra == 'llm-tract'", editable = "../../packages/llm" },
     { name = "torch-to-nnef-llm", extras = ["accelerate"], marker = "extra == 'llm-tract-accelerate'", editable = "../../packages/llm" },
     { name = "torch-to-nnef-llm", extras = ["peft"], marker = "extra == 'peft'", editable = "../../packages/llm" },
+    { name = "torch-to-nnef-nemo-asr", marker = "extra == 'nemo-asr'", editable = "../../packages/nemo-asr" },
     { name = "torch-to-nnef-nemo-asr", marker = "extra == 'nemo-tract'", editable = "../../packages/nemo-asr" },
     { name = "typing-extensions", specifier = ">=4.0.0" },
 ]
-provides-extras = ["llm-tract", "llm-tract-accelerate", "peft", "nemo-tract", "safetensors"]
+provides-extras = ["llm-tract", "llm-tract-accelerate", "peft", "nemo-tract", "safetensors", "llm", "nemo-asr"]
 
 [package.metadata.requires-dev]
 dev = [

--- a/examples/llm_wasm/uv.lock
+++ b/examples/llm_wasm/uv.lock
@@ -1082,7 +1082,7 @@ wheels = [
 
 [[package]]
 name = "torch-to-nnef"
-version = "0.24.1"
+version = "0.24.2"
 source = { editable = "../../" }
 dependencies = [
     { name = "mako" },
@@ -1108,13 +1108,15 @@ requires-dist = [
     { name = "pyyaml", specifier = ">=5.0" },
     { name = "safetensors", marker = "extra == 'safetensors'" },
     { name = "torch", specifier = ">=1.8.0,<3" },
+    { name = "torch-to-nnef-llm", marker = "extra == 'llm'", editable = "../../packages/llm" },
     { name = "torch-to-nnef-llm", marker = "extra == 'llm-tract'", editable = "../../packages/llm" },
     { name = "torch-to-nnef-llm", extras = ["accelerate"], marker = "extra == 'llm-tract-accelerate'", editable = "../../packages/llm" },
     { name = "torch-to-nnef-llm", extras = ["peft"], marker = "extra == 'peft'", editable = "../../packages/llm" },
+    { name = "torch-to-nnef-nemo-asr", marker = "extra == 'nemo-asr'", editable = "../../packages/nemo-asr" },
     { name = "torch-to-nnef-nemo-asr", marker = "extra == 'nemo-tract'", editable = "../../packages/nemo-asr" },
     { name = "typing-extensions", specifier = ">=4.0.0" },
 ]
-provides-extras = ["llm-tract", "llm-tract-accelerate", "peft", "nemo-tract", "safetensors"]
+provides-extras = ["llm-tract", "llm-tract-accelerate", "peft", "nemo-tract", "safetensors", "llm", "nemo-asr"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -1147,7 +1149,7 @@ test = [
 
 [[package]]
 name = "torch-to-nnef-llm"
-version = "0.24.1"
+version = "0.24.2"
 source = { editable = "../../packages/llm" }
 dependencies = [
     { name = "huggingface-hub" },

--- a/examples/mamba/external_state/uv.lock
+++ b/examples/mamba/external_state/uv.lock
@@ -1008,7 +1008,7 @@ wheels = [
 
 [[package]]
 name = "torch-to-nnef"
-version = "0.24.1"
+version = "0.24.2"
 source = { editable = "../../../" }
 dependencies = [
     { name = "mako" },
@@ -1029,13 +1029,15 @@ requires-dist = [
     { name = "pyyaml", specifier = ">=5.0" },
     { name = "safetensors", marker = "extra == 'safetensors'" },
     { name = "torch", specifier = ">=1.8.0,<3" },
+    { name = "torch-to-nnef-llm", marker = "extra == 'llm'", editable = "../../../packages/llm" },
     { name = "torch-to-nnef-llm", marker = "extra == 'llm-tract'", editable = "../../../packages/llm" },
     { name = "torch-to-nnef-llm", extras = ["accelerate"], marker = "extra == 'llm-tract-accelerate'", editable = "../../../packages/llm" },
     { name = "torch-to-nnef-llm", extras = ["peft"], marker = "extra == 'peft'", editable = "../../../packages/llm" },
+    { name = "torch-to-nnef-nemo-asr", marker = "extra == 'nemo-asr'", editable = "../../../packages/nemo-asr" },
     { name = "torch-to-nnef-nemo-asr", marker = "extra == 'nemo-tract'", editable = "../../../packages/nemo-asr" },
     { name = "typing-extensions", specifier = ">=4.0.0" },
 ]
-provides-extras = ["llm-tract", "llm-tract-accelerate", "peft", "nemo-tract", "safetensors"]
+provides-extras = ["llm-tract", "llm-tract-accelerate", "peft", "nemo-tract", "safetensors", "llm", "nemo-asr"]
 
 [package.metadata.requires-dev]
 dev = [

--- a/examples/mamba/pulse/uv.lock
+++ b/examples/mamba/pulse/uv.lock
@@ -1008,7 +1008,7 @@ wheels = [
 
 [[package]]
 name = "torch-to-nnef"
-version = "0.24.1"
+version = "0.24.2"
 source = { editable = "../../../" }
 dependencies = [
     { name = "mako" },
@@ -1029,13 +1029,15 @@ requires-dist = [
     { name = "pyyaml", specifier = ">=5.0" },
     { name = "safetensors", marker = "extra == 'safetensors'" },
     { name = "torch", specifier = ">=1.8.0,<3" },
+    { name = "torch-to-nnef-llm", marker = "extra == 'llm'", editable = "../../../packages/llm" },
     { name = "torch-to-nnef-llm", marker = "extra == 'llm-tract'", editable = "../../../packages/llm" },
     { name = "torch-to-nnef-llm", extras = ["accelerate"], marker = "extra == 'llm-tract-accelerate'", editable = "../../../packages/llm" },
     { name = "torch-to-nnef-llm", extras = ["peft"], marker = "extra == 'peft'", editable = "../../../packages/llm" },
+    { name = "torch-to-nnef-nemo-asr", marker = "extra == 'nemo-asr'", editable = "../../../packages/nemo-asr" },
     { name = "torch-to-nnef-nemo-asr", marker = "extra == 'nemo-tract'", editable = "../../../packages/nemo-asr" },
     { name = "typing-extensions", specifier = ">=4.0.0" },
 ]
-provides-extras = ["llm-tract", "llm-tract-accelerate", "peft", "nemo-tract", "safetensors"]
+provides-extras = ["llm-tract", "llm-tract-accelerate", "peft", "nemo-tract", "safetensors", "llm", "nemo-asr"]
 
 [package.metadata.requires-dev]
 dev = [

--- a/examples/multi_io_py/uv.lock
+++ b/examples/multi_io_py/uv.lock
@@ -1046,7 +1046,7 @@ wheels = [
 
 [[package]]
 name = "torch-to-nnef"
-version = "0.24.1"
+version = "0.24.2"
 source = { editable = "../../" }
 dependencies = [
     { name = "mako" },
@@ -1067,13 +1067,15 @@ requires-dist = [
     { name = "pyyaml", specifier = ">=5.0" },
     { name = "safetensors", marker = "extra == 'safetensors'" },
     { name = "torch", specifier = ">=1.8.0,<3" },
+    { name = "torch-to-nnef-llm", marker = "extra == 'llm'", editable = "../../packages/llm" },
     { name = "torch-to-nnef-llm", marker = "extra == 'llm-tract'", editable = "../../packages/llm" },
     { name = "torch-to-nnef-llm", extras = ["accelerate"], marker = "extra == 'llm-tract-accelerate'", editable = "../../packages/llm" },
     { name = "torch-to-nnef-llm", extras = ["peft"], marker = "extra == 'peft'", editable = "../../packages/llm" },
+    { name = "torch-to-nnef-nemo-asr", marker = "extra == 'nemo-asr'", editable = "../../packages/nemo-asr" },
     { name = "torch-to-nnef-nemo-asr", marker = "extra == 'nemo-tract'", editable = "../../packages/nemo-asr" },
     { name = "typing-extensions", specifier = ">=4.0.0" },
 ]
-provides-extras = ["llm-tract", "llm-tract-accelerate", "peft", "nemo-tract", "safetensors"]
+provides-extras = ["llm-tract", "llm-tract-accelerate", "peft", "nemo-tract", "safetensors", "llm", "nemo-asr"]
 
 [package.metadata.requires-dev]
 dev = [

--- a/examples/nemo_asr/uv.lock
+++ b/examples/nemo_asr/uv.lock
@@ -4861,7 +4861,7 @@ wheels = [
 
 [[package]]
 name = "torch-to-nnef"
-version = "0.24.1"
+version = "0.24.2"
 source = { editable = "../../" }
 dependencies = [
     { name = "mako" },
@@ -4889,13 +4889,15 @@ requires-dist = [
     { name = "pyyaml", specifier = ">=5.0" },
     { name = "safetensors", marker = "extra == 'safetensors'" },
     { name = "torch", specifier = ">=1.8.0,<3" },
+    { name = "torch-to-nnef-llm", marker = "extra == 'llm'", editable = "../../packages/llm" },
     { name = "torch-to-nnef-llm", marker = "extra == 'llm-tract'", editable = "../../packages/llm" },
     { name = "torch-to-nnef-llm", extras = ["accelerate"], marker = "extra == 'llm-tract-accelerate'", editable = "../../packages/llm" },
     { name = "torch-to-nnef-llm", extras = ["peft"], marker = "extra == 'peft'", editable = "../../packages/llm" },
+    { name = "torch-to-nnef-nemo-asr", marker = "extra == 'nemo-asr'", editable = "../../packages/nemo-asr" },
     { name = "torch-to-nnef-nemo-asr", marker = "extra == 'nemo-tract'", editable = "../../packages/nemo-asr" },
     { name = "typing-extensions", specifier = ">=4.0.0" },
 ]
-provides-extras = ["llm-tract", "llm-tract-accelerate", "peft", "nemo-tract", "safetensors"]
+provides-extras = ["llm-tract", "llm-tract-accelerate", "peft", "nemo-tract", "safetensors", "llm", "nemo-asr"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -4928,7 +4930,7 @@ test = [
 
 [[package]]
 name = "torch-to-nnef-nemo-asr"
-version = "0.24.1"
+version = "0.24.2"
 source = { editable = "../../packages/nemo-asr" }
 dependencies = [
     { name = "nemo-toolkit", extra = ["asr"] },

--- a/examples/quantization_py/uv.lock
+++ b/examples/quantization_py/uv.lock
@@ -644,7 +644,7 @@ wheels = [
 
 [[package]]
 name = "torch-to-nnef"
-version = "0.24.1"
+version = "0.24.2"
 source = { editable = "../../" }
 dependencies = [
     { name = "mako" },
@@ -665,13 +665,15 @@ requires-dist = [
     { name = "pyyaml", specifier = ">=5.0" },
     { name = "safetensors", marker = "extra == 'safetensors'" },
     { name = "torch", specifier = ">=1.8.0,<3" },
+    { name = "torch-to-nnef-llm", marker = "extra == 'llm'", editable = "../../packages/llm" },
     { name = "torch-to-nnef-llm", marker = "extra == 'llm-tract'", editable = "../../packages/llm" },
     { name = "torch-to-nnef-llm", extras = ["accelerate"], marker = "extra == 'llm-tract-accelerate'", editable = "../../packages/llm" },
     { name = "torch-to-nnef-llm", extras = ["peft"], marker = "extra == 'peft'", editable = "../../packages/llm" },
+    { name = "torch-to-nnef-nemo-asr", marker = "extra == 'nemo-asr'", editable = "../../packages/nemo-asr" },
     { name = "torch-to-nnef-nemo-asr", marker = "extra == 'nemo-tract'", editable = "../../packages/nemo-asr" },
     { name = "typing-extensions", specifier = ">=4.0.0" },
 ]
-provides-extras = ["llm-tract", "llm-tract-accelerate", "peft", "nemo-tract", "safetensors"]
+provides-extras = ["llm-tract", "llm-tract-accelerate", "peft", "nemo-tract", "safetensors", "llm", "nemo-asr"]
 
 [package.metadata.requires-dev]
 dev = [

--- a/examples/speech_enhancement/deepfilternet/uv.lock
+++ b/examples/speech_enhancement/deepfilternet/uv.lock
@@ -788,7 +788,7 @@ wheels = [
 
 [[package]]
 name = "torch-to-nnef"
-version = "0.24.1"
+version = "0.24.2"
 source = { editable = "../../../" }
 dependencies = [
     { name = "mako" },
@@ -809,13 +809,15 @@ requires-dist = [
     { name = "pyyaml", specifier = ">=5.0" },
     { name = "safetensors", marker = "extra == 'safetensors'" },
     { name = "torch", specifier = ">=1.8.0,<3" },
+    { name = "torch-to-nnef-llm", marker = "extra == 'llm'", editable = "../../../packages/llm" },
     { name = "torch-to-nnef-llm", marker = "extra == 'llm-tract'", editable = "../../../packages/llm" },
     { name = "torch-to-nnef-llm", extras = ["accelerate"], marker = "extra == 'llm-tract-accelerate'", editable = "../../../packages/llm" },
     { name = "torch-to-nnef-llm", extras = ["peft"], marker = "extra == 'peft'", editable = "../../../packages/llm" },
+    { name = "torch-to-nnef-nemo-asr", marker = "extra == 'nemo-asr'", editable = "../../../packages/nemo-asr" },
     { name = "torch-to-nnef-nemo-asr", marker = "extra == 'nemo-tract'", editable = "../../../packages/nemo-asr" },
     { name = "typing-extensions", specifier = ">=4.0.0" },
 ]
-provides-extras = ["llm-tract", "llm-tract-accelerate", "peft", "nemo-tract", "safetensors"]
+provides-extras = ["llm-tract", "llm-tract-accelerate", "peft", "nemo-tract", "safetensors", "llm", "nemo-asr"]
 
 [package.metadata.requires-dev]
 dev = [

--- a/examples/speech_enhancement/dpdfnet/uv.lock
+++ b/examples/speech_enhancement/dpdfnet/uv.lock
@@ -749,7 +749,7 @@ wheels = [
 
 [[package]]
 name = "torch-to-nnef"
-version = "0.24.1"
+version = "0.24.2"
 source = { editable = "../../../" }
 dependencies = [
     { name = "mako" },
@@ -770,13 +770,15 @@ requires-dist = [
     { name = "pyyaml", specifier = ">=5.0" },
     { name = "safetensors", marker = "extra == 'safetensors'" },
     { name = "torch", specifier = ">=1.8.0,<3" },
+    { name = "torch-to-nnef-llm", marker = "extra == 'llm'", editable = "../../../packages/llm" },
     { name = "torch-to-nnef-llm", marker = "extra == 'llm-tract'", editable = "../../../packages/llm" },
     { name = "torch-to-nnef-llm", extras = ["accelerate"], marker = "extra == 'llm-tract-accelerate'", editable = "../../../packages/llm" },
     { name = "torch-to-nnef-llm", extras = ["peft"], marker = "extra == 'peft'", editable = "../../../packages/llm" },
+    { name = "torch-to-nnef-nemo-asr", marker = "extra == 'nemo-asr'", editable = "../../../packages/nemo-asr" },
     { name = "torch-to-nnef-nemo-asr", marker = "extra == 'nemo-tract'", editable = "../../../packages/nemo-asr" },
     { name = "typing-extensions", specifier = ">=4.0.0" },
 ]
-provides-extras = ["llm-tract", "llm-tract-accelerate", "peft", "nemo-tract", "safetensors"]
+provides-extras = ["llm-tract", "llm-tract-accelerate", "peft", "nemo-tract", "safetensors", "llm", "nemo-asr"]
 
 [package.metadata.requires-dev]
 dev = [

--- a/examples/t2n_extra_custom_op/uv.lock
+++ b/examples/t2n_extra_custom_op/uv.lock
@@ -644,7 +644,7 @@ wheels = [
 
 [[package]]
 name = "torch-to-nnef"
-version = "0.24.1"
+version = "0.24.2"
 source = { editable = "../../" }
 dependencies = [
     { name = "mako" },
@@ -665,13 +665,15 @@ requires-dist = [
     { name = "pyyaml", specifier = ">=5.0" },
     { name = "safetensors", marker = "extra == 'safetensors'" },
     { name = "torch", specifier = ">=1.8.0,<3" },
+    { name = "torch-to-nnef-llm", marker = "extra == 'llm'", editable = "../../packages/llm" },
     { name = "torch-to-nnef-llm", marker = "extra == 'llm-tract'", editable = "../../packages/llm" },
     { name = "torch-to-nnef-llm", extras = ["accelerate"], marker = "extra == 'llm-tract-accelerate'", editable = "../../packages/llm" },
     { name = "torch-to-nnef-llm", extras = ["peft"], marker = "extra == 'peft'", editable = "../../packages/llm" },
+    { name = "torch-to-nnef-nemo-asr", marker = "extra == 'nemo-asr'", editable = "../../packages/nemo-asr" },
     { name = "torch-to-nnef-nemo-asr", marker = "extra == 'nemo-tract'", editable = "../../packages/nemo-asr" },
     { name = "typing-extensions", specifier = ">=4.0.0" },
 ]
-provides-extras = ["llm-tract", "llm-tract-accelerate", "peft", "nemo-tract", "safetensors"]
+provides-extras = ["llm-tract", "llm-tract-accelerate", "peft", "nemo-tract", "safetensors", "llm", "nemo-asr"]
 
 [package.metadata.requires-dev]
 dev = [

--- a/examples/tts/pocket_tts/uv.lock
+++ b/examples/tts/pocket_tts/uv.lock
@@ -1413,7 +1413,7 @@ wheels = [
 
 [[package]]
 name = "torch-to-nnef"
-version = "0.24.1"
+version = "0.24.2"
 source = { editable = "../../../" }
 dependencies = [
     { name = "mako" },
@@ -1434,13 +1434,15 @@ requires-dist = [
     { name = "pyyaml", specifier = ">=5.0" },
     { name = "safetensors", marker = "extra == 'safetensors'" },
     { name = "torch", specifier = ">=1.8.0,<3" },
+    { name = "torch-to-nnef-llm", marker = "extra == 'llm'", editable = "../../../packages/llm" },
     { name = "torch-to-nnef-llm", marker = "extra == 'llm-tract'", editable = "../../../packages/llm" },
     { name = "torch-to-nnef-llm", extras = ["accelerate"], marker = "extra == 'llm-tract-accelerate'", editable = "../../../packages/llm" },
     { name = "torch-to-nnef-llm", extras = ["peft"], marker = "extra == 'peft'", editable = "../../../packages/llm" },
+    { name = "torch-to-nnef-nemo-asr", marker = "extra == 'nemo-asr'", editable = "../../../packages/nemo-asr" },
     { name = "torch-to-nnef-nemo-asr", marker = "extra == 'nemo-tract'", editable = "../../../packages/nemo-asr" },
     { name = "typing-extensions", specifier = ">=4.0.0" },
 ]
-provides-extras = ["llm-tract", "llm-tract-accelerate", "peft", "nemo-tract", "safetensors"]
+provides-extras = ["llm-tract", "llm-tract-accelerate", "peft", "nemo-tract", "safetensors", "llm", "nemo-asr"]
 
 [package.metadata.requires-dev]
 dev = [

--- a/examples/vad/FSMN-wasm/uv.lock
+++ b/examples/vad/FSMN-wasm/uv.lock
@@ -859,7 +859,7 @@ wheels = [
 
 [[package]]
 name = "torch-to-nnef"
-version = "0.24.1"
+version = "0.24.2"
 source = { editable = "../../../" }
 dependencies = [
     { name = "mako" },
@@ -880,13 +880,15 @@ requires-dist = [
     { name = "pyyaml", specifier = ">=5.0" },
     { name = "safetensors", marker = "extra == 'safetensors'" },
     { name = "torch", specifier = ">=1.8.0,<3" },
+    { name = "torch-to-nnef-llm", marker = "extra == 'llm'", editable = "../../../packages/llm" },
     { name = "torch-to-nnef-llm", marker = "extra == 'llm-tract'", editable = "../../../packages/llm" },
     { name = "torch-to-nnef-llm", extras = ["accelerate"], marker = "extra == 'llm-tract-accelerate'", editable = "../../../packages/llm" },
     { name = "torch-to-nnef-llm", extras = ["peft"], marker = "extra == 'peft'", editable = "../../../packages/llm" },
+    { name = "torch-to-nnef-nemo-asr", marker = "extra == 'nemo-asr'", editable = "../../../packages/nemo-asr" },
     { name = "torch-to-nnef-nemo-asr", marker = "extra == 'nemo-tract'", editable = "../../../packages/nemo-asr" },
     { name = "typing-extensions", specifier = ">=4.0.0" },
 ]
-provides-extras = ["llm-tract", "llm-tract-accelerate", "peft", "nemo-tract", "safetensors"]
+provides-extras = ["llm-tract", "llm-tract-accelerate", "peft", "nemo-tract", "safetensors", "llm", "nemo-asr"]
 
 [package.metadata.requires-dev]
 dev = [

--- a/examples/vad/silero-jit/uv.lock
+++ b/examples/vad/silero-jit/uv.lock
@@ -666,7 +666,7 @@ wheels = [
 
 [[package]]
 name = "torch-to-nnef"
-version = "0.24.1"
+version = "0.24.2"
 source = { editable = "../../../" }
 dependencies = [
     { name = "mako" },
@@ -687,13 +687,15 @@ requires-dist = [
     { name = "pyyaml", specifier = ">=5.0" },
     { name = "safetensors", marker = "extra == 'safetensors'" },
     { name = "torch", specifier = ">=1.8.0,<3" },
+    { name = "torch-to-nnef-llm", marker = "extra == 'llm'", editable = "../../../packages/llm" },
     { name = "torch-to-nnef-llm", marker = "extra == 'llm-tract'", editable = "../../../packages/llm" },
     { name = "torch-to-nnef-llm", extras = ["accelerate"], marker = "extra == 'llm-tract-accelerate'", editable = "../../../packages/llm" },
     { name = "torch-to-nnef-llm", extras = ["peft"], marker = "extra == 'peft'", editable = "../../../packages/llm" },
+    { name = "torch-to-nnef-nemo-asr", marker = "extra == 'nemo-asr'", editable = "../../../packages/nemo-asr" },
     { name = "torch-to-nnef-nemo-asr", marker = "extra == 'nemo-tract'", editable = "../../../packages/nemo-asr" },
     { name = "typing-extensions", specifier = ">=4.0.0" },
 ]
-provides-extras = ["llm-tract", "llm-tract-accelerate", "peft", "nemo-tract", "safetensors"]
+provides-extras = ["llm-tract", "llm-tract-accelerate", "peft", "nemo-tract", "safetensors", "llm", "nemo-asr"]
 
 [package.metadata.requires-dev]
 dev = [

--- a/examples/yolo/uv.lock
+++ b/examples/yolo/uv.lock
@@ -820,7 +820,7 @@ wheels = [
 
 [[package]]
 name = "torch-to-nnef"
-version = "0.24.1"
+version = "0.24.2"
 source = { editable = "../../" }
 dependencies = [
     { name = "mako" },
@@ -841,13 +841,15 @@ requires-dist = [
     { name = "pyyaml", specifier = ">=5.0" },
     { name = "safetensors", marker = "extra == 'safetensors'" },
     { name = "torch", specifier = ">=1.8.0,<3" },
+    { name = "torch-to-nnef-llm", marker = "extra == 'llm'", editable = "../../packages/llm" },
     { name = "torch-to-nnef-llm", marker = "extra == 'llm-tract'", editable = "../../packages/llm" },
     { name = "torch-to-nnef-llm", extras = ["accelerate"], marker = "extra == 'llm-tract-accelerate'", editable = "../../packages/llm" },
     { name = "torch-to-nnef-llm", extras = ["peft"], marker = "extra == 'peft'", editable = "../../packages/llm" },
+    { name = "torch-to-nnef-nemo-asr", marker = "extra == 'nemo-asr'", editable = "../../packages/nemo-asr" },
     { name = "torch-to-nnef-nemo-asr", marker = "extra == 'nemo-tract'", editable = "../../packages/nemo-asr" },
     { name = "typing-extensions", specifier = ">=4.0.0" },
 ]
-provides-extras = ["llm-tract", "llm-tract-accelerate", "peft", "nemo-tract", "safetensors"]
+provides-extras = ["llm-tract", "llm-tract-accelerate", "peft", "nemo-tract", "safetensors", "llm", "nemo-asr"]
 
 [package.metadata.requires-dev]
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,9 @@ llm-tract-accelerate = ["torch_to_nnef_llm[accelerate]"]
 peft = ["torch_to_nnef_llm[peft]"]
 nemo-tract = ["torch_to_nnef_nemo_asr"]
 safetensors = ["safetensors"]
+# Intuitive aliases matching the split package / directory names
+llm = ["torch_to_nnef_llm"]
+nemo-asr = ["torch_to_nnef_nemo_asr"]
 [project.urls]
 Homepage = "https://github.com/sonos/torch-to-nnef"
 

--- a/uv.lock
+++ b/uv.lock
@@ -981,27 +981,33 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/d5/85/6379d42181bfc713094f081360fc5784d6c816b599d45e7f082502d173ce/cryptography-48.0.1-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:32143b24adb918f078134e1e230f1eb8cc04886b92c28b5f0041aaf3e5699225", size = 4696243, upload-time = "2026-06-09T22:32:33.446Z" },
     { url = "https://files.pythonhosted.org/packages/9c/87/c85d147b53323c7eb4d850920c8901377323c2a0ff8d79c262d4fee89aa2/cryptography-48.0.1-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f0d27a5696721ef7a672b8c810f6aded391058e0b9486e63e6d93baf765da691", size = 4713235, upload-time = "2026-06-09T22:31:40.141Z" },
     { url = "https://files.pythonhosted.org/packages/79/58/67cbf8cf1ee7c54b439ca07bbecf8362c07afc11a3724fea70f745784add/cryptography-48.0.1-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:eb86ce1af36fe65041b6db9a8bb064ee621a7e5fded0f80d475ec243477cd242", size = 4702323, upload-time = "2026-06-09T22:31:42.191Z" },
+    { url = "https://files.pythonhosted.org/packages/89/c6/24266ac10c47f6cd2a865f4446062b466da1d1f10b27189eac00e61bf0c9/cryptography-48.0.1-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:b024e784ad6c077ee0147b35ea9cbfc1e34e1fd4c1dcca214c2794d73a12df08", size = 5300085, upload-time = "2026-06-09T22:31:58.703Z" },
     { url = "https://files.pythonhosted.org/packages/d2/bb/cc4b78784f97efc8c5874c2a9743708d172be6663024b34a0467885ae0c8/cryptography-48.0.1-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:3752f2dbc8f07a30aad2932c986cea495b03bb554887828225da104f732852b6", size = 4746137, upload-time = "2026-06-09T22:31:31.01Z" },
     { url = "https://files.pythonhosted.org/packages/1f/52/0c44de3f5267f8fbe8e835138017522a333436166e406f0db9b9e6e3033f/cryptography-48.0.1-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:bd81490cd5801d755cf97bb68ac191f14b708470b1c7cf4580f669b9c9264cd8", size = 4333867, upload-time = "2026-06-09T22:32:28.096Z" },
     { url = "https://files.pythonhosted.org/packages/9a/2e/772d7adbfa931537bc401640b7cac9976bff689bda187833e5d63b428e49/cryptography-48.0.1-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:66fd0771e7b9c6dcd44cf1120690d2338d16d72795cf40cae2786a39eba65429", size = 4701805, upload-time = "2026-06-09T22:31:38.284Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/a3/b06844f303873493c963caf581c04df31c7035e0c1b0f02c4814d319ec80/cryptography-48.0.1-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:3fd2ca57062b241c856670b073487d2e86c4637937ca5601e48f97bf8e11fc8f", size = 5258461, upload-time = "2026-06-09T22:31:04.187Z" },
     { url = "https://files.pythonhosted.org/packages/9f/13/8b765e2e12b07c74941caadb9d1c8fdc006c4dfbf2b8f2d610519758954d/cryptography-48.0.1-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:0ee6ea481db1ab889cba043ec1eda17bb9c1ea79db6722f779c3667f9f70322f", size = 4745488, upload-time = "2026-06-09T22:32:30.07Z" },
     { url = "https://files.pythonhosted.org/packages/2e/aa/48972bce55049b32a94f4907eda4d75fa385aad8a39506cc2fc72196ecf0/cryptography-48.0.1-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:f2ceef93cb096aa3c4cc4b5c94ca6131f9196d28c64d6111533402a9b2054d41", size = 4830256, upload-time = "2026-06-09T22:31:43.868Z" },
     { url = "https://files.pythonhosted.org/packages/47/a2/e5079a032fb85cf6005046ca92bbd78b0c82dad2b5751ab8c311659da06f/cryptography-48.0.1-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:9bd3f92d76217892b15df84ca256c2c113d386fdda7a7d8691aeeced976507c6", size = 4979117, upload-time = "2026-06-09T22:31:05.845Z" },
     { url = "https://files.pythonhosted.org/packages/8a/13/6476736484b94041110c8340a3eb63962fea4975baea8cb4a512adb44d4d/cryptography-48.0.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d5d30989c6917b478b5817902e85fddaea2261efa8648383d965381ccb9e1ac4", size = 4689201, upload-time = "2026-06-09T22:31:09.745Z" },
     { url = "https://files.pythonhosted.org/packages/79/62/65a87f34d2a431546e2509b85d55e8c90df86d668f6731da64d538512ac2/cryptography-48.0.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:df637c05205ea7c1d7fbcbe54bbfea648a52951155f997af13d895d0ecc96991", size = 4702822, upload-time = "2026-06-09T22:32:24.409Z" },
     { url = "https://files.pythonhosted.org/packages/7f/59/810b5204b0a9b10f4b6bc06bd551a8b609803cd931806bc3b71884b225e5/cryptography-48.0.1-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:869c3b8a53bfe27147832df48b32adadf558249d50e76cb3769d40e986b13265", size = 4694875, upload-time = "2026-06-09T22:32:08.737Z" },
+    { url = "https://files.pythonhosted.org/packages/24/dc/d8ca05ffea724eec6d232ea6f18e74c269eb6bdfdcc9bfba689790d1325f/cryptography-48.0.1-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:e361afba8918070d376df76f408a4f67fec0ee9cff81a99e48fe9a233ef59e17", size = 5290385, upload-time = "2026-06-09T22:31:15.212Z" },
     { url = "https://files.pythonhosted.org/packages/03/8c/3be6cb4da181f5bb6c19cf560c2359d60644a6b5fc5b57854e528f47b296/cryptography-48.0.1-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:d069066deead00ac7f090be101be875a06855908f7ec004c27b8fefb4acfb411", size = 4737082, upload-time = "2026-06-09T22:32:22.66Z" },
     { url = "https://files.pythonhosted.org/packages/aa/f6/d5f60a5a1434dbfd949e227fd0065d194c7e6b6ac526b17f5c06152b8231/cryptography-48.0.1-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:09f73a725d582cef64b91281a322cd798d14a33b2b6f2b7ad9531dc336d84c02", size = 4325328, upload-time = "2026-06-09T22:32:10.777Z" },
     { url = "https://files.pythonhosted.org/packages/17/b7/ba75dd947a14b6ad907b01ae8f6b5b348cdd1b48142f0063dee9e20c1d9d/cryptography-48.0.1-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:15254441469dd6bf027039453288e2072124f8b6603563f5d759e1c9b69273fa", size = 4694530, upload-time = "2026-06-09T22:31:53.105Z" },
+    { url = "https://files.pythonhosted.org/packages/62/29/50d6b9e8aff12d8b67afaeb3569335e32dc83a5723e3bbded24fdac9f809/cryptography-48.0.1-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:8ace4507d1e6533c125f4fac754f8bb8b6a74c08e92179dabd7e16571a3efbf3", size = 5245046, upload-time = "2026-06-09T22:31:25.774Z" },
     { url = "https://files.pythonhosted.org/packages/9f/04/618f4115cfc0add0838c82507aa18a346089428da8653ad38b3ff36f5cb3/cryptography-48.0.1-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:b4e391975f038e66432328639620a4aff2d307513b004f1ca06d6225bced815c", size = 4736660, upload-time = "2026-06-09T22:32:12.676Z" },
     { url = "https://files.pythonhosted.org/packages/24/9c/06e062462a0de28a3b3911322eded4c16deb9f441b1b7575d3dc59488ab5/cryptography-48.0.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:42fcd8e26fe555d9b3577a135f5091fefa0aa4e99129c23fb56787a1bd4ada72", size = 4822229, upload-time = "2026-06-09T22:31:17.062Z" },
     { url = "https://files.pythonhosted.org/packages/f4/be/0561971eaaee4b8a0e7d5113c536921063ab91aaf23278ac374eaf881e11/cryptography-48.0.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:c1400da5e32a43253392277eac7490a60e497d810a63dd5608d71bbd7af507c9", size = 4966364, upload-time = "2026-06-09T22:31:32.842Z" },
     { url = "https://files.pythonhosted.org/packages/b0/d9/45f309a7e4e5f3f8f121d6d3be9e94024a7726ec598d6e08ae04edb2f04d/cryptography-48.0.1-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:48fe40804d4caa2288f24e70ca8c64c42dd826da0ad7e4f1b41b2128d679e6c8", size = 4690196, upload-time = "2026-06-09T22:31:54.74Z" },
     { url = "https://files.pythonhosted.org/packages/5f/9f/a1bc8bcc798811b8527eb374bbccf30a3f3e806829d967118222bf1125eb/cryptography-48.0.1-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:86be3b1b0b6bf09482fb50a979c508d2950ed95f5621ec77f4e385962006b83a", size = 4696782, upload-time = "2026-06-09T22:31:45.615Z" },
     { url = "https://files.pythonhosted.org/packages/66/c2/81a4fb4e4373c500bb526bc337ac5719dd31dd15b970b84a238168c6aa08/cryptography-48.0.1-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:4ab0a343c807bbcd90c971cd1ecf072937cd01847a9e002bef88fb47ac6be577", size = 4696618, upload-time = "2026-06-09T22:31:11.564Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/0b/aa68b221dde92d09cb29a024ede17550ee21e77a404e59fc093c82bb51e1/cryptography-48.0.1-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:9621de99d2da096006b629979efd8ae7eb2d8b822488d0c89ee4000c306c59b1", size = 5289970, upload-time = "2026-06-09T22:31:20.368Z" },
     { url = "https://files.pythonhosted.org/packages/78/13/fba657f958d2af66ea959a4ba01212632089249d34af1ae48054136344d7/cryptography-48.0.1-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:88c852a0ae366e262e5a1744b685e6a433dc8788dd2a277e418bf4904203609d", size = 4731873, upload-time = "2026-06-09T22:31:22.253Z" },
     { url = "https://files.pythonhosted.org/packages/4c/4c/9a964756d24a26b3e34dfcb16f961b89838786e6700b635b0d1e3adff4b6/cryptography-48.0.1-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:43c5835e2cb98c8733d86f57d6fc879b613f5c3478607281c3e36daffc6dd8a6", size = 4330804, upload-time = "2026-06-09T22:31:36.56Z" },
     { url = "https://files.pythonhosted.org/packages/4b/0f/a10f3a6eb12950a10e3a874070283aa2dd5875b2bfd15fad8a3e17b3f13e/cryptography-48.0.1-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:fe0180af5bf9236518a087e35bf2d9a347d5f5f51e63c579d683ddff424e3d46", size = 4696217, upload-time = "2026-06-09T22:31:13.351Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/6f/5cd12f951165ea73ef85266775d97e4c763b2474ccfd816dd69d3a18d6f8/cryptography-48.0.1-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:b7a2d1a937a738a881737cec135a38bb61470589b17515b9f73f571d0ae10401", size = 5245252, upload-time = "2026-06-09T22:32:02.193Z" },
     { url = "https://files.pythonhosted.org/packages/68/ab/8aaa12e4516ec4464033ab79b6f3b592bd5a92102467c4ace8a0d970203f/cryptography-48.0.1-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:b74ca3b8e5ecdd833bf6a002ca41b4793bb27fb8f1c06ffaf2643c9e9140e31b", size = 4731388, upload-time = "2026-06-09T22:32:04.019Z" },
     { url = "https://files.pythonhosted.org/packages/1b/24/50027ea4dca85ec1f40688f3c24fb32ccacd520583c9592c3cc95628e6fb/cryptography-48.0.1-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:2c37f2461406063b417837f5f3daab668652acd82423efcd7f0a9f04be972de1", size = 4824186, upload-time = "2026-06-09T22:32:18.707Z" },
     { url = "https://files.pythonhosted.org/packages/52/41/04cb5eb17085ade6f50cc611fb657df6a0f5885350de8764ece89c050197/cryptography-48.0.1-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:86fe77abb1bd87afb251d4d02ada7ecf53a32cee9b67d976abb2e45a13297475", size = 4964539, upload-time = "2026-06-09T22:31:18.793Z" },
@@ -6235,11 +6241,17 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+llm = [
+    { name = "torch-to-nnef-llm" },
+]
 llm-tract = [
     { name = "torch-to-nnef-llm" },
 ]
 llm-tract-accelerate = [
     { name = "torch-to-nnef-llm", extra = ["accelerate"] },
+]
+nemo-asr = [
+    { name = "torch-to-nnef-nemo-asr" },
 ]
 nemo-tract = [
     { name = "torch-to-nnef-nemo-asr" },
@@ -6289,13 +6301,15 @@ requires-dist = [
     { name = "pyyaml", specifier = ">=5.0" },
     { name = "safetensors", marker = "extra == 'safetensors'" },
     { name = "torch", specifier = ">=1.8.0,<3" },
+    { name = "torch-to-nnef-llm", marker = "extra == 'llm'", editable = "packages/llm" },
     { name = "torch-to-nnef-llm", marker = "extra == 'llm-tract'", editable = "packages/llm" },
     { name = "torch-to-nnef-llm", extras = ["accelerate"], marker = "extra == 'llm-tract-accelerate'", editable = "packages/llm" },
     { name = "torch-to-nnef-llm", extras = ["peft"], marker = "extra == 'peft'", editable = "packages/llm" },
+    { name = "torch-to-nnef-nemo-asr", marker = "extra == 'nemo-asr'", editable = "packages/nemo-asr" },
     { name = "torch-to-nnef-nemo-asr", marker = "extra == 'nemo-tract'", editable = "packages/nemo-asr" },
     { name = "typing-extensions", specifier = ">=4.0.0" },
 ]
-provides-extras = ["llm-tract", "llm-tract-accelerate", "peft", "nemo-tract", "safetensors"]
+provides-extras = ["llm-tract", "llm-tract-accelerate", "peft", "nemo-tract", "safetensors", "llm", "nemo-asr"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## What

Add two install extras that alias the existing redirect extras:

```toml
llm = ["torch_to_nnef_llm"]
nemo-asr = ["torch_to_nnef_nemo_asr"]
```

`llm-tract` and `nemo-tract` still work unchanged; these are non-breaking aliases.

## Why

The split (`4eff0704`) named the packages `torch_to_nnef_llm` / `torch_to_nnef_nemo_asr` and the directories `packages/llm` / `packages/nemo-asr`, but the redirect extras kept the older `llm-tract` / `nemo-tract` names. So `pip install "torch_to_nnef[nemo-asr]"` (the intuitive guess, matching the package and directory) silently installs only the base package: pip treats an unknown extra as a no-op with just a `WARNING: ... does not provide the extra 'nemo-asr'` and exits 0.

This makes the intuitive name resolve. Takes effect once a release ships the new metadata (PyPI reads extras from the published version); available immediately for editable installs.