### PR TITLE
fix(core): map aten::max/min full-reduction (single input, no dim) to reduce over all axes

### DIFF
--- a/tests/proptest/op_specs/reductions.py
+++ b/tests/proptest/op_specs/reductions.py
@@ -248,6 +248,42 @@ def _var_std_sample_st(method_name: str) -> st.SearchStrategy[OpSample]:
     return _draw()
 
 
+def _minmax_full_reduction_sample_st(
+    method_name: str,
+) -> st.SearchStrategy[OpSample]:
+    """`x.max()` / `x.min()` full reduction (no dim).
+
+    The full-reduction overload is `aten::max(input) -> Tensor`, a single-input
+    node with no dim/keepdim, which the reducer must map to a reduce over every
+    axis. Regression for the crash exporting Qwen2.5/3-VL vision towers
+    (`grid_thw.max()`).
+    """
+
+    @st.composite
+    def _draw(draw) -> OpSample:
+        rank = draw(st.integers(min_value=1, max_value=4))
+        shape = tuple(
+            draw(
+                st.lists(
+                    st.integers(min_value=1, max_value=6),
+                    min_size=rank,
+                    max_size=rank,
+                )
+            )
+        )
+        x = draw(
+            tensor_st(
+                shape,
+                torch.float32,
+                finite=True,
+                domain=Interval(-1e2, 1e2),
+            )
+        )
+        return OpSample(inputs=(x,), module=TensorFnPrimitive(method_name))
+
+    return _draw()
+
+
 def _reduction_specs() -> T.List[OpSpec]:
     return [
         OpSpec(
@@ -281,6 +317,16 @@ def _reduction_specs() -> T.List[OpSpec]:
         OpSpec(
             name="min-dim",
             sample_st=_reduction_sample_st("min"),
+            tolerance=TractCheckTolerance.EXACT,
+        ),
+        OpSpec(
+            name="max-full",
+            sample_st=_minmax_full_reduction_sample_st("max"),
+            tolerance=TractCheckTolerance.EXACT,
+        ),
+        OpSpec(
+            name="min-full",
+            sample_st=_minmax_full_reduction_sample_st("min"),
             tolerance=TractCheckTolerance.EXACT,
         ),
         # Argmax / argmin return int64 indices: the comparator's exact

--- a/torch_to_nnef/op/aten/reducer.py
+++ b/torch_to_nnef/op/aten/reducer.py
@@ -28,7 +28,13 @@ def reducer_helper(aten_op_name: str, node, op_helper, output_idx: int = 0):
     # exported graph already carries the post-cast output dtype, so we
     # can safely ignore it here.
     n_inputs = len(node.inputs)
-    if n_inputs == 2:
+    if n_inputs == 1:
+        # Full reduction with no dim arg, e.g. `aten::max(input) -> Tensor`
+        # (`torch.max(x)` / `x.max()`). Reduce over every axis.
+        (input_node,) = node.inputs
+        axis_node = None
+        keep_dim = False
+    elif n_inputs == 2:
         (input_node, axis_node) = node.inputs
         keep_dim = False
     elif n_inputs >= 3:
@@ -36,7 +42,7 @@ def reducer_helper(aten_op_name: str, node, op_helper, output_idx: int = 0):
         keep_dim = keep_dim_node.data
     else:
         raise T2NErrorNotImplemented(
-            f"reducer with {n_inputs} inputs (expected 2 or >=3)"
+            f"reducer with {n_inputs} inputs (expected 1, 2 or >=3)"
         )
 
     onode = node.outputs[output_idx]
@@ -57,13 +63,13 @@ def reducer_helper(aten_op_name: str, node, op_helper, output_idx: int = 0):
         name_to_tensor[op_reduce_out_name] = op_reduce_out
 
     # can be either 1 or n axes {
-    if isinstance(axis_node.data, int):
+    if axis_node is None or axis_node.data is None:
+        # No dim (full reduction): reduce over every axis.
+        axes = [pick_axis(input_node, _) for _ in range(input_node.rank)]
+    elif isinstance(axis_node.data, int):
         axes = [pick_axis(input_node, axis_node.data)]
     else:
-        if axis_node.data is None:
-            axes = [pick_axis(input_node, _) for _ in range(input_node.rank)]
-        else:
-            axes = [pick_axis(input_node, _) for _ in axis_node.data]
+        axes = [pick_axis(input_node, _) for _ in axis_node.data]
     #  }
     tensor_ref = op_helper.get_or_add_tensor_variable_in_nnef(input_node)
     if (
@@ -365,16 +371,21 @@ def reduce_min(node, op_helper, **kwargs):
 
 @OP_REGISTRY.register(torch_op_ids=["max"])
 def max_(node, op_helper, **kwargs):
-    """Map PyTorch: 'aten:max' to NNEF."""
-    if isinstance(node.inputs[1], PythonConstant):
+    """Map PyTorch: 'aten:max' to NNEF.
+
+    Three overloads: full reduction ``max(input)`` (1 input), dim reduction
+    ``max(input, dim, keepdim)`` (dim is a PythonConstant), and elementwise
+    ``max(input, other)`` (other is a tensor). The first two are reductions.
+    """
+    if len(node.inputs) == 1 or isinstance(node.inputs[1], PythonConstant):
         return reduce_max(node, op_helper)
     return op_helper.unary_output_op_without_attr(nnef_op_type="max", node=node)
 
 
 @OP_REGISTRY.register(torch_op_ids=["min"])
 def min_(node, op_helper, **kwargs):
-    """Map PyTorch: 'aten:min' to NNEF."""
-    if isinstance(node.inputs[1], PythonConstant):
+    """Map PyTorch: 'aten:min' to NNEF (see :func:`max_` for the overloads)."""
+    if len(node.inputs) == 1 or isinstance(node.inputs[1], PythonConstant):
         return reduce_min(node, op_helper)
     return op_helper.unary_output_op_without_attr(nnef_op_type="min", node=node)
 


### PR DESCRIPTION
## Problem

`aten::max`/`aten::min` have three overloads: full reduction `max(input)` (1
input), dim reduction `max(input, dim, keepdim)` (dim is a constant), and
elementwise `max(input, other)` (other is a tensor). The `max_`/`min_` handlers
indexed `node.inputs[1]` unconditionally, so the **full-reduction** form
(`torch.max(x)` / `x.max()`, a single-input node) raised `IndexError: list
index out of range` in `op/aten/reducer.py`.

This blocks exporting the Qwen2.5-VL / Qwen3-VL vision towers, which do
`grid_thw.max()`.

## Fix

- `max_`/`min_`: treat the single-input form as a reduction (route to
  `reduce_max`/`reduce_min`) alongside the existing dim form.
- `reducer_helper`: accept `n_inputs == 1` (no dim / keepdim) and, when there is
  no dim, reduce over every axis. This also makes the `aten::sum(input)`
  1-input variant the module docstring already describes actually work.

## Tests

- New `max-full` / `min-full` cases in the reductions proptest spec
  (`tests/proptest/op_specs/reductions.py`), full-reduction `x.max()` / `x.min()`
  swept over rank 1-4, checked EXACT against tract. They crash with `IndexError`
  before this change.
- Reduction-group regression (sum/mean/max/min/prod/arg/var/std/aminmax): 46
  passed, 8 expected xfails, no failures.