### PR TITLE
fix(core): fp16 export robustness (SDPA infer-rule, finite shape-infer placeholder, rank-2 linear f32-accum, f16 arange)

### DIFF
--- a/tests/test_f16.py
+++ b/tests/test_f16.py
@@ -175,8 +175,9 @@ def test_layer_norm_f16_unsupported_in_torch():
 
 
 @pytest.mark.skipif(
-    condition=not TRACT_INFERENCES_TO_TESTS_APPROX,
-    reason="no tract inference target available",
+    condition=not TRACT_INFERENCES_TO_TESTS_APPROX
+    or torch_version() < "2.2.0",
+    reason="no tract target, or torch too old for CPU fp16 ops",
 )
 def test_arange_f16_exports():
     """`arange` with an fp16 dtype must export.

--- a/tests/test_f16.py
+++ b/tests/test_f16.py
@@ -175,8 +175,7 @@ def test_layer_norm_f16_unsupported_in_torch():
 
 
 @pytest.mark.skipif(
-    condition=not TRACT_INFERENCES_TO_TESTS_APPROX
-    or torch_version() < "2.2.0",
+    condition=not TRACT_INFERENCES_TO_TESTS_APPROX or torch_version() < "2.2.0",
     reason="no tract target, or torch too old for CPU fp16 ops",
 )
 def test_arange_f16_exports():

--- a/tests/test_f16.py
+++ b/tests/test_f16.py
@@ -172,3 +172,28 @@ def test_layer_norm_f16_unsupported_in_torch():
         assert "\"LayerNormKernelImpl\" not implemented for 'Half'" in str(
             excinfo.value
         ) or "mixed dtype" in str(excinfo.value)
+
+
+@pytest.mark.skipif(
+    condition=not TRACT_INFERENCES_TO_TESTS_APPROX,
+    reason="no tract inference target available",
+)
+def test_arange_f16_exports():
+    """`arange` with an fp16 dtype must export.
+
+    RoPE-style position math on half-precision towers traces an
+    ``aten::arange`` whose dtype arg is float16; the arange op maps it to a
+    finite integer/f32 range for NNEF, so it must be accepted rather than
+    raising "dtype not implemented for arange".
+    """
+
+    class ArangeF16(nn.Module):
+        def forward(self, x):
+            pos = torch.arange(x.shape[-1], dtype=torch.float16)
+            return x * pos
+
+    check_model_io_test(
+        ArangeF16(),
+        test_input=torch.arange(4).reshape(1, 4).half(),
+        inference_target=TRACT_INFERENCES_TO_TESTS_APPROX[0],
+    )

--- a/tests/test_infer_shape.py
+++ b/tests/test_infer_shape.py
@@ -160,6 +160,31 @@ test_suite.add(
 )
 
 
+class SdpaModule(torch.nn.Module):
+    def forward(self, q, k, v):
+        return torch.nn.functional.scaled_dot_product_attention(q, k, v)
+
+
+# scaled_dot_product_attention carries an INFER_RULE so its output shape is
+# derived structurally (query layout with the value feature size) instead of
+# executing the op during shape inference -- executing it is value-sensitive
+# (an inf/nan placeholder mask makes the softmax raise) and dtype-sensitive
+# (placeholder q/k/v dtypes need not agree). This case checks the rule matches
+# the real op's shape/dtype.
+test_suite.add(
+    "scaled_dot_product_attention",
+    parse_ir_and_get_first_op(
+        SdpaModule(),
+        (
+            torch.randn(1, 2, 8, 4),
+            torch.randn(1, 2, 8, 4),
+            torch.randn(1, 2, 8, 4),
+        ),
+        "aten::scaled_dot_product_attention",
+    ),
+)
+
+
 @pytest.mark.parametrize(
     "ir_op",
     test_suite.ir_ops,

--- a/tests/test_infer_shape.py
+++ b/tests/test_infer_shape.py
@@ -170,19 +170,20 @@ class SdpaModule(torch.nn.Module):
 # executing the op during shape inference -- executing it is value-sensitive
 # (an inf/nan placeholder mask makes the softmax raise) and dtype-sensitive
 # (placeholder q/k/v dtypes need not agree). This case checks the rule matches
-# the real op's shape/dtype.
-test_suite.add(
-    "scaled_dot_product_attention",
-    parse_ir_and_get_first_op(
-        SdpaModule(),
-        (
-            torch.randn(1, 2, 8, 4),
-            torch.randn(1, 2, 8, 4),
-            torch.randn(1, 2, 8, 4),
+# the real op's shape/dtype. (SDPA exists from torch 2.0.)
+if hasattr(torch.nn.functional, "scaled_dot_product_attention"):
+    test_suite.add(
+        "scaled_dot_product_attention",
+        parse_ir_and_get_first_op(
+            SdpaModule(),
+            (
+                torch.randn(1, 2, 8, 4),
+                torch.randn(1, 2, 8, 4),
+                torch.randn(1, 2, 8, 4),
+            ),
+            "aten::scaled_dot_product_attention",
         ),
-        "aten::scaled_dot_product_attention",
-    ),
-)
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_linear_acc.py
+++ b/tests/test_linear_acc.py
@@ -46,6 +46,18 @@ if tract_latest.version >= "0.21.11":
     except RuntimeError as exp:
         print("failed to add the test because torch:", exp)
 
+    # rank-2 input: flattened projections in vision/audio towers (e.g. the
+    # attention out-proj / patch merger) hit `linear` with a 2D input, which
+    # the f32-accumulation einsum must handle alongside the 3D/4D forms.
+    mod_r2 = nn.Linear(3, 4).half()
+    inp_r2 = torch.arange(12).reshape(4, 3).half()
+    try:
+        with torch.inference_mode():
+            mod_r2(inp_r2)
+        test_suite.add(inp_r2, mod_r2)
+    except RuntimeError as exp:
+        print("failed to add the rank-2 linear test because torch:", exp)
+
     # `conv` shares the `force_linear_accumulation_in_f32` option with
     # `linear`: an fp16 conv accumulator diverges from PyTorch's CPU f16
     # kernels (which accumulate in f32), so we upcast the conv to f32 and

--- a/torch_to_nnef/op/aten/matmul.py
+++ b/torch_to_nnef/op/aten/matmul.py
@@ -558,7 +558,11 @@ def linear(g, node, name_to_tensor, null_ref, inference_target, **kwargs):
                 " fallback to f16"
             )
         else:
-            if input_node.rank == 3:
+            if input_node.rank == 2:
+                expr = "ij,kj->ik"
+                if weight_node.rank != 2:
+                    raise T2NErrorNotImplemented(weight_node.rank)
+            elif input_node.rank == 3:
                 expr = "bij,kj->bik"
                 if weight_node.rank != 2:
                     raise T2NErrorNotImplemented(weight_node.rank)

--- a/torch_to_nnef/op/aten/tensor_build.py
+++ b/torch_to_nnef/op/aten/tensor_build.py
@@ -51,10 +51,11 @@ def arange(g, node, name_to_tensor, inference_target, **kwargs):
         )
 
     # see SCALAR_TYPE_TO_PYTORCH_TYPE for reference index:
-    #   3 = int32, 4 = int64, 6 = float32, 7 = float64
-    # float64 shows up in RoPE-style position embeds; NNEF runtimes execute
-    # the arange as f32 which is fine for integer-range / position math.
-    if dtype_node.data not in [6, None, 4, 3, 7]:
+    #   3 = int32, 4 = int64, 5 = float16, 6 = float32, 7 = float64
+    # float64/float16 show up in RoPE-style position embeds (f16 on half
+    # precision towers); NNEF runtimes execute the arange as f32 which is fine
+    # for integer-range / position math.
+    if dtype_node.data not in [6, None, 4, 3, 7, 5]:
         raise T2NErrorNotImplemented(
             f"dtype {dtype_node} not implemented for arange"
         )

--- a/torch_to_nnef/torch_graph/ir_op.py
+++ b/torch_to_nnef/torch_graph/ir_op.py
@@ -395,6 +395,20 @@ def _infer_shape_embedding_output(
     return torch.Size(bx + ax[1:])
 
 
+def _infer_shape_sdpa(query, key, value) -> torch.Size:
+    """Infer `scaled_dot_product_attention` output shape without executing it.
+
+    Output follows the query layout with the value's feature size:
+    ``(*query.shape[:-1], value.shape[-1])``. Executing the real op during
+    shape inference is both value-sensitive (an inf/nan placeholder mask makes
+    the softmax raise) and dtype-sensitive (placeholder q/k/v dtypes need not
+    agree, and torch's SDPA rejects mixed dtypes), so short-circuit like the
+    other trace-hostile ops.
+    """
+    del key
+    return torch.Size(list(query.shape[:-1]) + [value.shape[-1]])
+
+
 def _infer_trace_result_matmul(a: torch.Tensor, b: torch.Tensor) -> torch.Size:
     """Infer output tensor shape of `aten::matmul` without executing it.
 
@@ -528,9 +542,17 @@ def _infer_shape_convolution_output(*args) -> torch.Size:
 def _build_empty_tensor_from_infer_trace(
     fn_infer_trace: T.Callable, inputs, qte_inputs_to_use: int
 ) -> torch.Tensor:
-    """Utility to build zero tensor of given dtype and shape."""
+    """Build a finite placeholder of the inferred dtype and shape.
+
+    Only the shape/dtype matter for inference, but this placeholder is fed
+    forward to rule-less ops that get executed (e.g. attention/softmax), so it
+    must be finite: ``torch.empty`` returns uninitialised memory that -- read
+    as ``float16`` -- is routinely ``inf``/``nan`` and makes those downstream
+    ops fail at trace time. ``zeros`` keeps it finite (as the name always
+    implied).
+    """
     infered_shape = fn_infer_trace(*inputs[:qte_inputs_to_use])
-    return torch.empty(infered_shape, dtype=inputs[0].dtype)
+    return torch.zeros(infered_shape, dtype=inputs[0].dtype)
 
 
 def _tensors_share_storage(left: torch.Tensor, right: torch.Tensor) -> bool:
@@ -586,6 +608,9 @@ INFER_RULES = {
         lambda _seq, vals, *_: vals.shape, 2, require_dtype=False
     ),
     ATEN_EMBEDDING: InferRule(_infer_shape_embedding_output, 2),
+    ATEN_SCALED_DOT_PRODUCT_ATTENTION: InferRule(
+        _infer_shape_sdpa, 3, require_dtype=False
+    ),
     ATEN_MATMUL: InferRule(_infer_trace_result_matmul, 2),
     ATEN_LINEAR: InferRule(_infer_shape_linear_output, 2),
     ATEN_GROUPED_MM: InferRule(_infer_shape_grouped_mm_output, 2),


### PR DESCRIPTION
## What

Four small, independent core fixes that let fp16 models (surfaced by multimodal vision/audio encoders) export and verify against `tract`. Each is exercised by a test.

### 1. SDPA shape-inference no longer executes the op (`ir_op.py`)
`scaled_dot_product_attention` had no `INFER_RULE`, so shape inference *executed* it. That is both value-sensitive (an `inf`/`nan` placeholder mask makes the softmax raise) and dtype-sensitive (placeholder q/k/v dtypes need not agree, and torch's SDPA rejects mixed dtypes). Added `_infer_shape_sdpa` (`query.shape[:-1] + [value.shape[-1]]`) so the shape is derived structurally, never executing the op — mirroring the existing bucketize/searchsorted short-circuits.

### 2. Finite shape-inference placeholder (`ir_op.py`)
`_build_empty_tensor_from_infer_trace` used `torch.empty` (uninitialised) despite its docstring saying *"zero tensor"*. Read as `float16`, that garbage is routinely `inf`/`nan` and propagates into rule-less ops that get executed for shape inference. Switched to `torch.zeros` (finite, as the name always implied).

### 3. `linear` f32-accumulation handles rank-2 input (`matmul.py`)
`force_linear_accumulation_in_f32` only supported input rank 3/4; flattened projections in vision/audio towers (attention out-proj, patch merger) are rank-2. Added the rank-2 einsum (`ij,kj->ik`).

### 4. `arange` accepts an fp16 dtype (`tensor_build.py`)
RoPE-style position math on half towers traces `aten::arange` with a float16 dtype (code 5), which was rejected. It is mapped to a finite integer/f32 range for NNEF (as the handler already does for f32/f64), so accept it.

## Tests
- `test_infer_shape.py`: SDPA case (infer-rule shape/dtype must match the real op).
- `test_linear_acc.py`: rank-2 `Linear` f32-accumulation case.
- `test_f16.py`: fp16 `arange` export.

Full suite green (`test_infer_shape`, `test_linear_acc`, `test_f16`, `test_primitive`, `test_export`, `test_const_fold_infer_rule`, `test_offload`: 946 passed; property-based op sweep 394 passed), ruff clean.