### PR TITLE
Add Qwen3.5 MoE hybrid cache handler

### DIFF
--- a/packages/llm/tests/test_causal_mask.py
+++ b/packages/llm/tests/test_causal_mask.py
@@ -35,7 +35,7 @@ def _build_mask(seq_len, past_len, n_layers=2, heads=2, head_dim=8):
     out = DefaultArchitectureHandler().build_forward_inputs(
         inputs=inputs, wrapper=wrapper
     )
-    return out["attention_mask"]
+    return out.model_inputs["attention_mask"]
 
 
 def _assert_causal(mask, seq_len, past_len):

--- a/packages/llm/tests/test_qwen35_moe_handler.py
+++ b/packages/llm/tests/test_qwen35_moe_handler.py
@@ -1,0 +1,120 @@
+from types import SimpleNamespace
+
+import torch
+
+from torch_to_nnef_llm.models.handlers import Qwen35MoeArchitectureHandler
+from torch_to_nnef_llm.models.handlers.registry import get_handler
+
+
+class FakeTokenizer:
+    def __call__(self, text, return_tensors=None):
+        del text, return_tensors
+        return SimpleNamespace(
+            input_ids=torch.arange(16, dtype=torch.long).reshape(1, 16)
+        )
+
+
+class FakeQwen35Config(SimpleNamespace):
+    def get_text_config(self, decoder=False):
+        del decoder
+        return self
+
+
+class FakeConfigHelper:
+    def __init__(self):
+        self.decoder_conf = FakeQwen35Config(
+            layer_types=["full_attention", "linear_attention"],
+            num_hidden_layers=2,
+            num_key_value_heads=2,
+            hidden_size=64,
+            num_attention_heads=4,
+            head_dim=16,
+            linear_key_head_dim=16,
+            linear_value_head_dim=16,
+            linear_num_key_heads=4,
+            linear_num_value_heads=4,
+            linear_conv_kernel_dim=4,
+            max_position_embeddings=128,
+        )
+
+    def get_num_kv_heads(self, layer_idx):
+        del layer_idx
+        return self.decoder_conf.num_key_value_heads
+
+    def get_head_dim(self):
+        return self.decoder_conf.head_dim
+
+
+def test_qwen35_moe_handler_is_registered():
+    assert get_handler("qwen3_5_moe_text") is Qwen35MoeArchitectureHandler
+
+
+def test_qwen35_moe_input_spec_names_hybrid_cache_tensors():
+    handler = Qwen35MoeArchitectureHandler()
+    spec = handler.build_input_spec(
+        tokenizer=FakeTokenizer(),
+        config_helper=FakeConfigHelper(),
+        inputs_dtype=torch.float32,
+        sample_text="hello",
+        n_input_tokens=3,
+        n_past_input_tokens=5,
+    )
+
+    assert spec.input_names == [
+        "input_ids",
+        "in_cache_key_0",
+        "in_cache_value_0",
+        "in_cache_conv_1",
+        "in_cache_recurrent_1",
+    ]
+    assert spec.output_names == [
+        "outputs",
+        "out_cache_key_0",
+        "out_cache_value_0",
+        "out_cache_conv_1",
+        "out_cache_recurrent_1",
+    ]
+    assert tuple(spec.inputs[1].shape) == (1, 2, 5, 16)
+    assert tuple(spec.inputs[3].shape) == (1, 192, 4)
+    assert tuple(spec.inputs[4].shape) == (1, 4, 16, 16)
+    assert spec.dynamic_axes["in_cache_key_0"] == {2: "P"}
+    assert "in_cache_conv_1" not in spec.dynamic_axes
+
+
+def test_qwen35_moe_forward_inputs_rebuild_transformers_hybrid_cache():
+    handler = Qwen35MoeArchitectureHandler()
+    config_helper = FakeConfigHelper()
+    spec = handler.build_input_spec(
+        tokenizer=FakeTokenizer(),
+        config_helper=config_helper,
+        inputs_dtype=torch.float32,
+        sample_text="hello",
+        n_input_tokens=3,
+        n_past_input_tokens=5,
+    )
+    wrapper = SimpleNamespace(
+        model=SimpleNamespace(config=config_helper.decoder_conf),
+        force_causal_mask=True,
+    )
+
+    state_context = handler.build_forward_inputs(
+        inputs=spec.inputs,
+        wrapper=wrapper,
+    )
+    cache = state_context.model_inputs["past_key_values"]
+
+    assert [type(layer).__name__ for layer in cache.layers] == [
+        "DynamicLayer",
+        "LinearAttentionLayer",
+    ]
+    assert tuple(cache.layers[0].keys.shape) == (1, 2, 5, 16)
+    assert tuple(cache.layers[0].values.shape) == (1, 2, 5, 16)
+    assert tuple(cache.layers[1].conv_states.shape) == (1, 192, 4)
+    assert tuple(cache.layers[1].recurrent_states.shape) == (1, 4, 16, 16)
+    assert cache.has_previous_state(1)
+    assert tuple(state_context.model_inputs["attention_mask"].shape) == (
+        1,
+        1,
+        3,
+        8,
+    )

