### PR TITLE
Add Transformers experts implementation option

### DIFF
--- a/packages/llm/tests/test_sdpa_attention_export.py
+++ b/packages/llm/tests/test_sdpa_attention_export.py
@@ -36,12 +36,21 @@ class _FakeTransformers:
     )
 
 
+class _FakeTransformersWithoutMoe:
+    """Stand-in for a supported Transformers predating the experts registry."""
+
+    __version__ = "4.52.0"
+    AutoModelForCausalLM = _FakeAutoModel
+    integrations = SimpleNamespace()
+
+
 def _load_fake_model(
     monkeypatch,
     *,
     attn_implementation=None,
     experts_implementation="auto",
     has_moe_experts=True,
+    transformers=_FakeTransformers,
 ):
     _FakeAutoModel.calls = []
     model_config = SimpleNamespace(model_type="phi")
@@ -62,7 +71,7 @@ def _load_fake_model(
         trust_remote_code=False,
         attn_implementation=attn_implementation,
         experts_implementation=experts_implementation,
-        transformers=_FakeTransformers,
+        transformers=transformers,
     )
 
 
@@ -118,6 +127,27 @@ def test_load_model_rejects_unknown_experts_implementation(monkeypatch):
     with pytest.raises(T2NErrorMisuse, match="experts_implementation"):
         _load_fake_model(
             monkeypatch, experts_implementation="definitely-not-real"
+        )
+
+
+def test_load_model_auto_is_noop_without_experts_registry(monkeypatch):
+    # Supported Transformers predating the experts registry must still load;
+    # the default `auto` degrades to a no-op instead of failing the export.
+    model = _load_fake_model(
+        monkeypatch,
+        experts_implementation="auto",
+        transformers=_FakeTransformersWithoutMoe,
+    )
+
+    assert model.config._experts_implementation == "grouped_mm"
+
+
+def test_load_model_rejects_explicit_experts_without_registry(monkeypatch):
+    with pytest.raises(T2NErrorMisuse, match="ALL_EXPERTS_FUNCTIONS"):
+        _load_fake_model(
+            monkeypatch,
+            experts_implementation="batched_mm",
+            transformers=_FakeTransformersWithoutMoe,
         )
 
 

--- a/packages/llm/tests/test_sdpa_attention_export.py
+++ b/packages/llm/tests/test_sdpa_attention_export.py
@@ -8,7 +8,8 @@ from torch_to_nnef_llm import cli, exporter, loader
 
 
 class _FakeModel:
-    config = SimpleNamespace(model_type="fake")
+    def __init__(self, config=None):
+        self.config = config or SimpleNamespace(model_type="fake")
 
     def to(self, _dtype):
         return self
@@ -18,22 +19,38 @@ class _FakeAutoModel:
     calls = []
 
     @classmethod
-    def from_config(cls, _config, **kwargs):
+    def from_config(cls, config, **kwargs):
         cls.calls.append(kwargs)
-        return _FakeModel()
+        return _FakeModel(config)
 
 
 class _FakeTransformers:
     __version__ = "5.12.1"
     AutoModelForCausalLM = _FakeAutoModel
+    integrations = SimpleNamespace(
+        moe=SimpleNamespace(
+            ALL_EXPERTS_FUNCTIONS=SimpleNamespace(
+                valid_keys=lambda: ["batched_mm", "grouped_mm"]
+            )
+        )
+    )
 
 
-def _load_fake_model(monkeypatch, *, attn_implementation=None):
+def _load_fake_model(
+    monkeypatch,
+    *,
+    attn_implementation=None,
+    experts_implementation="auto",
+    has_moe_experts=True,
+):
     _FakeAutoModel.calls = []
+    model_config = SimpleNamespace(model_type="phi")
+    if has_moe_experts:
+        model_config._experts_implementation = "grouped_mm"
     monkeypatch.setitem(
         loader.CUSTOM_CONFIGS,
         "fake/model",
-        SimpleNamespace(model_type="phi"),
+        model_config,
     )
     monkeypatch.setattr(
         loader,
@@ -44,6 +61,7 @@ def _load_fake_model(monkeypatch, *, attn_implementation=None):
         "fake/model",
         trust_remote_code=False,
         attn_implementation=attn_implementation,
+        experts_implementation=experts_implementation,
         transformers=_FakeTransformers,
     )
 
