### PR TITLE
fix(examples): make albert export trace-compatible with transformers 5.5

### DIFF
--- a/examples/dynamic_axes/export_albert_fixed.py
+++ b/examples/dynamic_axes/export_albert_fixed.py
@@ -1,10 +1,46 @@
 from pathlib import Path
 
+import torch
 import transformers
 from transformers import AlbertModel, AlbertTokenizer
 
 from torch_to_nnef import TractNNEF, export_model_to_nnef
 from torch_to_nnef.utils import SemanticVersion
+
+
+def apply_transformers_trace_compat():
+    """Make the transformers>=5.5 mask path survive torch.jit.trace.
+
+    Under trace, ``inputs_embeds.shape[1]`` becomes a 0-dim tensor, which
+    ``sdpa_mask`` mistakes for a deprecated ``cache_position`` arg and crashes
+    on ``q_length.shape[0]``. Re-express that scalar as the 1-D position tensor
+    the back-compat branch expects, so the query length stays symbolic (needed
+    for dynamic axes) instead of being baked to a constant.
+    """
+    if SemanticVersion.from_str(transformers.__version__) < "5.5.0":
+        return
+    import transformers.masking_utils as mu
+
+    orig_sdpa_mask = mu.sdpa_mask
+
+    def fix(q_length):
+        if isinstance(q_length, torch.Tensor) and q_length.dim() == 0:
+            return torch.arange(q_length, device=q_length.device)
+        return q_length
+
+    def traceable_sdpa_mask(*args, **kwargs):
+        if len(args) > 1:
+            args = list(args)
+            args[1] = fix(args[1])
+        if "q_length" in kwargs:
+            kwargs["q_length"] = fix(kwargs["q_length"])
+        return orig_sdpa_mask(*args, **kwargs)
+
+    mu.sdpa_mask = traceable_sdpa_mask
+    mu.eager_mask.__globals__["sdpa_mask"] = traceable_sdpa_mask
+
+
+apply_transformers_trace_compat()
 
 tokenizer = AlbertTokenizer.from_pretrained("albert-base-v2")
 # transformers 5.x no longer returns token_type_ids by default; request it

--- a/examples/dynamic_axes/export_albert_fixed.py
+++ b/examples/dynamic_axes/export_albert_fixed.py
@@ -16,8 +16,12 @@ def apply_transformers_trace_compat():
     on ``q_length.shape[0]``. Re-express that scalar as the 1-D position tensor
     the back-compat branch expects, so the query length stays symbolic (needed
     for dynamic axes) instead of being baked to a constant.
+
+    Scoped to 5.5.x: that back-compat branch is documented for removal in 5.6,
+    where rewriting the scalar into a 1-D tensor would instead break the trace.
     """
-    if SemanticVersion.from_str(transformers.__version__) < "5.5.0":
+    version = SemanticVersion.from_str(transformers.__version__)
+    if not "5.5.0" <= version < "5.6.0":
         return
     import transformers.masking_utils as mu
 
@@ -36,8 +40,9 @@ def apply_transformers_trace_compat():
             kwargs["q_length"] = fix(kwargs["q_length"])
         return orig_sdpa_mask(*args, **kwargs)
 
+    # eager_mask resolves sdpa_mask through the module globals, i.e. this same
+    # attribute, so one assignment covers both entry points.
     mu.sdpa_mask = traceable_sdpa_mask
-    mu.eager_mask.__globals__["sdpa_mask"] = traceable_sdpa_mask
 
 
 apply_transformers_trace_compat()

--- a/examples/multi_io_py/export_albert.py
+++ b/examples/multi_io_py/export_albert.py
@@ -15,8 +15,12 @@ def apply_transformers_trace_compat():
     ``sdpa_mask`` mistakes for a deprecated ``cache_position`` arg and crashes
     on ``q_length.shape[0]``. Re-express that scalar as the 1-D position tensor
     the back-compat branch expects so the mask builds under trace.
+
+    Scoped to 5.5.x: that back-compat branch is documented for removal in 5.6,
+    where rewriting the scalar into a 1-D tensor would instead break the trace.
     """
-    if SemanticVersion.from_str(transformers.__version__) < "5.5.0":
+    version = SemanticVersion.from_str(transformers.__version__)
+    if not "5.5.0" <= version < "5.6.0":
         return
     import transformers.masking_utils as mu
 
@@ -35,8 +39,9 @@ def apply_transformers_trace_compat():
             kwargs["q_length"] = fix(kwargs["q_length"])
         return orig_sdpa_mask(*args, **kwargs)
 
+    # eager_mask resolves sdpa_mask through the module globals, i.e. this same
+    # attribute, so one assignment covers both entry points.
     mu.sdpa_mask = traceable_sdpa_mask
-    mu.eager_mask.__globals__["sdpa_mask"] = traceable_sdpa_mask
 
 
 apply_transformers_trace_compat()

