### PR TITLE
fix(writer): stream plain offloaded variables

### DIFF
--- a/examples/dynamic_axes/uv.lock
+++ b/examples/dynamic_axes/uv.lock
@@ -1071,7 +1071,7 @@ wheels = [
 
 [[package]]
 name = "torch-to-nnef"
-version = "0.24.2"
+version = "0.24.3"
 source = { editable = "../../" }
 dependencies = [
     { name = "mako" },

--- a/examples/getting_started_py/uv.lock
+++ b/examples/getting_started_py/uv.lock
@@ -645,7 +645,7 @@ wheels = [
 
 [[package]]
 name = "torch-to-nnef"
-version = "0.24.2"
+version = "0.24.3"
 source = { editable = "../../" }
 dependencies = [
     { name = "mako" },

--- a/examples/multi_io_py/uv.lock
+++ b/examples/multi_io_py/uv.lock
@@ -1046,7 +1046,7 @@ wheels = [
 
 [[package]]
 name = "torch-to-nnef"
-version = "0.24.2"
+version = "0.24.3"
 source = { editable = "../../" }
 dependencies = [
     { name = "mako" },

--- a/examples/quantization_py/uv.lock
+++ b/examples/quantization_py/uv.lock
@@ -644,7 +644,7 @@ wheels = [
 
 [[package]]
 name = "torch-to-nnef"
-version = "0.24.2"
+version = "0.24.3"
 source = { editable = "../../" }
 dependencies = [
     { name = "mako" },

--- a/examples/t2n_extra_custom_op/uv.lock
+++ b/examples/t2n_extra_custom_op/uv.lock
@@ -644,7 +644,7 @@ wheels = [
 
 [[package]]
 name = "torch-to-nnef"
-version = "0.24.2"
+version = "0.24.3"
 source = { editable = "../../" }
 dependencies = [
     { name = "mako" },

--- a/examples/vad/silero-jit/uv.lock
+++ b/examples/vad/silero-jit/uv.lock
@@ -666,7 +666,7 @@ wheels = [
 
 [[package]]
 name = "torch-to-nnef"
-version = "0.24.2"
+version = "0.24.3"
 source = { editable = "../../../" }
 dependencies = [
     { name = "mako" },

--- a/tests/test_offload.py
+++ b/tests/test_offload.py
@@ -13,7 +13,7 @@ from tests.utils import (
     skipif_unsupported_qtensor,
 )
 from torch_to_nnef.inference_target.tract import TractCheckTolerance
-from torch_to_nnef.nnef_io.writer import Writer
+from torch_to_nnef.nnef_io.writer import Writer, write_nnef_tensor
 from torch_to_nnef.tensor.offload import OffloadedTensor
 from torch_to_nnef.tensor.opaque import (
     OFFLOAD_STATE_KEY,
@@ -218,6 +218,50 @@ def test_writer_uses_compact_offloaded_qtensor_path(monkeypatch):
         assert (out_dir / "weight.dat").read_bytes() == (
             ref_dir / "weight.dat"
         ).read_bytes()
+
+
+@skipif_limited_offload_support
+def test_writer_uses_plain_offloaded_tensor_path(monkeypatch, tmp_path):
+    original_weight = torch.randn(4, 32, dtype=torch.float16)
+    offloaded_value = OffloadedTensor.from_original_tensor(
+        original_weight, "my_offloaded_weight", offload_dir=tmp_path
+    )
+
+    ref_dir = tmp_path / "ref"
+    out_dir = tmp_path / "out"
+    ref_dir.mkdir()
+    out_dir.mkdir()
+    write_nnef_tensor(
+        original_weight.detach().numpy(),
+        ref_dir / "weight.dat",
+        quantized=False,
+    )
+
+    def fail_if_reloaded(*args, **kwargs):
+        raise AssertionError("writer should stream plain offloaded tensor")
+
+    monkeypatch.setattr(OffloadedTensor, "reload", fail_if_reloaded)
+
+    graph = SimpleNamespace(
+        operations=[
+            SimpleNamespace(
+                type="variable",
+                attribs={"label": "weight"},
+                output=SimpleNamespace(
+                    data=offloaded_value,
+                    quant=None,
+                ),
+            )
+        ]
+    )
+
+    Writer(inference_target=INFERENCE_TARGET)._write_tensors_from_operators(
+        graph, out_dir
+    )
+
+    assert (out_dir / "weight.dat").read_bytes() == (
+        ref_dir / "weight.dat"
+    ).read_bytes()
 
 
 class _ToyOpaque(OpaqueTensor, SupportsOffloadState):

--- a/torch_to_nnef/nnef_io/writer.py
+++ b/torch_to_nnef/nnef_io/writer.py
@@ -19,6 +19,7 @@ Also some minimal adaptation like code style have been done be pythonic.
 """
 
 import contextlib
+import gc
 import logging
 import os
 import shutil
@@ -38,6 +39,8 @@ from torch_to_nnef.inference_target.base import InferenceTarget
 from torch_to_nnef.inference_target.khronos import KhronosNNEF
 from torch_to_nnef.inference_target.tract import TractNNEF
 from torch_to_nnef.tensor.offload import OffloadedTensor
+from torch_to_nnef.tensor.opaque import OpaqueTensor
+from torch_to_nnef.utils import torch_safe_load
 
 LOGGER = logging.getLogger(__name__)
 
@@ -215,6 +218,29 @@ def write_nnef_tensor(array, filename, quantized):
         nnef.write_tensor(file=file, tensor=array, quantized=quantized)
 
 
+def write_offloaded_tensor(tensor, filename, quantized):
+    if issubclass(tensor.offloaded_tensor_type, OpaqueTensor):
+        raise T2NError(
+            "cannot write opaque offloaded tensor as a plain NNEF variable; "
+            "it must be handled by a custom writer"
+        )
+    loaded = torch_safe_load(tensor.offload_path, map_location="cpu")
+    if not isinstance(loaded, torch.Tensor):
+        raise T2NError(
+            "offloaded NNEF variable payload must reload as a torch.Tensor, "
+            f"got {type(loaded)}"
+        )
+    try:
+        write_nnef_tensor(
+            np.asarray(maybe_torch_to_np(loaded), order="C"),
+            filename,
+            quantized=quantized,
+        )
+    finally:
+        del loaded
+        gc.collect()
+
+
 def write_tensor_quantization_infos(tensor, file):
     assert tensor.quant is not None
     op_name = tensor.quant["op-name"]
@@ -376,19 +402,29 @@ class Writer:
                     LOGGER.info("written qtensor: '%s'", label)
                 else:
                     filename = op.attribs["label"] + ".dat"
+                    output_data = op.output.data
+                    if isinstance(output_data, OffloadedTensor):
+                        write_offloaded_tensor(
+                            output_data,
+                            os.path.join(folder, filename),
+                            quantized=bool(op.output.quant),
+                        )
+                        LOGGER.info(
+                            "written offloaded tensor: '%s'",
+                            op.attribs["label"],
+                        )
+                        continue
                     if (
-                        isinstance(op.output.data, torch.Tensor)
-                        and op.output.data.device.type == "meta"
+                        isinstance(output_data, torch.Tensor)
+                        and output_data.device.type == "meta"
                     ):
                         raise T2NError(
                             "cannot write meta tensor as NNEF variable "
                             f"'{op.attribs['label']}' with shape "
-                            f"{tuple(op.output.data.shape)}"
+                            f"{tuple(output_data.shape)}"
                         )
                     write_nnef_tensor(
-                        np.asarray(
-                            maybe_torch_to_np(op.output.data), order="C"
-                        ),
+                        np.asarray(maybe_torch_to_np(output_data), order="C"),
                         os.path.join(folder, filename),
                         quantized=bool(op.output.quant),
                     )


### PR DESCRIPTION
## Summary
- stream plain dense OffloadedTensor variable payloads from disk during NNEF writing
- keep opaque/quantized offloaded tensors on their existing custom writer path
- add a regression test that fails if plain offloaded variables go through OffloadedTensor.reload()

## Tests
- uv run ruff check torch_to_nnef/nnef_io/writer.py tests/test_offload.py
- uv run --group test pytest tests/test_offload.py -q