--- a/packages/llm/torch_to_nnef_llm/models/handlers/__init__.py
+++ b/packages/llm/torch_to_nnef_llm/models/handlers/__init__.py
@@ -3,6 +3,7 @@ from .default import DefaultArchitectureHandler
 from .openelm import OpenELMArchitectureHandler
 from .phi import PhiArchitectureHandler
 from .qwen3_vl import Qwen3VLArchitectureHandler
+from .qwen35_moe import Qwen35MoeArchitectureHandler
 from .registry import get_handler, register_handler
 
 __all__ = [
@@ -10,6 +11,7 @@ __all__ = [
     "DefaultArchitectureHandler",
     "OpenELMArchitectureHandler",
     "PhiArchitectureHandler",
+    "Qwen35MoeArchitectureHandler",
     "Qwen3VLArchitectureHandler",
     "get_handler",
     "register_handler",

--- a/packages/llm/torch_to_nnef_llm/models/handlers/base.py
+++ b/packages/llm/torch_to_nnef_llm/models/handlers/base.py
@@ -34,6 +34,48 @@ class ArchitectureHandler(ABC):
         """Return the HF model class to load for this architecture."""
         return transformers.AutoModelForCausalLM
 
+    @staticmethod
+    def build_causal_mask_with_past(
+        *,
+        seq_length: int,
+        past_length: int,
+        device: torch.device,
+    ) -> T.Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Build the additive causal-with-past mask plus RoPE positions.
+
+        Returns ``(attention_mask, position_ids, cache_position)`` for
+        ``seq_length`` new query tokens attending over ``past_length`` cached
+        keys. Shared by every handler that fakes a decode step so the subtle
+        position math lives in exactly one place.
+        """
+        attn_mask_dtype = torch.float32
+        neg = torch.finfo(attn_mask_dtype).min
+        # Query length S (new tokens) and past length P; the causal window is
+        # over S+P keys.
+        total_length = seq_length + past_length
+        # Absolute positions of the new tokens: P, P+1, ..., P+S-1. These
+        # drive RoPE; without them transformers (>4.52.4) infers positions
+        # that ignore the past, so decode RoPE is wrong and generation
+        # degenerates into repetition.
+        cache_position = torch.arange(past_length, total_length, device=device)
+        position_ids = cache_position.unsqueeze(0)
+        # Build the [S, S+P] causal-with-past additive mask from token
+        # POSITIONS (not a fixed-diagonal triu): query i sits at absolute
+        # position P+i and may attend to keys 0..P+i. Doing it via arange
+        # comparisons keeps it correct for any (S, P) at inference time;
+        # a baked triu diagonal (or a shape[0]=batch bug) made the mask
+        # degenerate and attention non-causal.
+        q_pos = cache_position.unsqueeze(1)
+        k_pos = torch.arange(total_length).unsqueeze(0)
+        future = (k_pos > q_pos).to(attn_mask_dtype)  # 1.0 where masked
+        attention_mask = (
+            (torch.full([seq_length, total_length], neg) * future)
+            .unsqueeze(0)
+            .unsqueeze(0)
+            .to(attn_mask_dtype)
+        )
+        return attention_mask, position_ids, cache_position
+
     def prepare_model_for_export(self, model) -> None:
         """Apply architecture-specific model tweaks before wrapping."""
         return None

--- a/packages/llm/torch_to_nnef_llm/models/handlers/default.py
+++ b/packages/llm/torch_to_nnef_llm/models/handlers/default.py
@@ -62,35 +62,14 @@ class DefaultArchitectureHandler(ArchitectureHandler):
         position_ids = None
         cache_position = None
         if getattr(wrapper, "force_causal_mask", False):
-            attn_mask_dtype = torch.float32
-            neg = torch.finfo(attn_mask_dtype).min
             # Query length S (new tokens) from input_ids, past length P from
             # the first KV cache tensor [batch, heads, P, head_dim].
-            seq_length = inputs[0].shape[1]
-            past_length = inputs[1].shape[2]
-            total_length = seq_length + past_length
-            # Absolute positions of the new tokens: P, P+1, ..., P+S-1. These
-            # drive RoPE; without them transformers (>4.52.4) infers positions
-            # that ignore the past, so decode RoPE is wrong and generation
-            # degenerates into repetition.
-            cache_position = torch.arange(
-                past_length, total_length, device=inputs[0].device
-            )
-            position_ids = cache_position.unsqueeze(0)
-            # Build the [S, S+P] causal-with-past additive mask from token
-            # POSITIONS (not a fixed-diagonal triu): query i sits at absolute
-            # position P+i and may attend to keys 0..P+i. Doing it via arange
-            # comparisons keeps it correct for any (S, P) at inference time;
-            # a baked triu diagonal (or the previous shape[0]=batch bug) made
-            # the mask degenerate and attention non-causal.
-            q_pos = cache_position.unsqueeze(1)
-            k_pos = torch.arange(total_length).unsqueeze(0)
-            future = (k_pos > q_pos).to(attn_mask_dtype)  # 1.0 where masked
-            attention_mask = (
-                (torch.full([seq_length, total_length], neg) * future)
-                .unsqueeze(0)
-                .unsqueeze(0)
-                .to(attn_mask_dtype)
+            attention_mask, position_ids, cache_position = (
+                self.build_causal_mask_with_past(
+                    seq_length=inputs[0].shape[1],
+                    past_length=inputs[1].shape[2],
+                    device=inputs[0].device,
+                )
             )
         if wrapper.with_dyn_cache:
             past_key_values = build_past_kv_dyn_cache(inputs[1:])

--- a/packages/llm/torch_to_nnef_llm/models/handlers/qwen35_moe.py
+++ b/packages/llm/torch_to_nnef_llm/models/handlers/qwen35_moe.py
@@ -123,6 +123,7 @@ class Qwen35MoeArchitectureHandler(DefaultArchitectureHandler):
         inputs: T.Tuple[torch.Tensor, ...],
         wrapper,
     ) -> StateContext:
+        # pylint: disable-next=import-outside-toplevel
         from transformers.cache_utils import DynamicCache
 
         cache = DynamicCache(config=wrapper.model.config)

--- a/packages/llm/torch_to_nnef_llm/models/handlers/qwen35_moe.py
+++ b/packages/llm/torch_to_nnef_llm/models/handlers/qwen35_moe.py
@@ -1,0 +1,203 @@
+import typing as T
+
+import torch
+
+from .base import IOSpec, StateContext
+from .default import DefaultArchitectureHandler
+from .registry import register_handler
+
+
+@register_handler
+class Qwen35MoeArchitectureHandler(DefaultArchitectureHandler):
+    """Handler for Qwen3.5 MoE text models with hybrid attention caches."""
+
+    ARCH_NAMES = ("qwen3_5_moe_text",)
+
+    @staticmethod
+    def _layer_types(config_helper) -> T.Sequence[str]:
+        return config_helper.decoder_conf.layer_types
+
+    @staticmethod
+    def _linear_conv_shape(decoder_conf) -> T.Tuple[int, int, int]:
+        key_dim = (
+            decoder_conf.linear_key_head_dim * decoder_conf.linear_num_key_heads
+        )
+        value_dim = (
+            decoder_conf.linear_value_head_dim
+            * decoder_conf.linear_num_value_heads
+        )
+        conv_dim = key_dim * 2 + value_dim
+        return (1, conv_dim, decoder_conf.linear_conv_kernel_dim)
+
+    @staticmethod
+    def _linear_recurrent_shape(decoder_conf) -> T.Tuple[int, int, int, int]:
+        return (
+            1,
+            decoder_conf.linear_num_value_heads,
+            decoder_conf.linear_key_head_dim,
+            decoder_conf.linear_value_head_dim,
+        )
+
+    def build_input_spec(
+        self,
+        *,
+        tokenizer,
+        config_helper,
+        inputs_dtype: torch.dtype,
+        sample_text: str,
+        n_input_tokens: int,
+        n_past_input_tokens: int,
+        real_kv_cache: T.Optional[T.List[torch.Tensor]] = None,
+    ) -> IOSpec:
+        if real_kv_cache is not None:
+            raise NotImplementedError(
+                "real cache reuse is not supported for "
+                "Qwen3.5 MoE hybrid caches"
+            )
+
+        test_input = tokenizer(sample_text, return_tensors="pt")
+        assert test_input.input_ids.shape[1] >= n_input_tokens
+
+        decoder_conf = config_helper.decoder_conf
+        inputs = [test_input.input_ids[:, :n_input_tokens]]
+        input_names = ["input_ids"]
+        output_names = ["outputs"]
+        dynamic_axes = {"input_ids": {1: "S"}}
+
+        for layer_idx, layer_type in enumerate(
+            self._layer_types(config_helper)
+        ):
+            if layer_type == "full_attention":
+                key_shape = (
+                    1,
+                    config_helper.get_num_kv_heads(layer_idx),
+                    n_past_input_tokens,
+                    config_helper.get_head_dim(),
+                )
+                value_shape = key_shape
+                key = torch.rand(key_shape).to(inputs_dtype)
+                value = torch.rand(value_shape).to(inputs_dtype)
+                inputs.extend([key, value])
+                for kind in ("key", "value"):
+                    in_name = f"in_cache_{kind}_{layer_idx}"
+                    input_names.append(in_name)
+                    output_names.append(f"out_cache_{kind}_{layer_idx}")
+                    dynamic_axes[in_name] = {2: "P"}
+            elif layer_type == "linear_attention":
+                conv = torch.zeros(
+                    self._linear_conv_shape(decoder_conf),
+                    dtype=inputs_dtype,
+                )
+                recurrent = torch.zeros(
+                    self._linear_recurrent_shape(decoder_conf),
+                    dtype=inputs_dtype,
+                )
+                inputs.extend([conv, recurrent])
+                input_names.extend(
+                    [
+                        f"in_cache_conv_{layer_idx}",
+                        f"in_cache_recurrent_{layer_idx}",
+                    ]
+                )
+                output_names.extend(
+                    [
+                        f"out_cache_conv_{layer_idx}",
+                        f"out_cache_recurrent_{layer_idx}",
+                    ]
+                )
+            else:
+                raise NotImplementedError(
+                    f"unsupported Qwen3.5 MoE layer type: {layer_type!r}"
+                )
+
+        return IOSpec(
+            inputs=tuple(inputs),
+            input_names=input_names,
+            output_names=output_names,
+            dynamic_axes=dynamic_axes,
+        )
+
+    def build_forward_inputs(
+        self,
+        *,
+        inputs: T.Tuple[torch.Tensor, ...],
+        wrapper,
+    ) -> StateContext:
+        from transformers.cache_utils import DynamicCache
+
+        cache = DynamicCache(config=wrapper.model.config)
+        layer_types = wrapper.model.config.layer_types
+
+        cursor = 1
+        first_full_key = None
+        for layer_idx, layer_type in enumerate(layer_types):
+            if layer_type == "full_attention":
+                key, value = inputs[cursor], inputs[cursor + 1]
+                cursor += 2
+                if first_full_key is None:
+                    first_full_key = key
+                cache.update(key, value, layer_idx)
+            elif layer_type == "linear_attention":
+                conv, recurrent = inputs[cursor], inputs[cursor + 1]
+                cursor += 2
+                cache.update_conv_state(conv, layer_idx)
+                cache.update_recurrent_state(recurrent, layer_idx)
+            else:
+                raise NotImplementedError(
+                    f"unsupported Qwen3.5 MoE layer type: {layer_type!r}"
+                )
+
+        attention_mask = None
+        position_ids = None
+        cache_position = None
+        if (
+            getattr(wrapper, "force_causal_mask", False)
+            and first_full_key is not None
+        ):
+            attn_mask_dtype = torch.float32
+            neg = torch.finfo(attn_mask_dtype).min
+            seq_length = inputs[0].shape[1]
+            past_length = first_full_key.shape[2]
+            total_length = seq_length + past_length
+            cache_position = torch.arange(
+                past_length, total_length, device=inputs[0].device
+            )
+            position_ids = cache_position.unsqueeze(0)
+            q_pos = cache_position.unsqueeze(1)
+            k_pos = torch.arange(total_length).unsqueeze(0)
+            future = (k_pos > q_pos).to(attn_mask_dtype)
+            attention_mask = (
+                (torch.full([seq_length, total_length], neg) * future)
+                .unsqueeze(0)
+                .unsqueeze(0)
+                .to(attn_mask_dtype)
+            )
+
+        model_inputs = {
+            "input_ids": inputs[0],
+            "past_key_values": cache,
+            "use_cache": True,
+            "attention_mask": attention_mask,
+        }
+        if position_ids is not None:
+            model_inputs["position_ids"] = position_ids
+            model_inputs["cache_position"] = cache_position
+        return StateContext(model_inputs=model_inputs, state={})
+
+    def build_forward_outputs(
+        self,
+        *,
+        model,
+        model_outputs: T.Any,
+        state_context: StateContext,
+        num_logits_to_keep: int,
+    ) -> T.List[torch.Tensor]:
+        del model, num_logits_to_keep
+        cache = state_context.model_inputs["past_key_values"]
+        outputs = [model_outputs["logits"]]
+        for layer in cache.layers:
+            if hasattr(layer, "keys"):
+                outputs.extend([layer.keys, layer.values])
+            else:
+                outputs.extend([layer.conv_states, layer.recurrent_states])
+        return outputs

--- a/packages/llm/torch_to_nnef_llm/models/handlers/qwen35_moe.py
+++ b/packages/llm/torch_to_nnef_llm/models/handlers/qwen35_moe.py
@@ -155,23 +155,15 @@ class Qwen35MoeArchitectureHandler(DefaultArchitectureHandler):
             getattr(wrapper, "force_causal_mask", False)
             and first_full_key is not None
         ):
-            attn_mask_dtype = torch.float32
-            neg = torch.finfo(attn_mask_dtype).min
-            seq_length = inputs[0].shape[1]
-            past_length = first_full_key.shape[2]
-            total_length = seq_length + past_length
-            cache_position = torch.arange(
-                past_length, total_length, device=inputs[0].device
-            )
-            position_ids = cache_position.unsqueeze(0)
-            q_pos = cache_position.unsqueeze(1)
-            k_pos = torch.arange(total_length).unsqueeze(0)
-            future = (k_pos > q_pos).to(attn_mask_dtype)
-            attention_mask = (
-                (torch.full([seq_length, total_length], neg) * future)
-                .unsqueeze(0)
-                .unsqueeze(0)
-                .to(attn_mask_dtype)
+            # Past length P comes from the first full-attention KV tensor
+            # [batch, heads, P, head_dim]; linear-attention state carries no
+            # comparable time axis.
+            attention_mask, position_ids, cache_position = (
+                self.build_causal_mask_with_past(
+                    seq_length=inputs[0].shape[1],
+                    past_length=first_full_key.shape[2],
+                    device=inputs[0].device,
+                )
             )
 
         model_inputs = {


### PR DESCRIPTION
## Summary
- add a Qwen3.5 MoE text architecture handler for hybrid full-attention + linear-attention caches
- expose linear-attention conv/recurrent state tensors in the exported graph signature instead of treating every layer as KV
- add focused handler tests for cache naming, shapes, registry wiring, and DynamicCache reconstruction

## Validation
- uv run ruff check packages/llm/torch_to_nnef_llm/models/handlers/qwen35_moe.py packages/llm/torch_to_nnef_llm/models/handlers/__init__.py packages/llm/tests/test_qwen35_moe_handler.py
- uv run ruff format --check packages/llm/torch_to_nnef_llm/models/handlers/qwen35_moe.py packages/llm/torch_to_nnef_llm/models/handlers/__init__.py packages/llm/tests/test_qwen35_moe_handler.py
- uv run --extra llm --group test pytest packages/llm/tests/test_qwen35_moe_handler.py