### PR TITLE
Handle Qwen3.5 linear cache state dictionaries

### DIFF
--- a/packages/llm/tests/test_qwen35_moe_handler.py
+++ b/packages/llm/tests/test_qwen35_moe_handler.py
@@ -82,6 +82,12 @@ def test_qwen35_moe_input_spec_names_hybrid_cache_tensors():
     assert "in_cache_conv_1" not in spec.dynamic_axes
 
 
+def test_qwen35_moe_linear_state_accepts_tensor_backed_cache():
+    state = torch.zeros(1, 192, 4)
+
+    assert Qwen35MoeArchitectureHandler._linear_state_tensor(state) is state
+
+
 def test_qwen35_moe_forward_inputs_rebuild_transformers_hybrid_cache():
     handler = Qwen35MoeArchitectureHandler()
     config_helper = FakeConfigHelper()
@@ -110,8 +116,12 @@ def test_qwen35_moe_forward_inputs_rebuild_transformers_hybrid_cache():
     ]
     assert tuple(cache.layers[0].keys.shape) == (1, 2, 5, 16)
     assert tuple(cache.layers[0].values.shape) == (1, 2, 5, 16)
-    assert tuple(cache.layers[1].conv_states.shape) == (1, 192, 4)
-    assert tuple(cache.layers[1].recurrent_states.shape) == (1, 4, 16, 16)
+    conv_state = handler._linear_state_tensor(cache.layers[1].conv_states)
+    recurrent_state = handler._linear_state_tensor(
+        cache.layers[1].recurrent_states
+    )
+    assert tuple(conv_state.shape) == (1, 192, 4)
+    assert tuple(recurrent_state.shape) == (1, 4, 16, 16)
     assert cache.has_previous_state(1)
     assert tuple(state_context.model_inputs["attention_mask"].shape) == (
         1,
@@ -119,3 +129,19 @@ def test_qwen35_moe_forward_inputs_rebuild_transformers_hybrid_cache():
         3,
         8,
     )
+
+    model_outputs = {"logits": torch.zeros(1, 3, 16)}
+    outputs = handler.build_forward_outputs(
+        model=wrapper.model,
+        model_outputs=model_outputs,
+        state_context=state_context,
+        num_logits_to_keep=1,
+    )
+
+    assert outputs == [
+        model_outputs["logits"],
+        cache.layers[0].keys,
+        cache.layers[0].values,
+        conv_state,
+        recurrent_state,
+    ]

--- a/packages/llm/torch_to_nnef_llm/models/handlers/qwen35_moe.py
+++ b/packages/llm/torch_to_nnef_llm/models/handlers/qwen35_moe.py
@@ -38,6 +38,17 @@ class Qwen35MoeArchitectureHandler(DefaultArchitectureHandler):
             decoder_conf.linear_value_head_dim,
         )
 
+    @staticmethod
+    def _linear_state_tensor(state):
+        if isinstance(state, dict):
+            if len(state) != 1:
+                raise ValueError(
+                    "expected a single Qwen3.5 MoE linear cache state, "
+                    f"got {len(state)}"
+                )
+            return next(iter(state.values()))
+        return state
+
     def build_input_spec(
         self,
         *,
@@ -192,5 +203,10 @@ class Qwen35MoeArchitectureHandler(DefaultArchitectureHandler):
             if hasattr(layer, "keys"):
                 outputs.extend([layer.keys, layer.values])
             else:
-                outputs.extend([layer.conv_states, layer.recurrent_states])
+                outputs.extend(
+                    [
+                        self._linear_state_tensor(layer.conv_states),
+                        self._linear_state_tensor(layer.recurrent_states),
+                    ]
+                )
         return outputs


### PR DESCRIPTION
## Summary
- unwrap dict-backed Qwen3.5 MoE linear attention cache states before returning exported outputs
- keep compatibility with tensor-backed cache states
- extend the handler test to cover output tensor ordering for hybrid caches

## Validation
- `uv run --extra llm --group test pytest packages/llm/tests/test_qwen35_moe_handler.py`
- `uv run ruff check packages/llm/torch_to_nnef_llm/models/handlers/qwen35_moe.py packages/llm/tests/test_qwen35_moe_handler.py`
- `uv run ruff format --check packages/llm/torch_to_nnef_llm/models/handlers/qwen35_moe.py packages/llm/tests/test_qwen35_moe_handler.py`