### PR TITLE
Keep the example lockfiles in sync with the bumped version

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -36,3 +36,135 @@ search = name = "torch-to-nnef-nemo-asr"
 	version = "{current_version}"
 replace = name = "torch-to-nnef-nemo-asr"
 	version = "{new_version}"
+
+[bumpversion:file(example-getting_started_py):examples/getting_started_py/uv.lock]
+search = name = "torch-to-nnef"
+	version = "{current_version}"
+replace = name = "torch-to-nnef"
+	version = "{new_version}"
+
+[bumpversion:file(example-imageclass-wasm):examples/imageclass-wasm/uv.lock]
+search = name = "torch-to-nnef"
+	version = "{current_version}"
+replace = name = "torch-to-nnef"
+	version = "{new_version}"
+
+[bumpversion:file(example-multi_io_py):examples/multi_io_py/uv.lock]
+search = name = "torch-to-nnef"
+	version = "{current_version}"
+replace = name = "torch-to-nnef"
+	version = "{new_version}"
+
+[bumpversion:file(example-quantization_py):examples/quantization_py/uv.lock]
+search = name = "torch-to-nnef"
+	version = "{current_version}"
+replace = name = "torch-to-nnef"
+	version = "{new_version}"
+
+[bumpversion:file(example-yolo):examples/yolo/uv.lock]
+search = name = "torch-to-nnef"
+	version = "{current_version}"
+replace = name = "torch-to-nnef"
+	version = "{new_version}"
+
+[bumpversion:file(dynamic_axes):examples/dynamic_axes/uv.lock]
+search = name = "torch-to-nnef"
+	version = "{current_version}"
+replace = name = "torch-to-nnef"
+	version = "{new_version}"
+
+[bumpversion:file(getting_started_py):examples/getting_started_py/uv.lock]
+search = name = "torch-to-nnef"
+	version = "{current_version}"
+replace = name = "torch-to-nnef"
+	version = "{new_version}"
+
+[bumpversion:file(image_gen):examples/image_gen/uv.lock]
+search = name = "torch-to-nnef"
+	version = "{current_version}"
+replace = name = "torch-to-nnef"
+	version = "{new_version}"
+
+[bumpversion:file(imageclass-wasm):examples/imageclass-wasm/uv.lock]
+search = name = "torch-to-nnef"
+	version = "{current_version}"
+replace = name = "torch-to-nnef"
+	version = "{new_version}"
+
+[bumpversion:file(llm_wasm):examples/llm_wasm/uv.lock]
+search = name = "torch-to-nnef"
+	version = "{current_version}"
+replace = name = "torch-to-nnef"
+	version = "{new_version}"
+
+[bumpversion:file(mamba/external_state):examples/mamba/external_state/uv.lock]
+search = name = "torch-to-nnef"
+	version = "{current_version}"
+replace = name = "torch-to-nnef"
+	version = "{new_version}"
+
+[bumpversion:file(mamba/pulse):examples/mamba/pulse/uv.lock]
+search = name = "torch-to-nnef"
+	version = "{current_version}"
+replace = name = "torch-to-nnef"
+	version = "{new_version}"
+
+[bumpversion:file(multi_io_py):examples/multi_io_py/uv.lock]
+search = name = "torch-to-nnef"
+	version = "{current_version}"
+replace = name = "torch-to-nnef"
+	version = "{new_version}"
+
+[bumpversion:file(nemo_asr):examples/nemo_asr/uv.lock]
+search = name = "torch-to-nnef"
+	version = "{current_version}"
+replace = name = "torch-to-nnef"
+	version = "{new_version}"
+
+[bumpversion:file(quantization_py):examples/quantization_py/uv.lock]
+search = name = "torch-to-nnef"
+	version = "{current_version}"
+replace = name = "torch-to-nnef"
+	version = "{new_version}"
+
+[bumpversion:file(speech_enhancement/deepfilternet):examples/speech_enhancement/deepfilternet/uv.lock]
+search = name = "torch-to-nnef"
+	version = "{current_version}"
+replace = name = "torch-to-nnef"
+	version = "{new_version}"
+
+[bumpversion:file(speech_enhancement/dpdfnet):examples/speech_enhancement/dpdfnet/uv.lock]
+search = name = "torch-to-nnef"
+	version = "{current_version}"
+replace = name = "torch-to-nnef"
+	version = "{new_version}"
+
+[bumpversion:file(t2n_extra_custom_op):examples/t2n_extra_custom_op/uv.lock]
+search = name = "torch-to-nnef"
+	version = "{current_version}"
+replace = name = "torch-to-nnef"
+	version = "{new_version}"
+
+[bumpversion:file(tts/pocket_tts):examples/tts/pocket_tts/uv.lock]
+search = name = "torch-to-nnef"
+	version = "{current_version}"
+replace = name = "torch-to-nnef"
+	version = "{new_version}"
+
+[bumpversion:file(vad/FSMN-wasm):examples/vad/FSMN-wasm/uv.lock]
+search = name = "torch-to-nnef"
+	version = "{current_version}"
+replace = name = "torch-to-nnef"
+	version = "{new_version}"
+
+[bumpversion:file(vad/silero-jit):examples/vad/silero-jit/uv.lock]
+search = name = "torch-to-nnef"
+	version = "{current_version}"
+replace = name = "torch-to-nnef"
+	version = "{new_version}"
+
+[bumpversion:file(yolo):examples/yolo/uv.lock]
+search = name = "torch-to-nnef"
+	version = "{current_version}"
+replace = name = "torch-to-nnef"
+	version = "{new_version}"

