### PR TITLE
ci(examples): fall back to plain-LFS HF download when the Xet backend fails

### DIFF
--- a/examples/bootstrap-uv.sh
+++ b/examples/bootstrap-uv.sh
@@ -35,12 +35,30 @@ ensure_uv() {
     command_exists uv || { echo "uv installation failed"; exit 1; }
 }
 
-# hf_pull <repo>: pre-download a HuggingFace repo into the local cache, retrying
-# on 429s, so the subsequent export reads from cache. This keeps the retry on
-# the *download* only -- we never retry the export step (which would re-run
-# t2n-internal errors). Requires the venv active (huggingface_hub installed).
+_hf_snapshot() {
+    python -c "import sys; from huggingface_hub import snapshot_download; snapshot_download(sys.argv[1])" "$1"
+}
+
+# hf_pull <repo>: pre-download a HuggingFace repo into the local cache so the
+# subsequent export reads from cache. Requires the venv active (huggingface_hub
+# installed).
+#
+# Prefer the default download path (Xet when available), so a healthy Xet is
+# used and stays exercised. Only on failure, retry on the plain-LFS path: Xet's
+# `xet-read-token` endpoint intermittently returns 404 (it is not on the HF
+# status page, so there is no health signal, and a 404 is not auto-retried), so
+# an outage degrades to LFS instead of failing CI while a working Xet keeps the
+# fast path. The `retry` wraps the LFS fallback so transient 429s recover too.
 hf_pull() {
-    retry python -c "import sys; from huggingface_hub import snapshot_download; snapshot_download(sys.argv[1])" "$1"
+    if _hf_snapshot "$1"; then
+        return 0
+    fi
+    echo "hf_pull: default (Xet) download failed for '$1'; " \
+        "falling back to the plain-LFS path" >&2
+    (
+        export HF_HUB_DISABLE_XET=1
+        retry _hf_snapshot "$1"
+    )
 }
 
 main() {


### PR DESCRIPTION
## What

`examples/bootstrap-uv.sh`'s `hf_pull` now prefers the default HuggingFace download path (Xet when available) and retries on the plain-LFS path only if that first attempt fails.

## Why

Xet intermittently returns 404 on its `xet-read-token` endpoint (seen persistently on `albert-base-v2`), which fails the `tier1: multi_io_py` example download in CI. It has flaked across several unrelated PRs, and a 404 is not auto-retried, so a re-run does not help.

Rather than disable Xet outright, this keeps it as the default and degrades gracefully:

- A healthy Xet is still used (and stays exercised, so a genuine Xet regression still surfaces in CI) and keeps its speed on large downloads.
- On failure, the pull retries with `HF_HUB_DISABLE_XET=1`, so an outage transparently falls back to LFS instead of turning CI red.
- Nothing to remember to revert: the fallback only fires on an actual failure, and if HF later makes a repo Xet-only it still works because Xet is tried first.

Xet is not tracked on status.huggingface.co, so there is no health signal or SLA for it, and its failures do not correlate with the Hub status (the Hub reports Operational while the Xet download 404s). That is exactly the kind of dependency a fallback, not a re-run, should cover.

The LFS path was verified working for a Xet-migrated repo (a 47 MB LFS weight fetched at ~15 MB/s with Xet disabled), so the fallback is a real path, not a broken one.