@@ -66,6 +84,41 @@ def test_load_model_treats_auto_attention_as_default(monkeypatch):
 def test_load_model_rejects_unknown_attention_implementation(monkeypatch):
     with pytest.raises(T2NErrorMisuse, match="attn_implementation"):
         _load_fake_model(monkeypatch, attn_implementation="definitely-not-real")
+
+
+def test_load_model_accepts_explicit_experts_implementation(monkeypatch):
+    model = _load_fake_model(monkeypatch, experts_implementation="batched_mm")
+
+    assert model.config._experts_implementation == "batched_mm"
+
+
+def test_load_model_uses_export_safe_auto_experts_default(monkeypatch):
+    model = _load_fake_model(monkeypatch, experts_implementation="auto")
+
+    assert model.config._experts_implementation == "batched_mm"
+
+
+def test_load_model_can_keep_model_experts_default(monkeypatch):
+    model = _load_fake_model(monkeypatch, experts_implementation="model")
+
+    assert model.config._experts_implementation == "grouped_mm"
+
+
+def test_load_model_ignores_experts_implementation_without_moe(monkeypatch):
+    model = _load_fake_model(
+        monkeypatch,
+        experts_implementation="auto",
+        has_moe_experts=False,
+    )
+
+    assert not hasattr(model.config, "_experts_implementation")
+
+
+def test_load_model_rejects_unknown_experts_implementation(monkeypatch):
+    with pytest.raises(T2NErrorMisuse, match="experts_implementation"):
+        _load_fake_model(
+            monkeypatch, experts_implementation="definitely-not-real"
+        )
 
 
 def test_reify_sdpa_operator_implies_sdpa_attention():
@@ -100,6 +153,29 @@ def test_dump_llm_routes_reified_sdpa_to_loader(monkeypatch, tmp_path):
 
     assert captured_load["attn_implementation"] == "sdpa"
     assert captured_dump["reify_sdpa_operator"] is True
+
+
+def test_dump_llm_routes_experts_implementation_to_loader(
+    monkeypatch, tmp_path
+):
+    captured_load = {}
+
+    class _Exporter:
+        def dump(self, **kwargs):
+            del kwargs
+
+    def fake_load(*args, **kwargs):
+        captured_load.update(kwargs)
+        return _Exporter()
+
+    monkeypatch.setattr(exporter.LLMExporter, "load", staticmethod(fake_load))
+    exporter.dump_llm(
+        "fake/model",
+        export_dirpath=tmp_path / "export",
+        experts_implementation="batched_mm",
+    )
+
+    assert captured_load["experts_implementation"] == "batched_mm"
 
 
 def test_cli_reify_sdpa_operator_implies_sdpa_attention(monkeypatch, tmp_path):
@@ -153,3 +229,29 @@ def test_cli_accepts_transformers_attention_implementation(
     cli.main()
 
     assert captured["attn_implementation"] == "eager"
+
+
+def test_cli_accepts_transformers_experts_implementation(monkeypatch, tmp_path):
+    captured = {}
+
+    def fake_dump_llm(**kwargs):
+        captured.update(kwargs)
+
+    monkeypatch.setattr(cli, "dump_llm", fake_dump_llm)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "torch-to-nnef-llm",
+            "-s",
+            "fake/model",
+            "-e",
+            str(tmp_path / "export"),
+            "--transformers-experts-implementation",
+            "batched_mm",
+        ],
+    )
+
+    cli.main()
+
+    assert captured["experts_implementation"] == "batched_mm"

