### PR TITLE
feat(core): accumulate fp16 conv in f32 under force_linear_accumulation_in_f32

### DIFF
--- a/tests/test_linear_acc.py
+++ b/tests/test_linear_acc.py
@@ -18,6 +18,18 @@ from .utils import (  # noqa: E402
 
 set_seed(int(os.environ.get("SEED", 25)))
 
+
+def _f16_cpu_conv_supported() -> bool:
+    try:
+        with torch.inference_mode():
+            nn.Conv2d(1, 1, 1).half()(torch.zeros(1, 1, 2, 2).half())
+        return True
+    except RuntimeError:
+        return False
+
+
+_F16_CONV_CPU_OK = _f16_cpu_conv_supported()
+
 tract_latest = deepcopy(TRACT_INFERENCES_TO_TESTS_APPROX[0])
 tract_latest.force_linear_accumulation_in_f32 = True
 
@@ -38,17 +50,19 @@ if tract_latest.version >= "0.21.11":
     # `linear`: an fp16 conv accumulator diverges from PyTorch's CPU f16
     # kernels (which accumulate in f32), so we upcast the conv to f32 and
     # cast the result back. Cover the plain conv and the transposed (deconv)
-    # paths, both reached through `aten::_convolution`.
-    conv = nn.Conv2d(4, 8, kernel_size=3, padding=1).half()
+    # paths, both reached through `aten::_convolution`. Old torch (e.g. 1.13)
+    # lacks CPU f16 conv, so guard like the linear case above.
     conv_inp = torch.randn(1, 4, 8, 8).half()
-    with torch.inference_mode():
-        conv(conv_inp)
-    test_suite.add(conv_inp, conv)
-
-    deconv = nn.ConvTranspose2d(4, 8, kernel_size=3, stride=2).half()
-    with torch.inference_mode():
-        deconv(conv_inp)
-    test_suite.add(conv_inp, deconv)
+    for conv_mod in (
+        nn.Conv2d(4, 8, kernel_size=3, padding=1).half(),
+        nn.ConvTranspose2d(4, 8, kernel_size=3, stride=2).half(),
+    ):
+        try:
+            with torch.inference_mode():
+                conv_mod(conv_inp)
+            test_suite.add(conv_inp, conv_mod)
+        except RuntimeError as exp:
+            print("failed to add the conv test because torch:", exp)
 
 
 @pytest.mark.parametrize(
@@ -83,14 +97,17 @@ def _check_conv_upcast_emitted(inference_target, path):
 
 
 @pytest.mark.skipif(
-    condition=tract_latest.version < "0.21.11",
-    reason="conv f32 accumulation needs tract>=0.21.11",
+    condition=tract_latest.version < "0.21.11" or not _F16_CONV_CPU_OK,
+    reason="conv f32 accum needs tract>=0.21.11 and CPU f16 conv",
 )
 @pytest.mark.parametrize("force_f32", [True, False])
 def test_conv_accumulate_f32_emits_cast_sandwich(force_f32):
     """The f32 sandwich is emitted only when the option is set."""
     inference_target = deepcopy(TRACT_INFERENCES_TO_TESTS_APPROX[0])
     inference_target.force_linear_accumulation_in_f32 = force_f32
+    # Without the upcast an fp16 conv legitimately diverges from tract, so only
+    # numerically check the f32 path; the flag-off case just inspects the graph.
+    inference_target.check_io = force_f32
     conv = nn.Conv2d(4, 8, kernel_size=3, padding=1).half()
     conv_inp = torch.randn(1, 4, 8, 8).half()
     check_model_io_test(

--- a/tests/test_linear_acc.py
+++ b/tests/test_linear_acc.py
@@ -1,7 +1,9 @@
 """Tests simple accumulator option."""
 
 import os
+import tarfile
 from copy import deepcopy
+from pathlib import Path
 
 import pytest
 import torch
@@ -32,6 +34,22 @@ if tract_latest.version >= "0.21.11":
     except RuntimeError as exp:
         print("failed to add the test because torch:", exp)
 
+    # `conv` shares the `force_linear_accumulation_in_f32` option with
+    # `linear`: an fp16 conv accumulator diverges from PyTorch's CPU f16
+    # kernels (which accumulate in f32), so we upcast the conv to f32 and
+    # cast the result back. Cover the plain conv and the transposed (deconv)
+    # paths, both reached through `aten::_convolution`.
+    conv = nn.Conv2d(4, 8, kernel_size=3, padding=1).half()
+    conv_inp = torch.randn(1, 4, 8, 8).half()
+    with torch.inference_mode():
+        conv(conv_inp)
+    test_suite.add(conv_inp, conv)
+
+    deconv = nn.ConvTranspose2d(4, 8, kernel_size=3, stride=2).half()
+    with torch.inference_mode():
+        deconv(conv_inp)
+    test_suite.add(conv_inp, deconv)
+
 
 @pytest.mark.parametrize(
     "id,test_input,model,inference_target",
@@ -42,4 +60,42 @@ def test_linear_accumulate_f32_export(id, test_input, model, inference_target):
     """Test simple aten PyTorch core."""
     check_model_io_test(
         model=model, test_input=test_input, inference_target=inference_target
+    )
+
+
+def _read_graph_nnef_from_archive(path: Path) -> str:
+    with tarfile.open(path, "r:*") as tf:
+        for member in tf.getmembers():
+            if member.name.endswith("graph.nnef"):
+                f = tf.extractfile(member)
+                assert f is not None
+                return f.read().decode("utf-8")
+    raise AssertionError("graph.nnef not found in exported archive")
+
+
+def _check_conv_upcast_emitted(inference_target, path):
+    graph_content = _read_graph_nnef_from_archive(path)
+    sandwich = ["tract_core_cast", "to = 'f32'", "to = 'f16'"]
+    if inference_target.force_linear_accumulation_in_f32:
+        assert all(elm in graph_content for elm in sandwich), graph_content
+    else:
+        assert not any(elm in graph_content for elm in sandwich)
+
+
+@pytest.mark.skipif(
+    condition=tract_latest.version < "0.21.11",
+    reason="conv f32 accumulation needs tract>=0.21.11",
+)
+@pytest.mark.parametrize("force_f32", [True, False])
+def test_conv_accumulate_f32_emits_cast_sandwich(force_f32):
+    """The f32 sandwich is emitted only when the option is set."""
+    inference_target = deepcopy(TRACT_INFERENCES_TO_TESTS_APPROX[0])
+    inference_target.force_linear_accumulation_in_f32 = force_f32
+    conv = nn.Conv2d(4, 8, kernel_size=3, padding=1).half()
+    conv_inp = torch.randn(1, 4, 8, 8).half()
+    check_model_io_test(
+        model=conv,
+        test_input=conv_inp,
+        inference_target=inference_target,
+        callback_post_export=_check_conv_upcast_emitted,
     )

--- a/torch_to_nnef/op/aten/matmul.py
+++ b/torch_to_nnef/op/aten/matmul.py
@@ -35,6 +35,115 @@ def _get_padding_same_symetric(
     return padding
 
 
+def _emit_conv_op_with_optional_f32_accumulation(
+    g,
+    node,
+    name_to_tensor,
+    inference_target,
+    *,
+    input_node,
+    weight_ref,
+    bias_ref,
+    output_tensor,
+    conv_type,
+    attribs,
+    null_ref,
+):
+    """Emit the NNEF ``conv``/``deconv`` op, optionally accumulating in f32.
+
+    NNEF ``conv`` has no ``acc`` attribute (unlike the ``tract_core_einsum``
+    used by ``linear``), so when the input is fp16 and
+    ``inference_target.force_linear_accumulation_in_f32`` is set we sandwich
+    the op between casts: lift input/weight/bias to f32, run the conv in f32,
+    then cast the result back to the traced output dtype. Without this the
+    fp16 conv accumulator diverges from PyTorch's CPU f16 kernels (which
+    accumulate in f32) -- e.g. a vision patch-embedding conv drifts ~14% and
+    the following norms amplify it. Mirrors the ``layer_norm`` and ``linear``
+    f32-accumulation paths.
+    """
+    input_ref = get_or_add_tensor_variable_in_nnef(
+        g, input_node, name_to_tensor
+    )
+    upcast_f32 = (
+        isinstance(inference_target, TractNNEF)
+        and input_node.dtype == torch.float16
+        and inference_target.force_linear_accumulation_in_f32
+    )
+    if upcast_f32 and inference_target.version < "0.21.11":
+        LOGGER.warning(
+            "conv can not yet accumulate in f32 (waiting tract>=0.21.11),"
+            " fallback to f16"
+        )
+        upcast_f32 = False
+
+    if not upcast_f32:
+        cast_and_add_nnef_operation(
+            name_to_tensor=name_to_tensor,
+            graph=g,
+            type=conv_type,
+            name=f"{node.outputs[0].export_name}_op",
+            inputs=(input_ref, weight_ref, bias_ref),
+            outputs=output_tensor,
+            attribs=attribs,
+            force_consistent_inputs_shapes=False,
+        )
+        return []
+
+    input_f32 = add_single_output_op(
+        g,
+        node,
+        name_to_tensor,
+        "tract_core_cast",
+        inputs=input_ref,
+        attrs={"to": "f32"},
+        output_tensor_name_suffix="_inf32",
+    )
+    weight_f32 = add_single_output_op(
+        g,
+        node,
+        name_to_tensor,
+        "tract_core_cast",
+        inputs=weight_ref,
+        attrs={"to": "f32"},
+        output_tensor_name_suffix="_wf32",
+    )
+    conv_inputs = [input_f32, weight_f32]
+    if bias_ref is not null_ref:
+        conv_inputs.append(
+            add_single_output_op(
+                g,
+                node,
+                name_to_tensor,
+                "tract_core_cast",
+                inputs=bias_ref,
+                attrs={"to": "f32"},
+                output_tensor_name_suffix="_bf32",
+            )
+        )
+    else:
+        conv_inputs.append(bias_ref)
+    conv_f32 = add_single_output_op(
+        g,
+        node,
+        name_to_tensor,
+        conv_type,
+        inputs=conv_inputs,
+        attrs=attribs,
+        output_tensor_name_suffix="_accf32",
+        force_consistent_inputs_shapes=False,
+    )
+    cast_and_add_nnef_operation(
+        name_to_tensor=name_to_tensor,
+        graph=g,
+        type="tract_core_cast",
+        name=f"{node.outputs[0].export_name}_op",
+        inputs=conv_f32,
+        outputs=output_tensor,
+        attribs={"to": TORCH_DTYPE_TO_TRACT_STR[node.outputs[0].dtype]},
+    )
+    return ["tract_core"]
+
+
 @OP_REGISTRY.register(
     # Most of these aten symbols never reach the trace: pytorch
     # decomposes them through `aten::_convolution_mode` or
@@ -113,17 +222,16 @@ def _convolution_mode(
         null_ref,
     )
 
-    cast_and_add_nnef_operation(
-        name_to_tensor=name_to_tensor,
-        graph=g,
-        type="conv",
-        name=f"{node.outputs[0].export_name}_op",
-        inputs=(
-            get_or_add_tensor_variable_in_nnef(g, input_node, name_to_tensor),
-            weight_ref,
-            bias_ref,
-        ),
-        outputs=output_tensor,
+    return _emit_conv_op_with_optional_f32_accumulation(
+        g,
+        node,
+        name_to_tensor,
+        inference_target,
+        input_node=input_node,
+        weight_ref=weight_ref,
+        bias_ref=bias_ref,
+        output_tensor=output_tensor,
+        conv_type="conv",
         attribs={
             "dilation": list(dilation),
             "padding": [
@@ -133,7 +241,7 @@ def _convolution_mode(
             "groups": groups,
             "border": "constant",
         },
-        force_consistent_inputs_shapes=False,
+        null_ref=null_ref,
     )
 
 
@@ -239,17 +347,16 @@ def _emit_conv(
                 pad_after -= op
         nnef_padding.append((pad_before, pad_after))
 
-    cast_and_add_nnef_operation(
-        name_to_tensor=name_to_tensor,
-        graph=g,
-        type="deconv" if transposed else "conv",
-        name=f"{node.outputs[0].export_name}_op",
-        inputs=(
-            get_or_add_tensor_variable_in_nnef(g, input_node, name_to_tensor),
-            weight_ref,
-            bias_ref,
-        ),
-        outputs=output_tensor,
+    return _emit_conv_op_with_optional_f32_accumulation(
+        g,
+        node,
+        name_to_tensor,
+        inference_target,
+        input_node=input_node,
+        weight_ref=weight_ref,
+        bias_ref=bias_ref,
+        output_tensor=output_tensor,
+        conv_type="deconv" if transposed else "conv",
         attribs={
             "dilation": list(dilation),
             "padding": nnef_padding,
@@ -257,7 +364,7 @@ def _emit_conv(
             "groups": groups,
             "border": "constant",
         },
-        force_consistent_inputs_shapes=False,
+        null_ref=null_ref,
     )
 
 
@@ -279,7 +386,7 @@ def _convolution(g, node, name_to_tensor, null_ref, inference_target, **kwargs):
         _,  # cuda_enabled
         _,  # allow_tf32
     ) = node.inputs
-    _emit_conv(
+    return _emit_conv(
         g,
         node,
         name_to_tensor,
@@ -324,7 +431,7 @@ def conv_transpose_nd(
         groups_node,
         dilation_node,
     ) = node.inputs
-    _emit_conv(
+    return _emit_conv(
         g,
         node,
         name_to_tensor,


### PR DESCRIPTION
## What

`force_linear_accumulation_in_f32` was only honored by the `linear` handler (`tract_core_einsum` with `acc="f32"`); the convolution family emitted a plain NNEF `conv`/`deconv` regardless. So an fp16 conv accumulated in fp16 in tract while PyTorch's CPU fp16 kernels accumulate in f32, and the two diverged.

This extends the conv family to honor the same option: when the input is fp16 and the flag is set (tract >= 0.21.11), the op is sandwiched `tract_core_cast`→f32 → conv → cast-back, mirroring the existing `layer_norm` and `linear` f32-accumulation paths. Covers `_convolution_mode`, `_convolution` and `conv_transpose*` (the shared `_emit_conv`) via one helper; non-fp16 and flag-off paths are byte-for-byte unchanged.

## Why

Surfaced while exporting vision encoders in fp16: a SigLIP patch-embedding `Conv2d` drifted ~14% vs the PyTorch reference at the very first op, and the following norms amplified it. In isolation the conv went from failing `check_io` at ~14% outliers to passing once accumulated in f32.

## Test

`tests/test_linear_acc.py` gains `Conv2d` and `ConvTranspose2d` fp16 cases (numerical `check_io`) plus an assertion that the f32 cast sandwich is emitted only when the option is set. Full suite green (`test_linear_acc`, `test_f16`, `test_primitive`: 893 passed), ruff clean.