--- a/examples/multi_io_py/export_albert.py
+++ b/examples/multi_io_py/export_albert.py
@@ -1,12 +1,59 @@
 from pathlib import Path
 
+import torch
+import transformers
 from transformers import AlbertModel, AlbertTokenizer
 
 from torch_to_nnef import TractNNEF, export_model_to_nnef
+from torch_to_nnef.utils import SemanticVersion
+
+
+def apply_transformers_trace_compat():
+    """Make the transformers>=5.5 mask path survive torch.jit.trace.
+
+    Under trace, ``inputs_embeds.shape[1]`` becomes a 0-dim tensor, which
+    ``sdpa_mask`` mistakes for a deprecated ``cache_position`` arg and crashes
+    on ``q_length.shape[0]``. Re-express that scalar as the 1-D position tensor
+    the back-compat branch expects so the mask builds under trace.
+    """
+    if SemanticVersion.from_str(transformers.__version__) < "5.5.0":
+        return
+    import transformers.masking_utils as mu
+
+    orig_sdpa_mask = mu.sdpa_mask
+
+    def fix(q_length):
+        if isinstance(q_length, torch.Tensor) and q_length.dim() == 0:
+            return torch.arange(q_length, device=q_length.device)
+        return q_length
+
+    def traceable_sdpa_mask(*args, **kwargs):
+        if len(args) > 1:
+            args = list(args)
+            args[1] = fix(args[1])
+        if "q_length" in kwargs:
+            kwargs["q_length"] = fix(kwargs["q_length"])
+        return orig_sdpa_mask(*args, **kwargs)
+
+    mu.sdpa_mask = traceable_sdpa_mask
+    mu.eager_mask.__globals__["sdpa_mask"] = traceable_sdpa_mask
+
+
+apply_transformers_trace_compat()
 
 tokenizer = AlbertTokenizer.from_pretrained("albert-base-v2")
-inputs = tokenizer("Hello, I am happy", return_tensors="pt")
-albert_model = AlbertModel.from_pretrained("albert-base-v2")
+# transformers 5.x no longer returns token_type_ids by default; request it
+# explicitly so the export below keeps its three-input signature on 4.x and 5.x.
+inputs = tokenizer(
+    "Hello, I am happy", return_tensors="pt", return_token_type_ids=True
+)
+# transformers 5.x defaults to a fused SDPA attention path that feeds a
+# non-float attn_mask into scaled_dot_product_attention, which fails during the
+# export forward. Eager attention decomposes into core ops that export cleanly.
+model_kwargs = {}
+if SemanticVersion.from_str(transformers.__version__) >= "5.0.0":
+    model_kwargs["attn_implementation"] = "eager"
+albert_model = AlbertModel.from_pretrained("albert-base-v2", **model_kwargs)
 
 file_path_export = Path("albert_v2.nnef.tgz")
 input_names = ["input_ids", "attention_mask", "token_type_ids"]


### PR DESCRIPTION
## Why

The two open Dependabot PRs (#253, #254) that bump `transformers` to 5.5.0 fail their tier1 example exports:

- **#253 `multi_io_py`** (4.53.2 -> 5.5.0): `KeyError: 'token_type_ids'` (5.x tokenizers no longer return `token_type_ids` by default).
- **#254 `dynamic_axes`** (5.3.0 -> 5.5.0): `IndexError: tuple index out of range` inside `transformers.masking_utils.sdpa_mask`.

The `sdpa_mask` crash is a new 5.5.0 trace incompatibility: under `torch.jit.trace`, `inputs_embeds.shape[1]` reaches `sdpa_mask` as a 0-dim tensor, which the new masking path mistakes for a deprecated `cache_position` arg and dereferences with `q_length.shape[0]`.

## Fix

- `multi_io_py`: request `token_type_ids` explicitly and force eager attention on 5.x, matching what `dynamic_axes` already did in #229.
- Both examples: add a version-gated (`>= 5.5.0`) trace-compat shim that re-expresses the 0-dim `q_length` scalar as the 1-D position tensor the back-compat branch expects. It uses `torch.arange(q_length)` on the tensor (not `int(...)`) so the query length stays symbolic; baking it to a constant breaks the dynamic `S` axis.

All version-specific logic is gated, so the changes are no-ops on the current pins.

## Validation

Ran both edited scripts end-to-end (export + `check_io`) against t2n + tract:

| Example | transformers | Result |
|---------|-------------|--------|
| `multi_io_py` | 4.53.2 (current pin) | IO bit match |
| `multi_io_py` | 5.5.0 | IO bit match |
| `dynamic_axes` | 5.3.0 (current pin) | IO bit match |
| `dynamic_axes` | 5.5.0 | IO bit match |

Once merged, Dependabot will rebase #253/#254 onto `main` and their bumped CI should pass.