### PR TITLE
fix(core): fold constant masked-select + argsort for tract, guard dynamic over-bake

### DIFF
--- a/tests/test_static_shape_fold.py
+++ b/tests/test_static_shape_fold.py
@@ -1,0 +1,193 @@
+"""Constant-fold lowerings for tract, and their dynamic-axes safety.
+
+Two ops must be folded because tract cannot represent/run them otherwise; these
+exercise the fold paths the proptest harness (runtime inputs) cannot reach:
+
+- boolean-mask advanced indexing ``x[mask]`` with a constant mask: a
+  masked-select (filter), which has no NNEF op (``tract_core_gather`` would
+  treat the bool mask as integer positions and give the wrong length), so a
+  constant mask folds to the selected constant,
+- ``argsort`` of a constant folds to a constant permutation: emitting
+  ``tract_core_topk`` instead fails on the Qwen2.5-VL window_index, whose sort
+  axis is a symbolic TDim even in a static export (``TDim is not a number``).
+
+Regression for the Qwen2.5-VL vision tower window_index
+(``index_padded[index_padded != -100]`` then ``argsort(window_index)``).
+
+The folds bake trace-time values, so they must NOT fire when the value depends
+on a dynamic axis (over-baking). Under ``dynamic_axes`` only genuine constants
+(``.data``) fold; the dynamic-axes tests below export once with a symbolic axis
+and run tract at several sizes to catch a frozen shape/index. (``reshape``/
+``view`` with ``-1`` needs no fold -- tract resolves it -- so it is only checked
+for dynamic correctness here.)
+"""
+
+import subprocess
+import tempfile
+from pathlib import Path
+
+import pytest
+import torch
+from torch import nn
+
+from torch_to_nnef.export import export_model_to_nnef
+from torch_to_nnef.inference_target import TractNNEF
+from torch_to_nnef.inference_target.tract import TractCheckTolerance, build_io
+
+
+def _export_and_check(module, x):
+    target = TractNNEF.latest()
+    target.check_io = True
+    with tempfile.TemporaryDirectory() as d:
+        export_model_to_nnef(
+            model=module.eval(),
+            args=(x,),
+            inference_target=target,
+            file_path_export=Path(d) / "m.nnef.tgz",
+            input_names=["x"],
+            output_names=["y"],
+        )
+
+
+def _export_dynamic(module, trace_x, dyn_axes, dst):
+    target = TractNNEF.latest()
+    target.check_io = False
+    target.dynamic_axes = dyn_axes
+    export_model_to_nnef(
+        model=module.eval(),
+        args=(trace_x,),
+        inference_target=target,
+        file_path_export=dst,
+        input_names=["x"],
+        output_names=["y"],
+    )
+    return target
+
+
+def _run_dynamic_at_sizes(module, trace_x, dyn_axes, make_x, sizes):
+    """Export once with a symbolic axis, then run tract at several sizes.
+
+    Surfaces over-baking: if a fold froze a shape/index to the trace-time
+    value, tract errors or mismatches at any size != the trace size.
+    """
+    module = module.eval()
+    with tempfile.TemporaryDirectory() as d:
+        d = Path(d)
+        nnef = d / "m.nnef.tgz"
+        target = _export_dynamic(module, trace_x, dyn_axes, nnef)
+        cli = target.tract_cli
+        for s in sizes:
+            xi = make_x(s)
+            inb, outb = d / f"in_{s}.npz", d / f"out_{s}.npz"
+            build_io(
+                module,
+                (xi,),
+                input_bundle_path=inb,
+                output_bundle_path=outb,
+                input_names=["x"],
+                output_names=["y"],
+            )
+            cmd = cli.assert_io_cmd_str(
+                nnef, inb, outb, check_tolerance=TractCheckTolerance.APPROXIMATE
+            )
+            proc = subprocess.run(cmd, capture_output=True, text=True)
+            assert proc.returncode == 0, (
+                f"tract failed/mismatched at size {s} (trace was "
+                f"{tuple(trace_x.shape)}):\n{proc.stdout[-800:]}{proc.stderr[-800:]}"
+            )
+
+
+class _BoolMaskAndArgsort(nn.Module):
+    def __init__(self):
+        super().__init__()
+        # constant "padded index" with sentinels, like Qwen window_index
+        self.register_buffer(
+            "idx", torch.tensor([3, -100, 1, -100, 2, 0], dtype=torch.long)
+        )
+
+    def forward(self, x):
+        kept = self.idx[self.idx != -100]  # bool-mask select -> [3,1,2,0]
+        order = torch.argsort(kept)  # argsort of a constant
+        gathered = kept[order]  # reorder via folded permutation
+        return x + gathered.sum().float()
+
+
+class _StaticViewMinusOne(nn.Module):
+    def forward(self, x):
+        # x is [4, 6]; view(-1, 3) must bake the -1 to 8 on a static input
+        return x.reshape(2, -1).reshape(-1, 3).sum()
+
+
+def test_bool_mask_and_argsort_fold_export():
+    _export_and_check(_BoolMaskAndArgsort(), torch.zeros(2, 3))
+
+
+def test_static_view_minus_one_export():
+    _export_and_check(_StaticViewMinusOne(), torch.arange(24.0).reshape(4, 6))
+
+
+def test_non_constant_bool_mask_is_rejected():
+    from torch_to_nnef.exceptions import T2NError
+
+    class _DynMask(nn.Module):
+        def forward(self, x):
+            return x[x > 0]
+
+    with pytest.raises(T2NError):
+        _export_and_check(_DynMask(), torch.randn(8))
+
+
+# ---------------------------------------------------------------------------
+# Dynamic-axes ("multiple time dimension") coverage.
+#
+# The static folds above bake trace-time values. Under `dynamic_axes` those
+# same folds must NOT freeze a shape/index that depends on the symbolic axis
+# (over-baking): the single fixed-shape export cannot surface that, so we
+# export once with a symbolic axis and drive tract at several sizes.
+# ---------------------------------------------------------------------------
+
+
+class _DynViewMinusOne(nn.Module):
+    def forward(self, x):  # x: [1, S, 4]; -1 == S*4, depends on the dyn axis
+        return x.reshape(x.shape[0], -1) * 1.0
+
+
+class _DynArgsortStaticAxis(nn.Module):
+    """argsort a whole-number tensor along a STATIC axis, dynamic time axis.
+
+    ``base`` is an integer tensor (so it carries ``_traced_data``) broadcast
+    over the dynamic axis. The sort is along the static last axis, so it lowers
+    fine at runtime -- but the argsort fold would fold it to a constant whose
+    shape freezes the dynamic axis to the trace-time length (over-baking),
+    mis-sorting every other size. This is a pattern models actually use
+    (ranking along a feature axis within a sequence).
+    """
+
+    def forward(self, x):  # x: [1, S, 4]
+        base = torch.arange(3, -1, -1).view(1, 1, 4).expand(1, x.shape[1], 4)
+        order = torch.argsort(base, dim=2)
+        return torch.gather(x, 2, order) * 1.0
+
+
+def test_dynamic_view_minus_one_runs_at_multiple_sizes():
+    # `-1` must stay a runtime shape ref, not baked to the trace-time S*4.
+    _run_dynamic_at_sizes(
+        _DynViewMinusOne(),
+        torch.randn(1, 3, 4),
+        {"x": {1: "S"}},
+        lambda s: torch.randn(1, s, 4),
+        sizes=[3, 5, 7],
+    )
+
+
+def test_dynamic_argsort_static_axis_runs_at_multiple_sizes():
+    # The argsort fold must NOT bake this whole-number sort to a constant whose
+    # shape freezes the dynamic axis: it over-bakes and mis-sorts sizes other
+    # than the trace (S=5, S=7 below diverge from PyTorch without the guard).
+    _run_dynamic_at_sizes(
+        _DynArgsortStaticAxis(),
+        torch.randn(1, 3, 4),
+        {"x": {1: "S"}},
+        lambda s: torch.randn(1, s, 4),
+        sizes=[3, 5, 7],
+    )

