### PR TITLE
fix(core): parse bare Scalar/NumberType SSA values instead of raising

### DIFF
--- a/tests/test_jit_scalar_outputs.py
+++ b/tests/test_jit_scalar_outputs.py
@@ -14,6 +14,8 @@ from torch_to_nnef.torch_graph.torch_const import (
     ATEN_BOOL,
     ATEN_DIV,
     ATEN_LEN,
+    ATEN_SCALARIMPLICIT,
+    NUMBERTYPE_KIND,
 )
 
 
@@ -85,5 +87,40 @@ def test_int_scalar_output_still_parses():
     assert len_outputs
 
     parsed = TensorVariable.parse(len_outputs[0])
+    assert parsed.dtype == torch.int64
+    assert parsed.shape == [1]
+
+
+class _ItemScalar(nn.Module):
+    def forward(self, x):
+        # `Tensor.item()` is typed `aten::item(...) -> Scalar`, i.e. a bare
+        # NumberType SSA value with no `aten::ScalarImplicit` wrapper, the same
+        # shape Qwen2.5-VL's vision tower produces when a 0-d tensor
+        # (grid_thw.max()) feeds a submodule `forward(seqlen)` -> arange.
+        return x + x.max().item()
+
+
+def _bare_number_value():
+    m = torch.jit.script(_ItemScalar())
+    for node in _walk(m.graph):
+        if node.kind() == ATEN_SCALARIMPLICIT:
+            continue
+        for out in node.outputs():
+            if out.type().kind() == NUMBERTYPE_KIND:
+                return out
+    return None
+
+
+def test_bare_number_scalar_value_parses():
+    """A bare `Scalar`/NumberType SSA value (no ScalarImplicit) must parse.
+
+    Regression for the Qwen2.5-VL vision export crash: t2n used to raise
+    `T2NErrorNotImplemented` here. It now parses as an int64 scalar; the
+    recursive-input path fills the concrete dtype/shape from the traced arg.
+    """
+    value = _bare_number_value()
+    assert value is not None, "test setup expected a bare NumberType SSA value"
+
+    parsed = TensorVariable.parse(value)
     assert parsed.dtype == torch.int64
     assert parsed.shape == [1]

--- a/torch_to_nnef/torch_graph/ir_data.py
+++ b/torch_to_nnef/torch_graph/ir_data.py
@@ -341,13 +341,25 @@ class TensorVariable(Data):
             # dtype, mirroring how INT scalars were already handled.
             dtype = scalar_dtype
             shape = [1]
+        elif node_type.kind() == NUMBERTYPE_KIND:
+            parent_node = node_c_value.node()
+            if parent_node.kind() == ATEN_SCALARIMPLICIT:
+                inner_type = parent_node.input().type()
+                stype = inner_type.scalarType()
+                dtype = str_to_torch_dtype(stype) if stype else None
+                shape = inner_type.sizes()
+            else:
+                # A bare `Scalar`/number SSA value with no `ScalarImplicit`
+                # wrapper: e.g. `Tensor.item()` (`aten::item -> Scalar`), or a
+                # submodule `forward(seqlen)` parameter typed `Scalar` because
+                # it was called with a 0-d tensor (Qwen2.5-VL's vision tower
+                # passes `grid_thw.max()` into a rotary embedding -> `arange`).
+                # Represent as an int64 scalar; the recursive-input path
+                # (`_parse_inputs`) overrides dtype/shape from the concrete
+                # traced argument when one is available.
+                dtype = torch.int64
+                shape = [1]
         else:
-            if node_type.kind() == NUMBERTYPE_KIND:
-                parent_node = node_c_value.node()
-                if parent_node.kind() == ATEN_SCALARIMPLICIT:
-                    node_type = parent_node.input().type()
-                else:
-                    raise T2NErrorNotImplemented()
             stype = node_type.scalarType()
             dtype = str_to_torch_dtype(stype) if stype else None
             shape = node_type.sizes()


### PR DESCRIPTION
## Problem

`TensorVariable.parse` raised `T2NErrorNotImplemented` for a bare `Scalar` /
`NumberType` SSA value whose producing node is not `aten::ScalarImplicit`. This
blocks tracing any graph that surfaces such a value, e.g.:

- `Tensor.item()` (typed `aten::item(...) -> Scalar`), and
- a submodule `forward(seqlen)` parameter typed `Scalar` because it is called
  with a 0-d tensor. The Qwen2.5-VL vision tower hits this: `grid_thw.max()`
  feeds `Qwen2_5_VisionRotaryEmbedding.forward(seqlen)` which does
  `torch.arange(seqlen)`, so exporting the vision encoder failed at
  `ir_data.py:350`.

## Fix

Handle the bare-`NumberType` case in `parse` instead of raising: represent it as
an `int64` scalar (`shape [1]`). The recursive-input path (`_parse_inputs`)
already overrides dtype/shape from the concrete traced argument when one is
available, so submodule scalar parameters resolve to their real type. The
existing `aten::ScalarImplicit` unwrapping is preserved (now via an explicit
`inner_type` branch, same result as before).

## Tests

- New `test_bare_number_scalar_value_parses` in `tests/test_jit_scalar_outputs.py`
  crafts a bare `NumberType` value via `Tensor.item()` and asserts it parses to
  an `int64` scalar. It fails with `T2NErrorNotImplemented` before this change.
- The existing int/float/bool scalar-output tests still pass; 51 IR-related
  tests (scalar outputs, constant folds, ir-data equality, cumsum) pass.

## Scope

This unblocks the specific `NumberType`/arange error. Fully exporting the
Qwen2.5-VL vision tower needs further, unrelated core work (next blocker is
`aten::max` full-reduction with no `dim` in `op/aten/reducer.py`), tracked
separately.