--- a/packages/llm/torch_to_nnef_llm/cli.py
+++ b/packages/llm/torch_to_nnef_llm/cli.py
@@ -162,6 +162,19 @@ def parser_cli(  # pylint: disable=too-many-positional-arguments
         )
 
         parser.add_argument(
+            "--transformers-experts-implementation",
+            dest="experts_implementation",
+            default="auto",
+            help="expert dispatch implementation selected through "
+            "Transformers' experts interface. 'auto' selects torch-to-nnef's "
+            "export-safe MoE default; 'model' leaves the model default "
+            "unchanged. This has no effect for architectures without "
+            "Transformers MoE expert implementation fields. Explicit values "
+            "are validated against the installed Transformers registry, for "
+            "example batched_mm or grouped_mm.",
+        )
+
+        parser.add_argument(
             "--upcast-quant",
             default=None,
             help="opt-in: dequantize a natively-quantized model (mxfp4, fp8, "

--- a/packages/llm/torch_to_nnef_llm/exporter.py
+++ b/packages/llm/torch_to_nnef_llm/exporter.py
@@ -172,6 +172,7 @@ def _load_exporter_from(
     trust_remote_code: bool = True,
     upcast_quant: T.Optional[T.Sequence[str]] = None,
     attn_implementation: T.Optional[str] = None,
+    experts_implementation: T.Optional[str] = "auto",
 ):
     if (
         is_forced_half_precision_model(force_inputs_dtype, force_module_dtype)
@@ -192,6 +193,7 @@ def _load_exporter_from(
         trust_remote_code=trust_remote_code,
         upcast_quant=upcast_quant,
         attn_implementation=attn_implementation,
+        experts_implementation=experts_implementation,
     )
     tokenizer = load_tokenizer(
         hf_model_causal.config,
@@ -1093,6 +1095,7 @@ def dump_llm(
     trust_remote_code: bool = True,
     upcast_quant: T.Optional[T.Sequence[str]] = None,
     attn_implementation: T.Optional[str] = None,
+    experts_implementation: T.Optional[str] = "auto",
     **kwargs,
 ) -> T.Tuple[T.Union[Path, None], LLMExporter]:
     """Util to export LLM model."""
@@ -1112,6 +1115,7 @@ def dump_llm(
         trust_remote_code=trust_remote_code,
         upcast_quant=upcast_quant,
         attn_implementation=attn_implementation,
+        experts_implementation=experts_implementation,
     )
     dump_kwargs = _normalize_dump_kwargs(kwargs)
     exporter.dump(**dump_kwargs)

--- a/packages/llm/torch_to_nnef_llm/loader.py
+++ b/packages/llm/torch_to_nnef_llm/loader.py
@@ -510,6 +510,77 @@ def _attention_kwargs(
     return {}
 
 
+DEFAULT_EXPERTS_IMPLEMENTATION = "batched_mm"
+
+
+def _valid_experts_implementations(
+    transformers: InjectedTransformersModule,
+) -> T.Set[str]:
+    try:
+        moe_mod = transformers.integrations.moe
+        return set(moe_mod.ALL_EXPERTS_FUNCTIONS.valid_keys())
+    except AttributeError as exp:
+        raise T2NErrorMisuse(
+            "experts_implementation requires a Transformers version exposing "
+            "transformers.integrations.moe.ALL_EXPERTS_FUNCTIONS"
+        ) from exp
+
+
+def _normalize_experts_implementation(
+    experts_implementation: T.Optional[str],
+    transformers: InjectedTransformersModule,
+) -> T.Optional[str]:
+    if experts_implementation in (None, "model"):
+        return None
+    valid_keys = _valid_experts_implementations(transformers)
+    if experts_implementation == "auto":
+        if DEFAULT_EXPERTS_IMPLEMENTATION not in valid_keys:
+            valid = ", ".join(["model", *sorted(valid_keys)])
+            raise T2NErrorMisuse(
+                f"Transformers experts registry does not expose "
+                f"{DEFAULT_EXPERTS_IMPLEMENTATION}; experts_implementation "
+                f"must be one of: {valid}"
+            )
+        return DEFAULT_EXPERTS_IMPLEMENTATION
+    if experts_implementation not in valid_keys:
+        valid = ", ".join(["auto", "model", *sorted(valid_keys)])
+        raise T2NErrorMisuse(f"experts_implementation must be one of: {valid}")
+    return experts_implementation
+
+
+def _iter_config_objects(model) -> T.Iterable[T.Any]:
+    seen = set()
+    stack = [getattr(model, "config", None)]
+    while stack:
+        config = stack.pop()
+        if config is None or id(config) in seen:
+            continue
+        seen.add(id(config))
+        yield config
+        text_config = getattr(config, "text_config", None)
+        if text_config is not None:
+            stack.append(text_config)
+
+
+def _apply_experts_implementation(
+    model, experts_implementation: T.Optional[str]
+):
+    if experts_implementation is None:
+        return
+    applied = False
+    for config in _iter_config_objects(model):
+        for attr in ("_experts_implementation", "experts_implementation"):
+            if hasattr(config, attr):
+                setattr(config, attr, experts_implementation)
+                applied = True
+    if not applied:
+        LOGGER.debug(
+            "experts_implementation=%s has no effect: the loaded model config "
+            "does not expose a Transformers experts implementation field",
+            experts_implementation,
+        )
+
+
 @require_extra_decorator(extra=T2NExtra.LLM_TRACT, module="huggingface_hub")
 @require_extra_decorator(extra=T2NExtra.LLM_TRACT, module="transformers")
 def _from_pretrained(
@@ -583,6 +654,7 @@ def load_model(
     trust_remote_code: bool = True,
     upcast_quant: T.Optional[T.Sequence[str]] = None,
     attn_implementation: T.Optional[str] = None,
+    experts_implementation: T.Optional[str] = "auto",
     *,
     transformers: InjectedTransformersModule = INJECTED,
 ):
@@ -596,6 +668,9 @@ def load_model(
     """
     # validate requested up-cast methods up-front, before any download/load
     upcast_quant = _normalize_upcast_request(upcast_quant)
+    experts_implementation = _normalize_experts_implementation(
+        experts_implementation, transformers
+    )
     # accept a str path from direct callers (the dump_llm path coerces upstream)
     if local_dir is not None:
         local_dir = Path(local_dir)
@@ -692,6 +767,7 @@ def load_model(
     # Finish the up-cast (post-load dequant + dense verification) before the
     # dtype cast below, since `.to(dtype)` does not dequantize quantized params.
     hf_model_causal = _finish_upcast(hf_model_causal, upcast_plan, upcast_quant)
+    _apply_experts_implementation(hf_model_causal, experts_implementation)
 
     if force_module_dtype is not None:
         force_dtype = DtypeStr(force_module_dtype).torch_dtype

--- a/packages/llm/torch_to_nnef_llm/loader.py
+++ b/packages/llm/torch_to_nnef_llm/loader.py
@@ -532,16 +532,26 @@ def _normalize_experts_implementation(
 ) -> T.Optional[str]:
     if experts_implementation in (None, "model"):
         return None
-    valid_keys = _valid_experts_implementations(transformers)
+    # `auto` is the default applied to every export, including non-MoE models
+    # on Transformers versions that predate the experts registry. It must stay
+    # best-effort: degrade to a no-op instead of failing the load. Only values
+    # the user set explicitly are validated strictly.
     if experts_implementation == "auto":
+        try:
+            valid_keys = _valid_experts_implementations(transformers)
+        except T2NErrorMisuse:
+            return None
         if DEFAULT_EXPERTS_IMPLEMENTATION not in valid_keys:
-            valid = ", ".join(["model", *sorted(valid_keys)])
-            raise T2NErrorMisuse(
-                f"Transformers experts registry does not expose "
-                f"{DEFAULT_EXPERTS_IMPLEMENTATION}; experts_implementation "
-                f"must be one of: {valid}"
+            LOGGER.warning(
+                "experts_implementation=auto is a no-op: the Transformers "
+                "experts registry is present but does not expose %s; a MoE "
+                "export may use a dispatch that is not export-safe. Updating "
+                "transformers may expose an export-safe expert dispatch",
+                DEFAULT_EXPERTS_IMPLEMENTATION,
             )
+            return None
         return DEFAULT_EXPERTS_IMPLEMENTATION
+    valid_keys = _valid_experts_implementations(transformers)
     if experts_implementation not in valid_keys:
         valid = ", ".join(["auto", "model", *sorted(valid_keys)])
         raise T2NErrorMisuse(f"experts_implementation must be one of: {valid}")


### PR DESCRIPTION
## Summary
- add `--transformers-experts-implementation` for selecting the expert dispatch implementation exposed by Transformers
- make `auto` the export-safe default for MoE models, currently selecting `batched_mm` when the installed Transformers registry exposes it
- add `model` as the explicit opt-out to preserve the model configuration unchanged
- make the option a no-op for architectures that do not expose Transformers MoE expert implementation fields
- validate explicit values against the installed Transformers registry instead of maintaining a local allow-list

## Validation
- `uv run --extra llm --group test pytest packages/llm/tests/test_sdpa_attention_export.py`
- `uv run ruff check packages/llm/torch_to_nnef_llm/loader.py packages/llm/torch_to_nnef_llm/exporter.py packages/llm/torch_to_nnef_llm/cli.py packages/llm/tests/test_sdpa_attention_export.py`
- `uv run ruff format --check packages/llm/torch_to_nnef_llm/loader.py packages/llm/torch_to_nnef_llm/exporter.py packages/llm/torch_to_nnef_llm/cli.py packages/llm/tests/test_sdpa_attention_export.py`