### PR TITLE
Register top-level Qwen3.5 MoE handler

### DIFF
--- a/packages/llm/tests/test_qwen35_moe_handler.py
+++ b/packages/llm/tests/test_qwen35_moe_handler.py
@@ -46,6 +46,7 @@ class FakeConfigHelper:
 
 
 def test_qwen35_moe_handler_is_registered():
+    assert get_handler("qwen3_5_moe") is Qwen35MoeArchitectureHandler
     assert get_handler("qwen3_5_moe_text") is Qwen35MoeArchitectureHandler
 
 

--- a/packages/llm/torch_to_nnef_llm/models/handlers/qwen35_moe.py
+++ b/packages/llm/torch_to_nnef_llm/models/handlers/qwen35_moe.py
@@ -11,7 +11,7 @@ from .registry import register_handler
 class Qwen35MoeArchitectureHandler(DefaultArchitectureHandler):
     """Handler for Qwen3.5 MoE text models with hybrid attention caches."""
 
-    ARCH_NAMES = ("qwen3_5_moe_text",)
+    ARCH_NAMES = ("qwen3_5_moe", "qwen3_5_moe_text")
 
     @staticmethod
     def _layer_types(config_helper) -> T.Sequence[str]:


### PR DESCRIPTION
## Summary
- register the Qwen3.5 MoE handler for the top-level Transformers config model type
- keep the existing text sub-config registration
- add a regression assertion for both model type strings

## Validation
- `uv run --extra llm --group test pytest packages/llm/tests/test_qwen35_moe_handler.py`
- `uv run ruff check packages/llm/torch_to_nnef_llm/models/handlers/qwen35_moe.py packages/llm/tests/test_qwen35_moe_handler.py`
- `uv run ruff format --check packages/llm/torch_to_nnef_llm/models/handlers/qwen35_moe.py packages/llm/tests/test_qwen35_moe_handler.py`