### PR TITLE
Support shape-derived repeat_interleave counts

### DIFF
--- a/examples/dynamic_axes/export_albert_fixed.py
+++ b/examples/dynamic_axes/export_albert_fixed.py
@@ -23,7 +23,7 @@ def apply_transformers_trace_compat():
     version = SemanticVersion.from_str(transformers.__version__)
     if not "5.5.0" <= version < "5.6.0":
         return
-    import transformers.masking_utils as mu
+    import transformers.masking_utils as mu  # pylint: disable=import-outside-toplevel
 
     orig_sdpa_mask = mu.sdpa_mask
 

--- a/examples/multi_io_py/export_albert.py
+++ b/examples/multi_io_py/export_albert.py
@@ -22,7 +22,7 @@ def apply_transformers_trace_compat():
     version = SemanticVersion.from_str(transformers.__version__)
     if not "5.5.0" <= version < "5.6.0":
         return
-    import transformers.masking_utils as mu
+    import transformers.masking_utils as mu  # pylint: disable=import-outside-toplevel
 
     orig_sdpa_mask = mu.sdpa_mask
 

--- a/tests/test_primitive.py
+++ b/tests/test_primitive.py
@@ -773,6 +773,13 @@ test_suite.add(
     torch.tensor([[[1, 2]], [[3, 4]], [[5, 6]]]),
     TorchFnPrimitive("repeat_interleave", opt_kwargs={"repeats": 3, "dim": 2}),
 )
+test_suite.add(
+    (
+        torch.arange(12, dtype=torch.float32).reshape(3, 4),
+        torch.zeros(3, 2, dtype=torch.long),
+    ),
+    BinaryPrimitive(lambda x, idx: x.repeat_interleave(idx.size(-1), dim=0)),
+)
 
 
 # More advanced slicing

--- a/torch_to_nnef/op/aten/expand.py
+++ b/torch_to_nnef/op/aten/expand.py
@@ -380,9 +380,20 @@ def repeat_interleave(g, node, name_to_tensor, inference_target, **kwargs):
         raise T2NErrorNotImplemented(
             "case with flattening tensor not implemented"
         )
-    if not isinstance(n_repeats.data, int):
+    axis = axis_node.data
+    if axis < 0:
+        axis += input_node.rank
+    repeat_count = _static_repeat_interleave_count(n_repeats)
+    if repeat_count is None:
+        repeat_count = _repeat_interleave_count_from_shapes(
+            input_node, node.outputs[0], axis
+        )
+    if repeat_count is None:
         raise T2NErrorNotImplemented(
-            "case with more than 1 dim repeats not implemented"
+            "case with more than 1 dim repeats not implemented: "
+            f"type={type(n_repeats).__name__}, data={n_repeats.data!r}, "
+            f"traced={getattr(n_repeats, '_traced_data', None)!r}, "
+            f"shape={getattr(n_repeats, 'shape', None)!r}"
         )
 
     # unsqueeze
@@ -394,13 +405,13 @@ def repeat_interleave(g, node, name_to_tensor, inference_target, **kwargs):
         inputs=get_or_add_tensor_variable_in_nnef(
             g, input_node, name_to_tensor
         ),
-        attrs={"axes": [axis_node.data + 1]},
+        attrs={"axes": [axis + 1]},
         output_tensor_name_suffix="unsqueeze",
     )
 
     # build repeats
     repeats = [1] * (input_node.rank + 1)
-    repeats[axis_node.data + 1] = n_repeats.data
+    repeats[axis + 1] = repeat_count
 
     out = add_single_output_op(
         g,
@@ -430,7 +441,7 @@ def repeat_interleave(g, node, name_to_tensor, inference_target, **kwargs):
         nnef_modules.append("tract_core")
 
         _repeats = [1] * (input_node.rank)
-        _repeats[axis_node.data] = n_repeats.data
+        _repeats[axis] = repeat_count
         _repeats = torch.from_numpy(np.array(_repeats))
         new_shape_out = add_single_output_op(
             g,
@@ -466,7 +477,7 @@ def repeat_interleave(g, node, name_to_tensor, inference_target, **kwargs):
         new_shape = nnef.Identifier(new_shape_tdim_casted.name)
     else:
         new_shape = list(input_node.shape)
-        new_shape[axis_node.data] *= n_repeats.data
+        new_shape[axis] *= repeat_count
 
     add_single_output_op(
         g,
@@ -477,6 +488,33 @@ def repeat_interleave(g, node, name_to_tensor, inference_target, **kwargs):
         attrs={"shape": new_shape},
     )
     return nnef_modules
+
+
+def _static_repeat_interleave_count(n_repeats) -> T.Optional[int]:
+    value = n_repeats.data
+    if isinstance(value, int):
+        return value
+    if isinstance(value, torch.Tensor) and value.numel() == 1:
+        return int(value.item())
+
+    traced = getattr(n_repeats, "_traced_data", None)
+    if isinstance(traced, torch.Tensor) and traced.numel() == 1:
+        return int(traced.item())
+    return None
+
+
+def _repeat_interleave_count_from_shapes(
+    input_node, output_node, axis: int
+) -> T.Optional[int]:
+    if input_node.shape is None or output_node.shape is None:
+        return None
+    input_dim = input_node.shape[axis]
+    output_dim = output_node.shape[axis]
+    if not isinstance(input_dim, int) or not isinstance(output_dim, int):
+        return None
+    if input_dim <= 0 or output_dim % input_dim != 0:
+        return None
+    return output_dim // input_dim
 
 
 @OP_REGISTRY.register()


### PR DESCRIPTION
## Summary
- support `repeat_interleave` when a scalar repeat count is represented as a rank-0 traced tensor
- fall back to deriving the static repeat count from traced input/output shapes when the repeat operand has no materialized value
- add a regression for `idx.size(-1)` driving `repeat_interleave`, matching the pattern emitted by Transformers MoE batched expert dispatch

## Validation
- uv run --group test pytest tests/test_primitive.py -k repeat_interleave
- uv run ruff check torch_to_nnef/op/aten/expand.py tests/test_primitive.py
- uv run ruff format --check torch_to_nnef/op/aten/expand.py tests/test_primitive.py
- smoke-exported a tiny random Qwen3.5 MoE dummy with Transformers `batched_mm` expert dispatch through NNEF export