--- a/examples/dynamic_axes/uv.lock
+++ b/examples/dynamic_axes/uv.lock
@@ -1069,7 +1069,7 @@ wheels = [
 
 [[package]]
 name = "torch-to-nnef"
-version = "0.24.3"
+version = "0.24.5"
 source = { editable = "../../" }
 dependencies = [
     { name = "mako" },

--- a/examples/getting_started_py/uv.lock
+++ b/examples/getting_started_py/uv.lock
@@ -643,7 +643,7 @@ wheels = [
 
 [[package]]
 name = "torch-to-nnef"
-version = "0.24.3"
+version = "0.24.5"
 source = { editable = "../../" }
 dependencies = [
     { name = "mako" },

--- a/examples/image_gen/uv.lock
+++ b/examples/image_gen/uv.lock
@@ -1347,7 +1347,7 @@ wheels = [
 
 [[package]]
 name = "torch-to-nnef"
-version = "0.24.3"
+version = "0.24.5"
 source = { editable = "../../" }
 dependencies = [
     { name = "mako" },

--- a/examples/imageclass-wasm/uv.lock
+++ b/examples/imageclass-wasm/uv.lock
@@ -641,7 +641,7 @@ wheels = [
 
 [[package]]
 name = "torch-to-nnef"
-version = "0.24.3"
+version = "0.24.5"
 source = { editable = "../../" }
 dependencies = [
     { name = "mako" },

--- a/examples/llm_wasm/uv.lock
+++ b/examples/llm_wasm/uv.lock
@@ -1082,7 +1082,7 @@ wheels = [
 
 [[package]]
 name = "torch-to-nnef"
-version = "0.24.3"
+version = "0.24.5"
 source = { editable = "../../" }
 dependencies = [
     { name = "mako" },

--- a/examples/mamba/external_state/uv.lock
+++ b/examples/mamba/external_state/uv.lock
@@ -1012,7 +1012,7 @@ wheels = [
 
 [[package]]
 name = "torch-to-nnef"
-version = "0.24.3"
+version = "0.24.5"
 source = { editable = "../../../" }
 dependencies = [
     { name = "mako" },

--- a/examples/mamba/pulse/uv.lock
+++ b/examples/mamba/pulse/uv.lock
@@ -1008,7 +1008,7 @@ wheels = [
 
 [[package]]
 name = "torch-to-nnef"
-version = "0.24.2"
+version = "0.24.5"
 source = { editable = "../../../" }
 dependencies = [
     { name = "mako" },

--- a/examples/multi_io_py/uv.lock
+++ b/examples/multi_io_py/uv.lock
@@ -1067,7 +1067,7 @@ wheels = [
 
 [[package]]
 name = "torch-to-nnef"
-version = "0.24.3"
+version = "0.24.5"
 source = { editable = "../../" }
 dependencies = [
     { name = "mako" },

--- a/examples/nemo_asr/uv.lock
+++ b/examples/nemo_asr/uv.lock
@@ -4841,7 +4841,7 @@ wheels = [
 
 [[package]]
 name = "torch-to-nnef"
-version = "0.24.3"
+version = "0.24.5"
 source = { editable = "../../" }
 dependencies = [
     { name = "mako" },

--- a/examples/quantization_py/uv.lock
+++ b/examples/quantization_py/uv.lock
@@ -644,7 +644,7 @@ wheels = [
 
 [[package]]
 name = "torch-to-nnef"
-version = "0.24.3"
+version = "0.24.5"
 source = { editable = "../../" }
 dependencies = [
     { name = "mako" },

--- a/examples/speech_enhancement/deepfilternet/uv.lock
+++ b/examples/speech_enhancement/deepfilternet/uv.lock
@@ -810,7 +810,7 @@ wheels = [
 
 [[package]]
 name = "torch-to-nnef"
-version = "0.24.3"
+version = "0.24.5"
 source = { editable = "../../../" }
 dependencies = [
     { name = "mako" },

--- a/examples/speech_enhancement/dpdfnet/uv.lock
+++ b/examples/speech_enhancement/dpdfnet/uv.lock
@@ -749,7 +749,7 @@ wheels = [
 
 [[package]]
 name = "torch-to-nnef"
-version = "0.24.2"
+version = "0.24.5"
 source = { editable = "../../../" }
 dependencies = [
     { name = "mako" },

--- a/examples/t2n_extra_custom_op/uv.lock
+++ b/examples/t2n_extra_custom_op/uv.lock
@@ -644,7 +644,7 @@ wheels = [
 
 [[package]]
 name = "torch-to-nnef"
-version = "0.24.3"
+version = "0.24.5"
 source = { editable = "../../" }
 dependencies = [
     { name = "mako" },

--- a/examples/tts/pocket_tts/uv.lock
+++ b/examples/tts/pocket_tts/uv.lock
@@ -1413,7 +1413,7 @@ wheels = [
 
 [[package]]
 name = "torch-to-nnef"
-version = "0.24.2"
+version = "0.24.5"
 source = { editable = "../../../" }
 dependencies = [
     { name = "mako" },

--- a/examples/vad/FSMN-wasm/uv.lock
+++ b/examples/vad/FSMN-wasm/uv.lock
@@ -859,7 +859,7 @@ wheels = [
 
 [[package]]
 name = "torch-to-nnef"
-version = "0.24.2"
+version = "0.24.5"
 source = { editable = "../../../" }
 dependencies = [
     { name = "mako" },

--- a/examples/vad/silero-jit/uv.lock
+++ b/examples/vad/silero-jit/uv.lock
@@ -666,7 +666,7 @@ wheels = [
 
 [[package]]
 name = "torch-to-nnef"
-version = "0.24.3"
+version = "0.24.5"
 source = { editable = "../../../" }
 dependencies = [
     { name = "mako" },

--- a/examples/yolo/uv.lock
+++ b/examples/yolo/uv.lock
@@ -816,7 +816,7 @@ wheels = [
 
 [[package]]
 name = "torch-to-nnef"
-version = "0.24.3"
+version = "0.24.5"
 source = { editable = "../../" }
 dependencies = [
     { name = "mako" },


### PR DESCRIPTION
## Problem

`examples run` has failed on every branch since 07:16 today, including three dependabot runs. All seven `tier1` jobs fail identically before running anything:

```
error: The lockfile at `uv.lock` needs to be updated, but `--locked` was provided.
```

All seventeen example lockfiles pin `torch-to-nnef` at **0.24.3** or **0.24.2** while `pyproject.toml` is at **0.24.5**, so `uv sync --locked` refuses.

## Cause

`.bumpversion.cfg` rewrites the version inside the root, `packages/llm` and `packages/nemo-asr` lockfiles, but not in the seventeen lockfiles under `examples/`. Each of those declares the editable `torch-to-nnef` dependency with its own copy of the version, so a bump silently desyncs them and the next `--locked` run fails.

This morning's 0.24.4 bump is where it broke; 0.24.5 kept it broken.

## Fix

Two parts, because only the second one stops it recurring:

1. Resync all seventeen example lockfiles to 0.24.5. Seven of them sit one level deeper (`examples/vad/silero-jit`, `examples/mamba/*`, `examples/speech_enhancement/*`, `examples/tts/pocket_tts`, `examples/vad/FSMN-wasm`) and had drifted as far back as 0.24.2.
2. Add a `bumpversion` stanza per example lockfile, matching the existing pattern used for the root and package lockfiles, so the next bump keeps all twenty in step.

## Testing

- `uv lock --check` in `examples/getting_started_py` now resolves cleanly, where it previously demanded an update
- `uv lock --check` also passes in `examples/vad/silero-jit` and `examples/mamba/pulse`, the two deeper trees
- `bumpversion --dry-run patch` visits all seventeen example lockfiles and exits 0