--- a/torch_to_nnef/op/aten/selector.py
+++ b/torch_to_nnef/op/aten/selector.py
@@ -11,6 +11,7 @@ from torch_to_nnef.exceptions import T2NErrorNotImplemented
 from torch_to_nnef.inference_target import TractNNEF
 from torch_to_nnef.op.helper import (
     AtenOpRegistry,
+    add_tensor_variable_node_as_nnef_tensor,
     cast_and_add_nnef_operation,
     get_or_add_tensor_variable_in_nnef,
     get_tract_dyn_axis_size_soc,
@@ -24,6 +25,32 @@ from torch_to_nnef.torch_graph.ir_data import PythonConstant, TensorVariable
 LOGGER = logging.getLogger(__name__)
 
 OP_REGISTRY = AtenOpRegistry()
+
+
+def _const_tensor(node, allow_traced=True):
+    """Return a node's concrete tensor value if statically known, else None.
+
+    Uses the folded ``.data`` (a genuine compile-time constant) when present.
+    Falls back to the value captured during tracing (``_traced_data``,
+    populated for whole-number tensors) only when ``allow_traced`` is set.
+
+    ``_traced_data`` holds the trace-time value even for tensors that depend on
+    a dynamic axis (e.g. ``arange(x.shape[dyn])``), so folding on it under
+    ``dynamic_axes`` would OVER-BAKE: freezing an index/permutation to the
+    trace-time length. Callers pass ``allow_traced=not has_dynamic_axes`` so
+    that in a dynamic export only true constants (``.data``) fold; anything
+    dynamic falls through to its runtime lowering.
+    """
+    if not isinstance(node, TensorVariable):
+        return None
+    data = node.data
+    if isinstance(data, torch.Tensor):
+        return data
+    if allow_traced:
+        traced = getattr(node, "_traced_data", None)
+        if isinstance(traced, torch.Tensor):
+            return traced
+    return None
 
 
 def _should_cast_for_select(inp, expected_np_dtype):
@@ -485,6 +512,35 @@ def index_(node, op_helper, inference_target, **kwargs):
     input_node, indexes_node = node.inputs
     # input_node = TensorVariable([?], shape=(169,4))
     # indexes_node = FixedTensorList (data=[TensorVariable([?], shape=(2401,))])
+
+    # Boolean-mask advanced indexing `x[mask]` is masked-select (a filter),
+    # NOT a gather: tract_core_gather would treat the bool mask as integer
+    # positions and produce the wrong length. Only a constant mask is
+    # representable statically, so fold it to the selected constant (this is
+    # what Qwen's window_index does: index_padded[index_padded != -100]).
+    if len(indexes_node.data) == 1:
+        mask_node = indexes_node.data[-1]
+        if (
+            isinstance(mask_node, TensorVariable)
+            and mask_node.dtype == torch.bool
+        ):
+            allow_traced = not inference_target.has_dynamic_axes
+            input_val = _const_tensor(input_node, allow_traced=allow_traced)
+            mask_val = _const_tensor(mask_node, allow_traced=allow_traced)
+            if input_val is None or mask_val is None:
+                raise T2NErrorNotImplemented(
+                    "boolean-mask index x[mask] with a non-constant mask is "
+                    "not supported for export (only constant masks fold)"
+                )
+            selected = input_val[mask_val.to(torch.bool)]
+            out = node.outputs[0]
+            if not isinstance(out.data, torch.Tensor):
+                out.set_data(selected)
+            add_tensor_variable_node_as_nnef_tensor(
+                op_helper.g, out, op_helper.name_to_tensor
+            )
+            return []
+
     if len(indexes_node.data) > 1:
         # gather_elements
         len_idx_vars = len(
@@ -1028,10 +1084,32 @@ def argsort(node, op_helper, inference_target, **kwargs):
         "not supported by Khronos spec"
     )
     input_node, dim_node, descending_node = node.inputs
-    input_nnef = op_helper.get_or_add_tensor_variable_in_nnef(input_node)
     assert isinstance(descending_node.data, bool), descending_node
     assert isinstance(dim_node, PythonConstant), dim_node
     assert isinstance(dim_node.data, int), dim_node
+
+    # Constant input (e.g. argsort of Qwen's folded window_index to build the
+    # reverse permutation): fold to a constant instead of a runtime
+    # tract_core_topk whose `k` would otherwise be a symbolic TDim. Under
+    # dynamic_axes only genuine constants (`.data`) fold: a trace-time
+    # `_traced_data` value (e.g. argsort of an `arange(x.shape[dyn])`) would
+    # over-bake the permutation to the trace length and mis-sort other sizes.
+    input_val = _const_tensor(
+        input_node, allow_traced=not inference_target.has_dynamic_axes
+    )
+    if input_val is not None:
+        idx = torch.argsort(
+            input_val, dim=dim_node.data, descending=descending_node.data
+        )
+        out = node.outputs[0]
+        if not isinstance(out.data, torch.Tensor):
+            out.set_data(idx)
+        add_tensor_variable_node_as_nnef_tensor(
+            op_helper.g, out, op_helper.name_to_tensor
+        )
+        return ["tract_core"]
+
+    input_nnef = op_helper.get_or_add_tensor_variable_in_nnef(input_node)
     dim = pick_axis(input_node, dim_node.data)
     if inference_target.has_dynamic_axes:
         # Centralized dynamic axis extraction


### PR DESCRIPTION
## What

Two aten ops need constant-folding for tract export, because tract cannot represent or run them otherwise. This also guards those folds against over-baking under `dynamic_axes`.

- **boolean-mask index `x[mask]`** (masked-select / filter): no NNEF op exists (`tract_core_gather` would treat the bool mask as integer positions and produce the wrong length). A constant mask folds to the selected constant; a non-constant mask raises `T2NErrorNotImplemented`.
- **`argsort` of a constant**: folds to a constant permutation. Emitting `tract_core_topk` instead fails on the real Qwen2.5-VL vision tower, whose `window_index` sort axis is a symbolic `TDim` even in a static (baked-grid) export, so tract reports `Topk ... TDim is not a number`. Verified: forcing a concrete `k` does not help (tract still needs the input axis `d` concrete, and `k > d` cannot be validated), so the fold is the correct lowering here.

Regression for the Qwen2.5-VL vision tower window_index (`index_padded[index_padded != -100]` then `argsort(window_index)`).

## Over-baking guard

The folds bake trace-time values, so they must not fire when the value depends on a dynamic axis. `_const_tensor` gains `allow_traced`; call sites pass `allow_traced = not inference_target.has_dynamic_axes`, so under `dynamic_axes` only genuine constants (`.data`) fold and anything dynamic falls through to its runtime lowering. Static export is unchanged (over-baking is harmless there).

## Tests

`tests/test_static_shape_fold.py`:
- static folds: constant masked-select + argsort, non-constant mask rejected;
- dynamic-axes multi-size runs (export once with a symbolic axis, drive tract at S in [3, 5, 7]): `view -1` stays correct; `argsort` of a whole-number tensor along a static axis with a dynamic other dim runs correctly and is not frozen to the trace length (this fails without the guard: S=5/7 diverge).

## Note

The earlier `reshape`/`view -1` static-fold was dropped: on the real Qwen2.5-VL tower tract resolves it natively (IO bit match without it), so folding it was redundant and also introduced an unconditional over-bake path in `view`.