### PR TITLE
fix(conv): handle string padding "valid"/"same" in shape inference

### DIFF
--- a/tests/test_infer_shape.py
+++ b/tests/test_infer_shape.py
@@ -88,6 +88,42 @@ test_suite.add(
 )
 
 test_suite.add(
+    "conv1d_padding_valid",
+    parse_ir_and_get_first_op(
+        torch.nn.Conv1d(4, 16, kernel_size=3, padding="valid"),
+        (torch.randn(1, 4, 224),),
+        "aten::_convolution_mode",
+    ),
+)
+
+test_suite.add(
+    "conv1d_padding_same",
+    parse_ir_and_get_first_op(
+        torch.nn.Conv1d(4, 16, kernel_size=3, padding="same"),
+        (torch.randn(1, 4, 224),),
+        "aten::_convolution_mode",
+    ),
+)
+
+test_suite.add(
+    "conv2d_padding_valid",
+    parse_ir_and_get_first_op(
+        torch.nn.Conv2d(3, 16, kernel_size=3, padding="valid"),
+        (torch.randn(1, 3, 32, 32),),
+        "aten::_convolution_mode",
+    ),
+)
+
+test_suite.add(
+    "conv2d_padding_same",
+    parse_ir_and_get_first_op(
+        torch.nn.Conv2d(3, 16, kernel_size=3, padding="same"),
+        (torch.randn(1, 3, 32, 32),),
+        "aten::_convolution_mode",
+    ),
+)
+
+test_suite.add(
     "linear",
     parse_ir_and_get_first_op(
         torch.nn.Linear(128, 64),

--- a/torch_to_nnef/torch_graph/ir_op.py
+++ b/torch_to_nnef/torch_graph/ir_op.py
@@ -458,6 +458,13 @@ def _infer_shape_convolution_output(*args) -> torch.Size:
             return [v] * dim
         return list(v)
 
+    # ``conv{1,2,3}d`` accept string padding modes ``"valid"`` (no padding)
+    # and ``"same"`` (output spatial size == input spatial size, stride 1).
+    # These reach us verbatim, so resolve them before numeric normalization.
+    same_padding = padding == "same"
+    if isinstance(padding, str):
+        padding = 0
+
     stride = _normalize(stride, spatial_rank)
     padding = _normalize(padding, spatial_rank)
     dilation = _normalize(dilation, spatial_rank)
@@ -491,9 +498,13 @@ def _infer_shape_convolution_output(*args) -> torch.Size:
             s = stride[i]
             p = padding[i]
             d = dilation[i]
-            # PyTorch formula:
-            # out = floor((in + 2p - d*(k-1) - 1) / s + 1)
-            out_dim = ((in_size + 2 * p - d * (k - 1) - 1) // s) + 1
+            if same_padding:
+                # ``padding="same"`` keeps the spatial size unchanged.
+                out_dim = in_size
+            else:
+                # PyTorch formula:
+                # out = floor((in + 2p - d*(k-1) - 1) / s + 1)
+                out_dim = ((in_size + 2 * p - d * (k - 1) - 1) // s) + 1
             assert out_dim > 0, "invalid convolution output size"
             out_spatial.append(out_dim)
 


### PR DESCRIPTION
## Problem

Exporting a model whose `Conv{1,2,3}d` uses string padding (`padding="valid"` or `padding="same"`) crashes during IR shape inference:

```
TypeError: unsupported operand type(s) for +: 'int' and 'str'
  .../torch_graph/ir_op.py in _infer_shape_convolution_output
    out_dim = ((in_size + 2 * p - d * (k - 1) - 1) // s) + 1
```

Reported downstream (sve-nnet WaveNet export) as a regression after upgrading torch-to-nnef from `0.20.3` to `0.24.1`. `0.20.3` inferred conv shapes by real tracing, so it was unaffected. The manual `_infer_shape_convolution_output` helper introduced in `0.24.x` assumed numeric padding.

## Root cause

String padding reaches the helper verbatim and `_normalize("valid", 1)` returns `list("valid")`, i.e. `['v','a','l','i','d']`. The formula then evaluates `2 * 'v'`, giving `'vv'`, and `in_size + 'vv'` throws. This only surfaces on the approx shape-inference path (`_infer_missing_shapes_from_ops_outputs`), which runs when a conv sits in a nested submodule whose output shapes are not yet known (as in the reported WaveNet).

## Fix

Resolve string padding before numeric normalization:

- `"valid"`: 0 padding
- `"same"`: output spatial size equals input size (stride-1, per PyTorch semantics)

The op-emit path (`_convolution_mode` in `op/aten/matmul.py`) already handled both modes. This only aligns the shape-inference path.

## Scope check

Conv `padding` is the only int-array parameter in the aten surface that also accepts a string sentinel, and convolution is the only op with a manual approx shape-inference helper that touches int-array args. All other ops infer shapes via real tracing (`approx=False`), which is immune to string sentinels. No other ops are affected.

## Tests

Adds 4 cases to `tests/test_infer_shape.py` (conv1d/conv2d, valid/same) comparing the approx formula against a real trace. They fail without the fix and pass with it (full file green, 11/11).

`test_infer_shape.py` is the correct home rather than the conv proptest spec: the bug lives in the IR shape-inference internals, and a plain top-level conv export never triggers the approx path, so an end-to-end proptest would stay green with or without the fix.

Also verified end-to-end: the original WaveNet (`padding="valid"`) export succeeds, and a `Conv1d(padding="same")` export passes `check_io=True` (tract output matches PyTorch).

## Note

No version bump included: left to the maintainer `bump2version`/tag release flow. A patch release (e.g. `0.24.3`) is needed for downstream consumers to pick this up.